### PR TITLE
remove combineEnhancers

### DIFF
--- a/lib/src/commonMain/kotlin/org/reduxkotlin/CombineEnhancers.kt
+++ b/lib/src/commonMain/kotlin/org/reduxkotlin/CombineEnhancers.kt
@@ -1,8 +1,0 @@
-package org.reduxkotlin
-
-
-fun<State> combineEnhancers(vararg enhancers: StoreEnhancer<State>): StoreEnhancer<State> =
-        { storeCreator ->
-            compose(enhancers.map { it })(storeCreator)
-        }
-

--- a/lib/src/commonMain/kotlin/org/reduxkotlin/Compose.kt
+++ b/lib/src/commonMain/kotlin/org/reduxkotlin/Compose.kt
@@ -4,9 +4,7 @@ package org.reduxkotlin
  * Composes a list of single argument functions from right to left.
  */
 fun <T> compose(vararg functions: (T) -> T): (T) -> T =
-        { x -> functions.foldRight(x, { f, composed -> f(composed) })
-        }
+        { x -> functions.foldRight(x, { f, composed -> f(composed) }) }
 
 fun <T> compose(functions: List<(T) -> T>): (T) -> T =
-        { x -> functions.foldRight(x, { f, composed -> f(composed) })
-        }
+        { x -> functions.foldRight(x, { f, composed -> f(composed) }) }


### PR DESCRIPTION
#45 
Removing `combineEnhancers` due to this not being needed.  Enhancers can be combined using the generic `compose` function.  

Linebreaks updated in compose functions.
