### PR TITLE
update references to createStore to createThreadSafeStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Using a function:
                }
 ```
 
-Using the convinence helper function `middleware`:
+Using the convenience helper function `middleware`:
 ```
    val loggingMiddleware = middleware { store, next, action -> 
           //log here
@@ -109,7 +109,7 @@ Using the convinence helper function `middleware`:
 
 __Create a store__
 ```
-  val store = createStore(reducer, AppState(user, listOf()), applyMiddleware(loggingMiddleware))
+  val store = createThreadSafeStore(reducer, AppState(user, listOf()), applyMiddleware(loggingMiddleware))
 ```
 
 You then will have access to dispatch and subscribe functions from the `store`.

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ allprojects {
         jcenter()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         maven { url "https://dl.bintray.com/spekframework/spek-dev" }
+        mavenCentral()
     }
 
     group = GROUP

--- a/examples/counter/android/build.gradle.kts
+++ b/examples/counter/android/build.gradle.kts
@@ -40,5 +40,5 @@ dependencies {
     implementation(Libs.appcompat)
 
     implementation(project(":examples:counter:common"))
-    implementation(project(":lib"))
+    implementation(project(":lib-threadsafe"))
 }

--- a/examples/counter/android/src/main/java/org/reduxkotlin/example/counter/MainActivity.kt
+++ b/examples/counter/android/src/main/java/org/reduxkotlin/example/counter/MainActivity.kt
@@ -5,7 +5,7 @@ import android.os.Handler
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.android.synthetic.main.activity_main.*
 import org.reduxkotlin.StoreSubscription
-import org.reduxkotlin.createStore
+import org.reduxkotlin.createThreadSafeStore
 import org.reduxkotlin.examples.counter.Decrement
 import org.reduxkotlin.examples.counter.Increment
 import org.reduxkotlin.examples.counter.reducer
@@ -16,7 +16,7 @@ import org.reduxkotlin.examples.counter.reducer
  */
 
 
-val store = createStore(reducer, 0)
+val store = createThreadSafeStore(reducer, 0)
 
 class MainActivity: AppCompatActivity() {
     lateinit var storeSubscription: StoreSubscription

--- a/examples/todos/android/build.gradle.kts
+++ b/examples/todos/android/build.gradle.kts
@@ -43,5 +43,5 @@ dependencies {
     implementation(Libs.recyclerView)
 
     implementation(project(":examples:todos:common"))
-    implementation(project(":lib"))
+    implementation(project(":lib-threadsafe"))
 }

--- a/examples/todos/android/src/main/java/org/reduxkotlin/example/todos/MainActivity.kt
+++ b/examples/todos/android/src/main/java/org/reduxkotlin/example/todos/MainActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.android.synthetic.main.activity_main.*
 import org.reduxkotlin.StoreSubscription
-import org.reduxkotlin.createStore
+import org.reduxkotlin.createThreadSafeStore
 import org.reduxkotlin.examples.todos.*
 
 /**
@@ -13,7 +13,7 @@ import org.reduxkotlin.examples.todos.*
  */
 
 
-val store = createStore(::rootReducer, AppState())
+val store = createThreadSafeStore(::rootReducer, AppState())
 
 class MainActivity: AppCompatActivity() {
     private lateinit var storeSubscription: StoreSubscription

--- a/examples/todos/common/build.gradle
+++ b/examples/todos/common/build.gradle
@@ -32,7 +32,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation kotlin("stdlib-common")
-                implementation project(":lib")
+                implementation project(":lib-threadsafe")
             }
         }
         commonTest {

--- a/lib/src/commonMain/kotlin/org/reduxkotlin/Definitions.kt
+++ b/lib/src/commonMain/kotlin/org/reduxkotlin/Definitions.kt
@@ -84,6 +84,8 @@ fun <State> middleware(dispatch: (Store<State>, next: Dispatcher, action: Any) -
  *
  *   val rootReducer = combineReducers(loginReducer, feedReducer)
  *   val store = createStore(rootReducer, AppState())
+ *      **or**
+ *   val store = createThreadSafeStore(rootReducer, AppState())
  */
 inline fun <TState, reified TAction> reducerForActionType(
     crossinline reducer: ReducerForActionType<TState, TAction>

--- a/website/docs/advanced/Middleware.md
+++ b/website/docs/advanced/Middleware.md
@@ -84,7 +84,7 @@ fun createThunkMiddleware(extraArgument: Any? = null): ThunkMiddleware =
         }
     }
         
-val store = createStore(
+val store = createThreadSafeStore(
     reducer,
     applyMiddleware(
         createThunkMiddleware(),

--- a/website/docs/api/Store.md
+++ b/website/docs/api/Store.md
@@ -105,7 +105,7 @@ perform side effects, or chain them to execute in a sequence, see the examples f
 #### Example
 
 ```kotlin
-val store = createStore(todos, AppState(list = listOf("Use Redux")))
+val store = createThreadSafeStore(todos, AppState(list = listOf("Use Redux")))
 
 data class AddTodo(
     val text: String

--- a/website/docs/api/applyMiddleware.md
+++ b/website/docs/api/applyMiddleware.md
@@ -46,7 +46,7 @@ maybe not calling it at all. The last middleware in the chain will receive the r
  ```kotlin
 typealias StoreEnhancer<State> = (StoreCreator<State>) -> StoreCreator<State>
  ```
-but the easiest way to apply it is to pass it to [`createStore()`](./createStore.md) as the last 
+but the easiest way to apply it is to pass it to [`createThreadSafeStore()`](./createStore.md) as the last 
 `enhancer` argument.
 
 #### Example: Custom Logger Middleware
@@ -67,7 +67,7 @@ fun loggerMiddleware2(store: Store<AppState>) = { next: Dispatcher ->
 }
 
 
-val store = createStore(todos, AppState.INITIAL_STATE, applyMiddleware(::logger))
+val store = createThreadSafeStore(todos, AppState.INITIAL_STATE, applyMiddleware(::logger))
 
 store.dispatch(AddTodoAction(text = "Understand middleware"))
 // (These lines will be logged by the middleware:)

--- a/website/docs/api/compose.md
+++ b/website/docs/api/compose.md
@@ -30,7 +30,7 @@ This example demonstrates how to use `compose` to enhance a [store](Store.md) wi
 [redux-devtools](https://github.com/reduxjs/redux-devtools) package.
 
 ```kotlin
-val store = createStore(
+val store = createThreadSafeStore(
   reducer,
   compose(
         presenterEnhancer(uiContext),

--- a/website/docs/basics/Reducers.md
+++ b/website/docs/basics/Reducers.md
@@ -96,7 +96,7 @@ method is to use a `val` in the companion object of `AppState`.
 > parameter from the `createStore` function. ReduxKotlin requires a preloaded state to be passed to
 > `createStore`. This allows us to use a nonnullable type for State.
 ```kotlin
-val store = createStore(reducer, INITIAL_STATE)
+val store = createThreadSafeStore(reducer, INITIAL_STATE)
 ```
 
 Now let's handle `SET_VISIBILITY_FILTER`. All it needs to do is to change `visibilityFilter` on the

--- a/website/docs/basics/Store.md
+++ b/website/docs/basics/Store.md
@@ -23,10 +23,10 @@ split your data handling logic, you'll use [reducer composition](Reducers.md#spl
 instead of many stores.
 
 It's easy to create a store if you have a reducer. In the [previous section](Reducers.md), we 
-combined several reducers into one. We will now pass it to [`createStore()`](../api/createStore.md).
+combined several reducers into one. We will now pass it to [`createThreadSafeStore()`](../api/createStore.md).
 
 ```kotlin
-val store = createStore(todoAppReducer, INITIAL_STATE)
+val store = createThreadSafeStore(todoAppReducer, INITIAL_STATE)
 ```
 
 > ##### Note on required initial state

--- a/website/docs/introduction/GettingStarted.md
+++ b/website/docs/introduction/GettingStarted.md
@@ -91,7 +91,7 @@ class Decrement
 
 // Create a Redux store holding the state of your app.
 // 0 is the initial state
-val store = createStore(reducer, 0)
+val store = createThreadSafeStore(reducer, 0)
 
 // You can use subscribe() to update the UI in response to state changes.
 // Normally you'd use an additional layer or view binding library rather than subscribe() directly.

--- a/website/docs/introduction/ThreePrinciples.md
+++ b/website/docs/introduction/ThreePrinciples.md
@@ -81,7 +81,7 @@ fun rootReducer(state: AppState, action: Any) = AppState(
     visibilityFilter = visibilityFilterReducer(state.visibilityFilter, action)
 )
 
-val store = createStore(::rootReducer, AppState.INITIAL_STATE)
+val store = createThreadSafeStore(::rootReducer, AppState.INITIAL_STATE)
 ```
 
 That's it! Now you know what Redux is all about.


### PR DESCRIPTION
Update docs and examples to use `createThreadSafeStore` in most cases.  This is the recommended function to create a store and should be used almost everywhere.