### PR TITLE
fix(samples): respect system bar insets on edge-to-edge devices

### DIFF
--- a/examples/counter/android/build.gradle.kts
+++ b/examples/counter/android/build.gradle.kts
@@ -29,6 +29,7 @@ android {
 }
 
 dependencies {
+    implementation(libs.androidx.activity)
     implementation(libs.androidx.appcompat)
     implementation(project(":examples:counter:common"))
     implementation(project(":redux-kotlin-threadsafe"))

--- a/examples/counter/android/src/main/java/org/reduxkotlin/example/counter/MainActivity.kt
+++ b/examples/counter/android/src/main/java/org/reduxkotlin/example/counter/MainActivity.kt
@@ -2,7 +2,11 @@ package org.reduxkotlin.example.counter
 
 import android.os.Bundle
 import android.os.Handler
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import org.reduxkotlin.StoreSubscription
 import org.reduxkotlin.example.counter.databinding.ActivityMainBinding
 import org.reduxkotlin.examples.counter.Decrement
@@ -22,9 +26,17 @@ class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, insets ->
+            val bars = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
+            )
+            v.updatePadding(bars.left, bars.top, bars.right, bars.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
         storeSubscription = store.subscribe { render(store.state) }
         binding.btnIncrement.setOnClickListener { store.dispatch(Increment()) }
         binding.btnDecrement.setOnClickListener { store.dispatch(Decrement()) }

--- a/examples/todos/android/build.gradle.kts
+++ b/examples/todos/android/build.gradle.kts
@@ -29,6 +29,7 @@ android {
 }
 
 dependencies {
+    implementation(libs.androidx.activity)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.recyclerview)

--- a/examples/todos/android/src/main/java/org/reduxkotlin/example/todos/MainActivity.kt
+++ b/examples/todos/android/src/main/java/org/reduxkotlin/example/todos/MainActivity.kt
@@ -1,7 +1,11 @@
 package org.reduxkotlin.example.todos
 
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import org.reduxkotlin.StoreSubscription
 import org.reduxkotlin.example.todos.databinding.ActivityMainBinding
 import org.reduxkotlin.examples.todos.*
@@ -20,9 +24,19 @@ class MainActivity : AppCompatActivity() {
     private var adapter = TodoAdapter()
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, insets ->
+            val bars = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars()
+                    or WindowInsetsCompat.Type.displayCutout()
+                    or WindowInsetsCompat.Type.ime(),
+            )
+            v.updatePadding(bars.left, bars.top, bars.right, bars.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
         storeSubscription = store.subscribe { render(store.state) }
         binding.btnAddTodo.setOnClickListener {
             val todoText = binding.etTodo.text.toString()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 android-gradle-plugin = "9.1.0"
+androidx-activity = "1.10.1"
 androidx-appcompat = "1.7.1"
 androidx-constraintlayout = "2.2.1"
 androidx-recyclerview = "1.4.0"
@@ -13,6 +14,7 @@ nexus-publish-plugin = "2.0.0"
 
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
+androidx-activity = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }


### PR DESCRIPTION
## Summary

`targetSdk = 35` opts the sample apps into Android 15's mandatory edge-to-edge windowing. The samples weren't applying window insets, so on recent devices content rendered underneath the status bar and three-button nav bar — the first row of UI (the counter label / the todos EditText) ended up obscured.

## Fix

Both `MainActivity` files now follow the canonical AndroidX edge-to-edge pattern:

1. Add `androidx.activity:activity-ktx` (1.10.1 — the most recent release compatible with `compileSdk = 35`) to the version catalog and to each sample's `dependencies` block.
2. Call `enableEdgeToEdge()` before `super.onCreate(...)` / `setContentView(...)`.
3. Install a `ViewCompat.setOnApplyWindowInsetsListener` on the root binding view:
   - **counter**: pads by `systemBars | displayCutout`
   - **todos**: pads by `systemBars | displayCutout | ime` (extra `ime` so the layout reflows when the soft keyboard appears against the `EditText`)
4. Return `WindowInsetsCompat.CONSUMED` so child views don't double-apply insets.

## Test plan

- [x] `./gradlew :examples:counter:android:assembleDebug` — clean
- [x] `./gradlew :examples:todos:android:assembleDebug` — clean
- [x] `./gradlew detektAll` — clean
- [ ] On-device check: status bar and nav bar no longer overlap content; in todos, EditText slides above the soft keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)