### PR TITLE
Thread Safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## [0.5.0] - 2020-06-11
+ - kotlin 1.3.72
+ - createThreadSafeStore fun added for thread synchronized access
+ - createEnsureSameThreadStore to provide existing same-thread-enforcement
+
 ## [0.4.0] - 2020-03-23
  - kotlin 1.3.70
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 ## [0.5.0] - 2020-06-11
+ - update lib dependency to api import, so core lib is included in redux-kotlin-threadsafe
+## [0.5.0] - 2020-06-11
  - kotlin 1.3.72
  - createThreadSafeStore fun added for thread synchronized access
  - createEnsureSameThreadStore to provide existing same-thread-enforcement

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ kotlin {
   sourceSets {
         commonMain { //   <---  name may vary on your project
             dependencies {
-                implementation "org.reduxkotlin:redux-kotlin-threadsafe:0.5.0"
+                implementation "org.reduxkotlin:redux-kotlin-threadsafe:0.5.1"
             }
         }
  }
@@ -52,7 +52,7 @@ kotlin {
 
 For JVM only:
 ```
-  implementation "org.reduxkotlin:redux-kotlin-threadsafe-jvm:0.5.0"
+  implementation "org.reduxkotlin:redux-kotlin-threadsafe-jvm:0.5.1"
 ```
 
 *Non threadsafe store is available.  Typical usage will be with the threadsafe store. [More info read here](https://www.reduxkotlin.org/introduction/getting-started)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ kotlin {
   sourceSets {
         commonMain { //   <---  name may vary on your project
             dependencies {
-                implementation "org.reduxkotlin:redux-kotlin:0.4.0"
+                implementation "org.reduxkotlin:redux-kotlin-threadsafe:0.5.0"
             }
         }
  }
@@ -52,8 +52,11 @@ kotlin {
 
 For JVM only:
 ```
-  implementation "org.reduxkotlin:redux-kotlin-jvm:0.4.0"
+  implementation "org.reduxkotlin:redux-kotlin-threadsafe-jvm:0.5.0"
 ```
+
+*Non threadsafe store is available.  Typical usage will be with the threadsafe store. [More info read here](https://www.reduxkotlin.org/introduction/getting-started)
+
 
 Usage is very similar to JS Redux and those docs will be useful https://redux.js.org/.  These docs are not an intro to Redux, and just documentation on Kotlin specific bits.  For more info on Redux in general, check out https://redux.js.org/.
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
         classpath Plugins.kotlin
         classpath Plugins.dokka
         classpath Plugins.android
+        classpath Plugins.atomicFu
     }
 }
 
@@ -24,7 +25,6 @@ allprojects {
         jcenter()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         maven { url "https://dl.bintray.com/spekframework/spek-dev" }
-
     }
 
     group = GROUP

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -181,6 +181,9 @@ object Libs {
   const val spek_runner_junit5: String = "org.spekframework.spek2:spek-runner-junit5:" +
       Versions.spek
 
+  const val kotlin_coroutines: String = "org.jetbrains.kotlinx:kotlinx-coroutines-core-common:" +
+          Versions.coroutines
+
   const val kotlin_coroutines_jvm: String = "org.jetbrains.kotlinx:kotlinx-coroutines-core:" +
           Versions.coroutines
 

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -2,4 +2,5 @@ object Plugins {
     const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.org_jetbrains_kotlin}"
     const val dokka  = "org.jetbrains.dokka:dokka-gradle-plugin:${Versions.dokka_gradle_plugin}"
     const val android = "com.android.tools.build:gradle:${Versions.com_android_tools_build_gradle}"
+    const val atomicFu = "org.jetbrains.kotlinx:atomicfu-gradle-plugin:${Versions.atomicFu}"
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -45,6 +45,8 @@ object Versions {
 
   const val coroutines = "1.3.7"
 
+  const val atomicFu = "0.14.2"
+
   /**
    *
    * See issue 19: How to update Gradle itself?

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=org.reduxkotlin.redux-kotlin
-VERSION_NAME=0.5.0
+VERSION_NAME=0.5.1
 
 POM_ARTIFACT_ID=reduxkotlin
 POM_DESCRIPTION=Redux implementation for Kotlin.  Mulitiplatform supported.

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=org.reduxkotlin.redux-kotlin
-VERSION_NAME=0.4.0
+VERSION_NAME=0.5.0
 
 POM_ARTIFACT_ID=reduxkotlin
 POM_DESCRIPTION=Redux implementation for Kotlin.  Mulitiplatform supported.

--- a/lib-threadsafe/build.gradle
+++ b/lib-threadsafe/build.gradle
@@ -38,7 +38,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation kotlin("stdlib-common")
-                implementation project(":lib")
+                api project(":lib")
             }
         }
         commonTest {

--- a/lib-threadsafe/build.gradle
+++ b/lib-threadsafe/build.gradle
@@ -1,0 +1,136 @@
+repositories {
+    maven { url "https://dl.bintray.com/spekframework/spek-dev" }
+}
+apply plugin: 'java'
+apply plugin: 'kotlin-multiplatform'
+apply plugin: 'kotlinx-atomicfu'
+
+archivesBaseName = 'redux-kotlin-threadsafe'
+
+group 'org.reduxkotlin'
+version '0.4.0'
+
+kotlin {
+    jvm()
+    js() {
+        [compileKotlinJs, compileTestKotlinJs].each { configuration ->
+            configuration.kotlinOptions {
+                moduleKind = 'umd'
+                sourceMap = true
+                metaInfo = true
+            }
+        }
+    }
+
+    iosArm64("ios")
+    iosX64("iosSim")
+    macosX64("macos")
+    mingwX64("win")
+    wasm32("wasm")
+    linuxArm32Hfp("linArm32")
+    linuxMips32("linMips32")
+    linuxMipsel32("linMipsel32")
+    linuxX64("lin64")
+
+    sourceSets {
+
+        commonMain {
+            dependencies {
+                implementation kotlin("stdlib-common")
+                implementation project(":lib")
+            }
+        }
+        commonTest {
+            kotlin.srcDir('src/test/kotlin')
+            dependencies {
+                implementation kotlin("test-common")
+                implementation kotlin("test-annotations-common")
+                implementation Libs.spek_dsl_metadata
+                implementation Libs.atrium_cc_en_gb_robstoll_common
+                implementation Libs.mockk_common
+                implementation Libs.kotlin_coroutines
+            }
+        }
+
+        jvmMain {
+            kotlin.srcDir('src/jvmMain/kotlin')
+            dependencies {
+                implementation kotlin("stdlib")
+            }
+        }
+        jvmTest {
+            dependencies {
+                implementation kotlin("test")
+                implementation kotlin("test-junit")
+                implementation Libs.kotlin_coroutines_test
+                implementation Libs.kotlin_coroutines_jvm
+                implementation Libs.spek_dsl_jvm
+                implementation Libs.atrium_cc_en_gb_robstoll
+                implementation Libs.mockk
+
+                runtimeOnly Libs.spek_runner_junit5
+                runtimeOnly Libs.kotlin_reflect
+
+            }
+        }
+        jsMain {
+            kotlin.srcDir('src/jsMain/kotlin')
+            dependencies {
+                implementation kotlin("stdlib-js")
+            }
+            compileKotlinJs {
+                kotlinOptions.metaInfo = true
+                kotlinOptions.sourceMap = true
+                kotlinOptions.suppressWarnings = true
+                kotlinOptions.verbose = true
+                kotlinOptions.main = "call"
+                kotlinOptions.moduleKind = "umd"
+            }
+        }
+        jsTest {
+            dependencies {
+                implementation kotlin("test-js")
+                implementation kotlin("stdlib-js")
+            }
+        }
+
+        iosSimMain.dependsOn iosMain
+        iosSimTest.dependsOn iosTest
+    }
+}
+
+
+afterEvaluate {
+    // Alias the task names we use elsewhere to the new task names.
+    tasks.create('installMP').dependsOn('publishKotlinMultiplatformPublicationToMavenLocal')
+    tasks.create('installLocally') {
+        dependsOn 'publishKotlinMultiplatformPublicationToTestRepository'
+        dependsOn 'publishJvmPublicationToTestRepository'
+        dependsOn 'publishJsPublicationToTestRepository'
+        dependsOn 'publishMetadataPublicationToTestRepository'
+    }
+    tasks.create('installIosLocally') {
+        dependsOn 'publishKotlinMultiplatformPublicationToTestRepository'
+        dependsOn 'publishIosArm32PublicationToTestRepository'
+        dependsOn 'publishIosArm64PublicationToTestRepository'
+        dependsOn 'publishIosX64PublicationToTestRepository'
+        dependsOn 'publishMetadataPublicationToTestRepository'
+    }
+    // NOTE: We do not alias uploadArchives because CI runs it on Linux and we only want to run it on Mac OS.
+    //tasks.create('uploadArchives').dependsOn('publishKotlinMultiplatformPublicationToMavenRepository')
+}
+
+apply from: rootProject.file('gradle/publish.gradle')
+
+publishing {
+    publications.all {
+        // Rewrite all artifacts from using the project name to just 'runtime'.
+        artifactId = artifactId.replace(project.name, 'redux-kotlin-threadsafe')
+    }
+}
+
+jvmTest {
+    useJUnitPlatform {
+        includeEngines 'spek2'
+    }
+}

--- a/lib-threadsafe/build.gradle
+++ b/lib-threadsafe/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'kotlinx-atomicfu'
 archivesBaseName = 'redux-kotlin-threadsafe'
 
 group 'org.reduxkotlin'
-version '0.4.0'
+version '0.5.0'
 
 kotlin {
     jvm()
@@ -53,7 +53,6 @@ kotlin {
         }
 
         jvmMain {
-            kotlin.srcDir('src/jvmMain/kotlin')
             dependencies {
                 implementation kotlin("stdlib")
             }
@@ -74,7 +73,6 @@ kotlin {
             }
         }
         jsMain {
-            kotlin.srcDir('src/jsMain/kotlin')
             dependencies {
                 implementation kotlin("stdlib-js")
             }

--- a/lib-threadsafe/build.gradle
+++ b/lib-threadsafe/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'kotlinx-atomicfu'
 archivesBaseName = 'redux-kotlin-threadsafe'
 
 group 'org.reduxkotlin'
-version '0.5.0'
+version '0.5.1'
 
 kotlin {
     jvm()

--- a/lib-threadsafe/build.gradle
+++ b/lib-threadsafe/build.gradle
@@ -26,8 +26,9 @@ kotlin {
     iosX64("iosSim")
     macosX64("macos")
     mingwX64("win")
-    wasm32("wasm")
-    linuxArm32Hfp("linArm32")
+    //below are currently not supported by atomicfu
+    //wasm32("wasm")
+    //linuxArm32Hfp("linArm32")
     linuxMips32("linMips32")
     linuxMipsel32("linMipsel32")
     linuxX64("lin64")

--- a/lib-threadsafe/src/commonMain/kotlin/org/reduxkotlin/CreateThreadSafeStore.kt
+++ b/lib-threadsafe/src/commonMain/kotlin/org/reduxkotlin/CreateThreadSafeStore.kt
@@ -1,0 +1,30 @@
+package org.reduxkotlin
+
+/**
+ * Creates a SYNCHRONIZED, THREADSAFE Redux store that holds the state tree.
+ * The only way to change the data in the store is to call `dispatch()` on it.
+ *
+ * There should only be a single store in your app. To specify how different
+ * parts of the state tree respond to actions, you may combine several reducers
+ * into a single reducer function by using `combineReducers`.
+ *
+ * @param {Reducer} [reducer] A function that returns the next state tree, given
+ * the current state tree and the action to handle.
+ *
+ * @param {Any} [preloadedState] The initial state. You may optionally specify
+ * it to hydrate the state from the server in universal apps, or to restore a
+ * previously serialized user session.
+ *
+ * @param {Enhancer} [enhancer] The store enhancer. You may optionally specify
+ * it to enhance the store with third-party capabilities such as middleware,
+ * time travel, persistence, etc. The only store enhancer that ships with Redux
+ * is `applyMiddleware()`.
+ *
+ * @returns {Store} A Redux store that lets you read the state, dispatch actions
+ * and subscribe to changes.
+ */
+fun <State> createThreadSafeStore(
+    reducer: Reducer<State>,
+    preloadedState: State,
+    enhancer: StoreEnhancer<State>? = null
+): Store<State> = SynchronizedStore(createStore(reducer, preloadedState, enhancer))

--- a/lib-threadsafe/src/commonMain/kotlin/org/reduxkotlin/SynchronizedStore.kt
+++ b/lib-threadsafe/src/commonMain/kotlin/org/reduxkotlin/SynchronizedStore.kt
@@ -1,0 +1,30 @@
+package org.reduxkotlin
+
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+
+/**
+ * Threadsafe wrapper for ReduxKotlin store that synchronizes access to each function using
+ * kotlinx.AtomicFu [https://github.com/Kotlin/kotlinx.atomicfu]
+ * Allows all store functions to be accessed from any thread.
+ * This does have a performance impact for JVM/Native.
+ * TODO more info at [https://ReduxKotlin.org]
+ */
+class SynchronizedStore<TState>(private val store: Store<TState>) : Store<TState>, SynchronizedObject() {
+
+    override var dispatch: Dispatcher = { action ->
+        synchronized(this) { store.dispatch(action) }
+    }
+
+    override val getState: GetState<TState> = {
+        synchronized(this) { store.getState() }
+    }
+
+    override val replaceReducer: (Reducer<TState>) -> Unit = { reducer ->
+        synchronized(this) { store.replaceReducer(reducer) }
+    }
+
+    override val subscribe: (StoreSubscriber) -> StoreSubscription = { storeSubscriber ->
+        synchronized(this) { store.subscribe(storeSubscriber) }
+    }
+}

--- a/lib-threadsafe/src/jvmTest/kotlin/org/reduxkotlin/util/CreateThreadSafeStoreSpec.kt
+++ b/lib-threadsafe/src/jvmTest/kotlin/org/reduxkotlin/util/CreateThreadSafeStoreSpec.kt
@@ -1,0 +1,56 @@
+package org.reduxkotlin.util
+
+import kotlinx.coroutines.*
+import org.reduxkotlin.*
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import kotlin.system.measureTimeMillis
+import kotlin.test.*
+
+object CreateThreadSafeStoreSpec : Spek({
+    describe("createThreadSafeStore") {
+        it("multithreaded increments massively") {
+            suspend fun massiveRun(action: suspend () -> Unit) {
+                val n = 100  // number of coroutines to launch
+                val k = 1000 // times an action is repeated by each coroutine
+                val time = measureTimeMillis {
+                    coroutineScope {
+                        // scope for coroutines
+                        repeat(n) {
+                            launch {
+                                repeat(k) { action() }
+                            }
+                        }
+                    }
+                }
+                println("Completed ${n * k} actions in $time ms")
+            }
+
+            val counterContext = newFixedThreadPoolContext(5, "CounterContext")
+
+            //NOTE: changing this to createStore() breaks the tests
+            val store = createThreadSafeStore(counterReducer, TestCounterState())
+            runBlocking {
+                withContext(counterContext) {
+                    massiveRun {
+                        store.dispatch(Increment())
+                    }
+                }
+                withContext(counterContext) {
+                    assertEquals(100000, store.state.counter)
+                }
+            }
+        }
+    }
+})
+
+class Increment
+
+data class TestCounterState(val counter: Int = 0)
+
+val counterReducer = { state: TestCounterState, action: Any ->
+    when (action) {
+        is Increment -> state.copy(counter = state.counter + 1)
+        else -> state
+    }
+}

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'kotlin-multiplatform'
 archivesBaseName = 'redux-kotlin'
 
 group 'org.reduxkotlin'
-version '0.5.0'
+version '0.5.1'
 
 kotlin {
     jvm()

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'kotlin-multiplatform'
 archivesBaseName = 'redux-kotlin'
 
 group 'org.reduxkotlin'
-version '0.4.0'
+version '0.5.0'
 
 kotlin {
     jvm()

--- a/lib/src/commonMain/kotlin/org/reduxkotlin/CreateSameThreadEnforcedStore.kt
+++ b/lib/src/commonMain/kotlin/org/reduxkotlin/CreateSameThreadEnforcedStore.kt
@@ -1,0 +1,54 @@
+package org.reduxkotlin
+
+import org.reduxkotlin.utils.getThreadName
+import org.reduxkotlin.utils.stripCoroutineName
+
+/**
+ * Creates a Redux store that can only be accessed from the same thread.
+ * Any call to the store's functions called from a thread other than thread
+ * from which it was created will throw an IllegalStateException.
+ *
+ * Most use cases will want to use [createThreadSafeStore] or [createStore]
+ * More details:   TODO add documentation link
+ *
+ * see [createStore] for details on store params/behavior
+ */
+fun <State> createSameThreadEnforcedStore(
+    reducer: Reducer<State>,
+    preloadedState: State,
+    enhancer: StoreEnhancer<State>? = null
+): Store<State> {
+
+    val store = createStore(reducer, preloadedState, enhancer)
+    val storeThreadName = stripCoroutineName(getThreadName())
+    fun isSameThread() = stripCoroutineName(getThreadName()) == storeThreadName
+    fun checkSameThread() = check(isSameThread()) {
+        """You may not call the store from a thread other than the thread on which it was created.
+            |This includes: getState(), dispatch(), subscribe(), and replaceReducer()
+            |This store was created on: '$storeThreadName' and current
+            |thread is '${getThreadName()}'
+            """.trimMargin()
+    }
+
+    return object : Store<State> {
+        override val getState = {
+            checkSameThread()
+            store.getState()
+        }
+
+        override var dispatch: Dispatcher = { action ->
+            checkSameThread()
+            store.dispatch(action)
+        }
+
+        override val subscribe = { storeSubscriber: StoreSubscriber ->
+            checkSameThread()
+            store.subscribe(storeSubscriber)
+        }
+
+        override val replaceReducer = { reducer: Reducer<State> ->
+            checkSameThread()
+            store.replaceReducer(reducer)
+        }
+    }
+}

--- a/lib/src/commonMain/kotlin/org/reduxkotlin/CreateStore.kt
+++ b/lib/src/commonMain/kotlin/org/reduxkotlin/CreateStore.kt
@@ -5,7 +5,9 @@ import org.reduxkotlin.utils.isPlainObject
 /**
  * Creates a NON-THREADSAFE Redux store that holds the state tree.
  * If your application needs thread-safety access to store consider [createThreadSafeStore]
- * see: TODO link to docs
+ * see:
+ *  https://reduxkotlin.org/api/createThreadSafeStore
+ *  https://www.reduxkotlin.org/introduction/threading
  *
  * The only way to change the data in the store is to call `dispatch()` on it.
  *

--- a/lib/src/jvmTest/kotlin/org/reduxkotlin/util/CreateSameThreadEnforcedStoreSpec.kt
+++ b/lib/src/jvmTest/kotlin/org/reduxkotlin/util/CreateSameThreadEnforcedStoreSpec.kt
@@ -13,13 +13,12 @@ import kotlin.IllegalStateException
 import kotlin.system.measureTimeMillis
 import kotlin.test.*
 
-
-object ThreadUtilSpec : Spek({
+object CreateSameThreadEnforcedStoreSpec : Spek({
     val mainThreadSurrogate = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
     Dispatchers.setMain(mainThreadSurrogate)
 
     describe("createStore") {
-        val store = createStore(
+        val store = createSameThreadEnforcedStore(
             todos, TestState(
                 listOf(
                     Todo(
@@ -47,7 +46,7 @@ object ThreadUtilSpec : Spek({
 
             runBlocking {
                 CoroutineScope(Dispatchers.Main).async {
-                    val store = createStore(
+                    val store = createSameThreadEnforcedStore(
                         testReducer,
                         TestState(),
                         applyMiddleware(middleware.middleware)
@@ -82,7 +81,7 @@ object ThreadUtilSpec : Spek({
             lateinit var store: Store<TestCounterState>
             runBlocking {
                 withContext(counterContext) {
-                    store = createStore(counterReducer, TestCounterState())
+                    store = createSameThreadEnforcedStore(counterReducer, TestCounterState())
                 }
             }
             runBlocking {

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,7 @@ pluginManagement {
 
 include(
     ':lib',
+    ':lib-threadsafe',
     ':examples:counter:common',
     ':examples:counter:android',
     ':examples:todos:common',

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,1 +1,2 @@
 .now
+.vercel

--- a/website/docs/README.md
+++ b/website/docs/README.md
@@ -25,6 +25,8 @@
 - [Glossary](Glossary.md)
 - [API Reference](api/README.md)
   - [createStore](api/createStore.md)
+  - [createThreadSafeStore](api/createThreadSafeStore.md)
+  - [createSameThreadEnforcedStore](api/createSameThreadEnforcedStore.md)
   - [Store](api/Store.md)
   - [applyMiddleware](api/applyMiddleware.md)
   - [compose](api/compose.md)

--- a/website/docs/api/README.md
+++ b/website/docs/api/README.md
@@ -74,6 +74,7 @@ data class Store<State>(
 ### Top-Level Functions
 
 - [createStore(reducer: Reducer, preloadedState: State, enhancer: StoreEnhancer)](createStore.md)
+- [createThreadSafeStore(reducer: Reducer, preloadedState: State, enhancer: StoreEnhancer)](createThreadSafeStore.md)
 - [applyMiddleware(...middlewares)](applyMiddleware.md)
 - [compose(...functions)](compose.md)
 

--- a/website/docs/api/createSameThreadEnforcedStore.md
+++ b/website/docs/api/createSameThreadEnforcedStore.md
@@ -1,0 +1,17 @@
+---
+id: createSameThreadEnforcedstore
+title: createSameThreadEnforcedStore
+sidebar_label: createSameThreadEnforcedStore
+hide_title: true
+---
+
+# `createSameThreadEnforcedStore(reducer, preloadedState, enhancer)
+
+Creates a Redux [store](Store.md) that can only be accessed from the same thread.  
+Any call to the store's functions called from a thread other than thread from which  
+ it was created will throw an IllegalStateException.
+
+ *Strongly* recommended that [`createThreadSafeStore()`](./createThreadSafeStore.md) is used unless there is
+ good reason to do otherwise.
+
+ see [`createStore()`](./createStore.md) for usage.

--- a/website/docs/api/createSameThreadEnforcedStore.md
+++ b/website/docs/api/createSameThreadEnforcedStore.md
@@ -1,11 +1,11 @@
 ---
-id: createSameThreadEnforcedstore
+id: createsamethreadenforcedstore
 title: createSameThreadEnforcedStore
 sidebar_label: createSameThreadEnforcedStore
 hide_title: true
 ---
 
-# `createSameThreadEnforcedStore(reducer, preloadedState, enhancer)
+# `createSameThreadEnforcedStore(reducer, preloadedState, enhancer)`
 
 Creates a Redux [store](Store.md) that can only be accessed from the same thread.  
 Any call to the store's functions called from a thread other than thread from which  

--- a/website/docs/api/createStore.md
+++ b/website/docs/api/createStore.md
@@ -10,6 +10,13 @@ hide_title: true
 Creates a Redux [store](Store.md) that holds the complete state tree of your app.  
 There should only be a single store in your app.
 
+If using `createStore` directly, it will not be threadsafe.
+
+It is ***STRONGLY*** recommended that [`createThreadSafeStore()`](./createThreadSafeStore.md) is used unless there is
+ good reason to do otherwise.
+
+The rest of this doc applies to all `createStore` functions.
+
 #### Arguments
 
 1. `reducer` _(Reducer)_: A [reducing function](../Glossary.md#reducer) that returns the next 

--- a/website/docs/api/createThreadSafeStore.md
+++ b/website/docs/api/createThreadSafeStore.md
@@ -1,0 +1,23 @@
+---
+id: createThreadSafeStore
+title: createThreadSafeStore
+sidebar_label: createThreadSafeStore
+hide_title: true
+---
+
+# `createThreadSafeStore(reducer, preloadedState, enhancer)
+
+Creates a Redux [store](Store.md) that is may be accessed from any thread.
+
+***This is the recommended way to create a store.***
+
+There is some performance overhead in using `createThreadSafeStore()` due to
+synchronization, however it is small and mostly likely not impact UI.
+
+Some quick benchmarks on an Android app have shown that:
+
+1. calling `getState` was always < 1ms with or without synchronization
+2. `dispatch` calls to 1-3ms longer with synchronization
+3. During a cold launch of app differences were more dramatic.  Some calls to `dispatch` took +100ms more than an store that was not synchronized.
+
+see [`createStore()`](./createStore.md) for usage.

--- a/website/docs/api/createThreadSafeStore.md
+++ b/website/docs/api/createThreadSafeStore.md
@@ -1,11 +1,11 @@
 ---
-id: createThreadSafeStore
+id: createthreadsafestore
 title: createThreadSafeStore
 sidebar_label: createThreadSafeStore
 hide_title: true
 ---
 
-# `createThreadSafeStore(reducer, preloadedState, enhancer)
+# `createThreadSafeStore(reducer, preloadedState, enhancer)`
 
 Creates a Redux [store](Store.md) that is may be accessed from any thread.
 

--- a/website/docs/introduction/GettingStarted.md
+++ b/website/docs/introduction/GettingStarted.md
@@ -33,7 +33,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation "org.reduxkotlin:redux-kotlin-threadsafe:0.5.0"
+                implementation "org.reduxkotlin:redux-kotlin-threadsafe:0.5.1"
             }
         }
     }
@@ -47,11 +47,11 @@ __For single platform project (i.e. just Android):__
 
 ```groovy
 dependencies {
-    implementation "org.reduxkotlin:redux-kotlin-threadsafe-jvm:0.5.0"
+    implementation "org.reduxkotlin:redux-kotlin-threadsafe-jvm:0.5.1"
 }
 ```
 
-NOTE: If threadsafety is not a concern (i.e. a JS only project) "org.reduxkotlin:redux-kotlin:0.5.0" may be used.
+NOTE: If threadsafety is not a concern (i.e. a JS only project) "org.reduxkotlin:redux-kotlin:0.5.1" may be used.
 [**More info on threading available here.**](/introduction/threading)
 
 ## Basic Example

--- a/website/docs/introduction/GettingStarted.md
+++ b/website/docs/introduction/GettingStarted.md
@@ -33,7 +33,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation "org.reduxkotlin:redux-kotlin:0.4.0"
+                implementation "org.reduxkotlin:redux-kotlin-threadsafe:0.5.0"
             }
         }
     }
@@ -47,9 +47,12 @@ __For single platform project (i.e. just Android):__
 
 ```groovy
 dependencies {
-    implementation "org.reduxkotlin:redux-kotlin:0.4.0"
+    implementation "org.reduxkotlin:redux-kotlin-threadsafe-jvm:0.5.0"
 }
 ```
+
+NOTE: If threadsafety is not a concern (i.e. a JS only project) "org.reduxkotlin:redux-kotlin:0.5.0" may be used.
+[**More info on threading available here.**](/introduction/threading)
 
 ## Basic Example
 
@@ -116,8 +119,8 @@ action transforms the entire application's state.
 
 In a typical Redux app, there is just a single store with a single root reducing function. As your
 app grows, you split the root reducer into smaller reducers independently operating on the different
-parts of the state tree. Redux is unopinonated - how reducers and actions are organized is up to
-you. Useful patterns will be documented here soon.TODO
+parts of the state tree. Redux is unopinionated - how reducers and actions are organized is up to
+you. Useful patterns will be documented here soon.
 
 This architecture might seem like an overkill for a counter app, but the beauty of this pattern is
 how well it scales to large and complex apps. It also enables very powerful developer tools, because

--- a/website/docs/introduction/Threading.md
+++ b/website/docs/introduction/Threading.md
@@ -19,17 +19,20 @@ state.  Or 2 actions dispatched concurrently could cause an invalid state.
 
 **So you there are 3 options:**
 
-    1) Synchronize access to the store  - [createThreadSafeStore()](../api/createThreadSafeStore.md)
-    2) Only access the store from the same thread - [createSameThreadEnforcedStore()](../api/createSameThreadEnforcedStore.md)
-    3) Live in the wild west and access store anytime, any thread and live with consequences - NOT RECOMMENDED - [createStore()](../api/createStore.md)
+1) Synchronize access to the store  - [createThreadSafeStore()](../api/createThreadSafeStore.md)
+2) Only access the store from the same thread - [createSameThreadEnforcedStore()](../api/createSameThreadEnforcedStore.md)
+3) Live in the wild west and access store anytime, any thread
+    and live with consequences - NOT_RECOMMENDED - [createStore()](../api/createStore.md)
 
 ReduxKotlin allows all these, but most cases will fall into #1.
+
+## ThreadSafe
 
 Starting with ReduxKotlin 0.5.0 there is a threadsafe store which uses synchronization (AtomicFu library)
 to allow safe access to all the functions on the store.  This is the recommended usage for 90% of use cases.
 
 ```kotlin
-    val store = createThreadSafeStore(...)
+    val store = createThreadSafeStore(reducer, state)
 ```
 
 Who is the other 10%? If you are only targeting Javascript thread safety is not an issue, so
@@ -55,9 +58,13 @@ have do not have the enforcement in place yet.
 
 To use `same thread enforcement`:
 ```kotlin
-    val store = createSameThreadEnforcedStore(...)
+    val store = createSameThreadEnforcedStore(reducer, state)
 ```
 
+## Wild west - no enforcement
+
+`createStore()` may be used if the project is only a single threaded application (i.e. JS only), or you
+just want control access within your codebase(NOT_RECOMMENDED).
 
 ***IF*** you are using vanilla `createStore()`, then you may use an different artifact,  
 and avoid pulling in AtomicFu dependency:
@@ -67,7 +74,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation "org.reduxkotlin:redux-kotlin:0.5.0"
+                implementation "org.reduxkotlin:redux-kotlin:0.5.1"
             }
         }
     }

--- a/website/docs/introduction/Threading.md
+++ b/website/docs/introduction/Threading.md
@@ -7,24 +7,71 @@ hide_title: true
 
 # Redux on Multi-threaded Platforms
 
+TLDR; use [createThreadSafeStore()](../api/createThreadSafeStore.md), unless your Javascript only
+
 Redux in multi-threaded environments brings additional concerns that are not present in redux
 for Javascript.  Javascript is single threaded, so Redux.js did not have to address the issue.
 Android, iOS, and native do have threading, and as such attention must be paid to which threads interact with the store.
 
-As of ReduxKotlin 0.3.0 there is `same thread enforcement` for the [getState](../api/store#getstate-_or_-state-property), [dispatch](../api/store#dispatchaction-any-any), [replaceReducer](../api/store#replacereducernextreducer-reducer-state-unit),
-and [subscribe](../api/store#subscribelistener-storesubscriber) functions on the store.  This means these methods must be called from the same thread where
+In a multi-threaded system invalid states and race conditions can happen.
+For example if `getState` was called at the same time as a dispatch, the state could represent a past
+state.  Or 2 actions dispatched concurrently could cause an invalid state.
+
+**So you there are 3 options:**
+
+    1) Synchronize access to the store  - [createThreadSafeStore()](../api/createThreadSafeStore.md)
+    2) Only access the store from the same thread - [createSameThreadEnforcedStore()](../api/createSameThreadEnforcedStore.md)
+    3) Live in the wild west and access store anytime, any thread and live with consequences - NOT RECOMMENDED - [createStore()](../api/createStore.md)
+
+ReduxKotlin allows all these, but most cases will fall into #1.
+
+Starting with ReduxKotlin 0.5.0 there is a threadsafe store which uses synchronization (AtomicFu library)
+to allow safe access to all the functions on the store.  This is the recommended usage for 90% of use cases.
+
+```kotlin
+    val store = createThreadSafeStore(...)
+```
+
+Who is the other 10%? If you are only targeting Javascript thread safety is not an issue, so
+`createStore` is the way to go.  Other possible reasons could be applications that need optimal
+performance, however it is unlikely that the extra overhead from synchronization will be an issue.
+
+## Same thread enforcement
+
+Another option is `same thread enforcement`. This means these methods must be called from the same thread where
 the store was created.  An `IllegalStateException` will be thrown if one of these are called from a 
 different thread.
 
-If this `same thread enforcement` was not in place invalid states and race conditions could happen.  
-For example if `getState` was called at the same time as a dispatch, the state would represent a past
-state.  Or 2 actions dispatched concurrently could cause an invalid state.
+
+`Same thread enforcement` was the default behavior for ReduxKotlin 0.3.0 - 0.4.0.
 
 Note that this is __SAME__ thread enforcement - not __MAIN__ thread enforcement.  ReduxKotlin does not
 force you to use the main thread, although you can if you'd like.  Most mobile applications do redux on the main
 thread, however it could be moved to a background thread.  Using a background thread could be desirable 
 if the reducers & middleware processing produce UI effects such as dropped frames.
 
-
 Currently `same thread enforcement` is implemented for JVM, iOS, & macOS.  The other platforms
 have do not have the enforcement in place yet.
+
+To use `same thread enforcement`:
+```kotlin
+    val store = createSameThreadEnforcedStore(...)
+```
+
+
+***IF*** you are using vanilla `createStore()`, then you may use an different artifact,  
+and avoid pulling in AtomicFu dependency:
+
+```groovy
+kotlin {
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation "org.reduxkotlin:redux-kotlin:0.5.0"
+            }
+        }
+    }
+}
+```
+**ONLY USE THE ABOVE IF YOU DO NOT WANT THREAD SAFETY**
+

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -29,9 +29,17 @@
         "title": "compose",
         "sidebar_label": "compose"
       },
+      "api/createsamethreadenforcedstore": {
+        "title": "createSameThreadEnforcedStore",
+        "sidebar_label": "createSameThreadEnforcedStore"
+      },
       "api/createstore": {
         "title": "createStore",
         "sidebar_label": "createStore"
+      },
+      "api/createthreadsafestore": {
+        "title": "createThreadSafeStore",
+        "sidebar_label": "createThreadSafeStore"
       },
       "api/api-reference": {
         "title": "API Reference",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -45,6 +45,8 @@
     "API Reference": [
       "api/api-reference",
       "api/createstore",
+      "api/createthreadsafestore",
+      "api/createsamethreadenforcedstore",
       "api/store",
       "api/combinereducers",
       "api/applymiddleware",


### PR DESCRIPTION
Addresses thread safety by providing a thread-safe store as an option. #43 

- created lib-threadsafe module as a separate artifact to be deployed to maven
- created `createSameThreadEnforcedStore` as an alternative and preserve existing behavior
- modified `createStore()` so that is does not do same thread enforcement
- updated docs
- bumped version to 0.5.0
