### PR TITLE
chore(build): clear four small Gradle/Kotlin deprecation warnings

### DIFF
--- a/build-conventions/build.gradle.kts
+++ b/build-conventions/build.gradle.kts
@@ -31,6 +31,11 @@ tasks {
             jvmTarget.set(JvmTarget.JVM_17)
         }
     }
+    withType<JavaCompile>().configureEach {
+        // Match the Kotlin jvmTarget above so Gradle stops flagging
+        // "Inconsistent JVM Target Compatibility Between Java and Kotlin Tasks".
+        options.release.set(17)
+    }
 }
 
 develocity {

--- a/build-conventions/src/main/kotlin/convention.detekt.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.detekt.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 detekt {
     config.from(rootDir.resolve("gradle/detekt.yml"))
     buildUponDefaultConfig = true
-    source = files("src/", "*.kts")
+    source.setFrom("src/", "*.kts")
 }
 
 tasks {

--- a/build-conventions/src/main/kotlin/convention.publishing.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.publishing.gradle.kts
@@ -101,7 +101,7 @@ publishing {
                     password = System.getenv("GH_PASSWORD")
                 }
             }
-            maven("file://${rootProject.buildDir}/localMaven") {
+            maven(rootProject.layout.buildDirectory.dir("localMaven").map { it.asFile.toURI() }) {
                 name = "Local"
             }
         }

--- a/build-conventions/src/main/kotlin/util/gradle.kt
+++ b/build-conventions/src/main/kotlin/util/gradle.kt
@@ -3,15 +3,12 @@ package util
 import java.nio.charset.Charset
 
 object Git {
-    val headCommitHash by lazy { execAndCapture("git rev-parse --verify HEAD") }
+    val headCommitHash by lazy { execAndCapture("git", "rev-parse", "--verify", "HEAD") }
 }
 
-fun execAndCapture(cmd: String): String? {
-    val child = Runtime.getRuntime().exec(cmd)
-    child.waitFor()
-    return if (child.exitValue() == 0) {
-        child.inputStream.readAllBytes().toString(Charset.defaultCharset()).trim()
-    } else {
-        null
-    }
+fun execAndCapture(vararg cmd: String): String? {
+    val process = ProcessBuilder(*cmd).start()
+    val output = process.inputStream.readAllBytes().toString(Charset.defaultCharset()).trim()
+    process.waitFor()
+    return if (process.exitValue() == 0) output else null
 }


### PR DESCRIPTION
## Summary

Picks off the easy residual deprecation warnings that surface on every clean build. Each fix is independent and minimal.

| File | Deprecation | Fix |
|---|---|---|
| `convention.publishing.gradle.kts:104` | `Project.buildDir` (removed in Gradle 10) | Use `layout.buildDirectory.dir(...).map { it.asFile.toURI() }` |
| `convention.detekt.gradle.kts:14` | `var source: ConfigurableFileCollection` setter | `source.setFrom(...)` |
| `util/gradle.kt:10` | `Runtime.exec(String)` deprecated since JDK 18 (whitespace tokenisation is security-sensitive) | `ProcessBuilder(vararg argv).start()` |
| `build-conventions/build.gradle.kts` | "Inconsistent JVM Target Compatibility Between Java and Kotlin Tasks" (`compileJava` 21 vs `compileKotlin` 17 after the JDK 21 toolchain bump) | Pin `JavaCompile.options.release.set(17)` |

## Deliberately deferred

These showed up in the same scan but each needs its own scope:

- **`apply false`** in `convention.library-mpp-loved.gradle.kts` — removing it as the Gradle 10 deprecation suggests fails compilation, because the conditional `apply(plugin = "convention.library-android")` path loses access to the plugin's DSL types. Needs a convention restructure (e.g. fold `convention.library-android` directly into `convention.library-mpp-loved` under the `hasAndroidSdk` gate).
- **`dokkaHtml`** (Dokka V1) — separate Dokka V2 migration PR.
- **`androidLibrary { }`** rename → `android { }` — separate PR (#269).
- **`macosX64`** native-tier deprecation — judgment call about dropping x86 macOS support.
- **`ReportingExtension.file()`** — emitted from inside a plugin (likely Detekt or Dokka), resolves with the next upstream bump.

## Test plan

- [x] `./gradlew help` — green, no longer surfaces the four targeted warnings
- [x] `./gradlew :redux-kotlin:jvmTest :redux-kotlin-threadsafe:jvmTest` — green
- [x] `./gradlew detektAll` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)