### PR TITLE
chore(build): rename KMP androidLibrary { } block to android { }

### DIFF
--- a/build-conventions/src/main/kotlin/convention.library-mpp-loved.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.library-mpp-loved.gradle.kts
@@ -30,7 +30,7 @@ kotlin {
     }
 
     if (hasAndroidSdk) {
-        androidLibrary {
+        android {
             minSdk = 21
         }
     }

--- a/redux-kotlin-threadsafe/build.gradle.kts
+++ b/redux-kotlin-threadsafe/build.gradle.kts
@@ -17,7 +17,7 @@ val hasAndroidSdk: Boolean = run {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.reduxkotlin.threadsafe"
     }
 

--- a/redux-kotlin/build.gradle.kts
+++ b/redux-kotlin/build.gradle.kts
@@ -17,7 +17,7 @@ val hasAndroidSdk: Boolean = run {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.reduxkotlin"
     }
 


### PR DESCRIPTION
## Summary

The Kotlin Multiplatform plugin renamed its Android Library target DSL from `androidLibrary { ... }` to `android { ... }`; the old name remains as a `@Deprecated` shim and shows up as one of the noisiest warnings on every build:

```
'fun KotlinMultiplatformExtension.androidLibrary(...)' is deprecated.
The 'androidLibrary' block is deprecated. Please use 'android' instead.
```

Three sites updated:
- `build-conventions/src/main/kotlin/convention.library-mpp-loved.gradle.kts`
- `redux-kotlin/build.gradle.kts`
- `redux-kotlin-threadsafe/build.gradle.kts`

## Test plan

- [x] `./gradlew help --warning-mode all` no longer surfaces the `androidLibrary` deprecation
- [x] `./gradlew :redux-kotlin:jvmTest :redux-kotlin-threadsafe:jvmTest` — green
- [x] `./gradlew detektAll` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)