### PR TITLE
[WIP] enforce same thread on getState()

### DIFF
--- a/examples/counter/android/src/main/java/org/reduxkotlin/example/counter/MainActivity.kt
+++ b/examples/counter/android/src/main/java/org/reduxkotlin/example/counter/MainActivity.kt
@@ -37,9 +37,11 @@ class MainActivity: AppCompatActivity() {
     }
 
     private fun incrementIfOdd() {
-        if (store.state % 2 != 0) {
-            store.dispatch(Increment())
-        }
+        Thread {
+            if (store.state % 2 != 0) {
+                store.dispatch(Increment())
+            }
+        }.start()
     }
 
     private fun incrementAsync() {

--- a/lib/src/commonMain/kotlin/org/reduxkotlin/utils/ThreadUtil.kt
+++ b/lib/src/commonMain/kotlin/org/reduxkotlin/utils/ThreadUtil.kt
@@ -1,0 +1,8 @@
+package org.reduxkotlin.utils
+
+const val UNKNOWN_THREAD_NAME = "UNKNOWN_THREAD_NAME"
+
+/**
+ * Returns the name of the current thread.
+ */
+expect fun getThreadName(): String

--- a/lib/src/iosMain/kotlin/org/reduxkotlin/utils/ThreadUtils.kt
+++ b/lib/src/iosMain/kotlin/org/reduxkotlin/utils/ThreadUtils.kt
@@ -1,0 +1,4 @@
+package org.reduxkotlin.utils
+import platform.Foundation.NSThread.Companion.currentThread
+
+actual fun getThreadName(): String = currentThread.name ?: "Unknown"

--- a/lib/src/jsMain/kotlin/org/reduxkotlin/utils/ThreadUtil.kt
+++ b/lib/src/jsMain/kotlin/org/reduxkotlin/utils/ThreadUtil.kt
@@ -1,0 +1,3 @@
+package org.reduxkotlin.utils
+
+actual fun getThreadName() = "main"

--- a/lib/src/jvmMain/kotlin/org/reduxkotlin/utils/ThreadUtilJvm.kt
+++ b/lib/src/jvmMain/kotlin/org/reduxkotlin/utils/ThreadUtilJvm.kt
@@ -1,0 +1,3 @@
+package org.reduxkotlin.utils
+
+actual fun getThreadName(): String = Thread.currentThread().name


### PR DESCRIPTION
First pass at thread enforcement.  This throws an exception when 'getState' is accessed from a thread other than the one the store was created on. The sample app now throws the exception when tapping the first button.  This is only here for the draft PR.
TODO
 - add all targets: linux, mac, windows, wasm, etc
 - add unit tests - if possible add platform specific tests source sets in the lib module
 - do thread enforcement on dispatch as well.

Before this PR, if accessed from another thread it may through the exception from the `isDispatching` check if dispatching was happing on another thread.  This new exception will be more informative.

@AOrobator thoughts?