### PR TITLE
Update publish.gradle

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -76,10 +76,10 @@ task javadocsJar(type: Jar, dependsOn: dokka) {
 
 signing {
     required { isReleaseBuild() /*&& gradle.taskGraph.hasTask("uploadArchives") */ }
-//    def signingKey = findProperty("GPG_SECRET") ?: System.getenv('GPG_SECRET') ?: ""
-//    def signingPassword = findProperty("GPG_SIGNING_PASSWORD") ?: System.getenv('GPG_SIGNING_PASSWORD') ?: ""
-//    useInMemoryPgpKeys(signingKey, signingPassword)
-//    sign(publishing.publications)
+    def signingKey = findProperty("GPG_SECRET") ?: System.getenv('GPG_SECRET') ?: ""
+    def signingPassword = findProperty("GPG_SIGNING_PASSWORD") ?: System.getenv('GPG_SIGNING_PASSWORD') ?: ""
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign(publishing.publications)
 }
 
 publishing {


### PR DESCRIPTION
Appears this was accidentally committed and broke maven publishing from CI ~2 years ago. 