### PR TITLE
build: migrate Dokka Gradle plugin to V2 mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
 
       - name: Gradle Assemble Dokka
-        run: ./gradlew dokkaHtmlMultiModule -Pversion=${VERSION//v} --scan
+        run: ./gradlew dokkaGenerate -Pversion=${VERSION//v} --scan
 
       - uses: actions/upload-artifact@v7
         with:
@@ -154,7 +154,7 @@ jobs:
         run: |
           REPO_NAME=${{ github.repository }}
           REPO_NAME=${REPO_NAME#${{ github.repository_owner }}/}
-          cp -avr build/dokka/htmlMultiModule/ public;
+          cp -avr build/dokka/html/ public;
           find public -type f -regex '.*\.\(htm\|html\|txt\|text\|js\|css\)$' -exec gzip -f -k {} \;
           echo "/${REPO_NAME} /${REPO_NAME}/${REPO_NAME}/index.html 301" > public/_redirects;
           echo "/${REPO_NAME}/index.html /${REPO_NAME}/${REPO_NAME}/index.html 301" >> public/_redirects;

--- a/build-conventions/src/main/kotlin/convention.publishing.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.publishing.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.dokka.gradle.tasks.DokkaGeneratePublicationTask
 import org.jetbrains.kotlin.konan.target.HostManager
 import util.Git
 
@@ -8,11 +9,22 @@ plugins {
     signing
 }
 
+// The `androidMain` source set shares files with `jvmCommonMain` via `kotlin.srcDir`
+// (see `convention.library-mpp-loved`). Dokka V2's pre-generation validity check
+// rejects a single .kt file appearing in two source sets, so suppress the android
+// source set entirely — its docs would be duplicates of jvmCommonMain anyway.
+dokka {
+    dokkaSourceSets.matching { it.name.startsWith("android") }.configureEach {
+        suppress.set(true)
+    }
+}
+
 tasks {
+    val dokkaPublicationHtml = named<DokkaGeneratePublicationTask>("dokkaGeneratePublicationHtml")
     register<Jar>("javadocJar") {
-        dependsOn(dokkaHtml)
+        dependsOn(dokkaPublicationHtml)
         archiveClassifier.set("javadoc")
-        from(dokkaHtml.get().outputDirectory)
+        from(dokkaPublicationHtml.flatMap { it.outputDirectory })
     }
     withType<Jar> {
         manifest {

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,10 @@ kotlin.js.generate.externals=false
 kotlin.incremental.js=true
 kotlin.native.ignoreDisabledTargets=true
 kotlin.js.browser.karma.browsers=chromium-headless
+# Opt into the Dokka 2 Gradle plugin's V2 mode. V1 is deprecated and slated
+# for removal; the new task graph uses `dokkaGenerate` instead of `dokkaHtml`.
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 #======================================== Android =======================================
 android.useAndroidX=true
 #======================================== GitHub ========================================


### PR DESCRIPTION
## Summary

Dokka 2.x has its V2 Gradle plugin model — `dokkaGenerate` instead of `dokkaHtml`, new task types, restructured output layout. V1 is `@Deprecated` on Dokka 2.2 and slated for removal upstream. Every build currently emits:

```
'val TaskContainer.dokkaHtml: TaskProvider<DokkaTask>' is deprecated.
Dokka Gradle plugin V1 mode is deprecated, and scheduled to be removed
in Dokka v2.2.0. Migrate to V2 mode https://kotl.in/dokka-gradle-migration.
```

This PR opts into V2 mode and rewires every consumer.

## Changes

- **`gradle.properties`** — add `org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled` plus the `.noWarn=true` companion flag (the latter silences the opt-in-property-name churn warning).
- **`convention.publishing.gradle.kts`**:
  - `javadocJar` task: replace `dependsOn(dokkaHtml)` / `from(dokkaHtml.get().outputDirectory)` with a type-safe lookup of `dokkaGeneratePublicationHtml` (`DokkaGeneratePublicationTask`) plus `flatMap { it.outputDirectory }` so Gradle wires the task-output dependency correctly.
  - Suppress the `android*` Dokka source sets. The `androidMain` source set in this project shares `.kt` files with `jvmCommonMain` via `kotlin.srcDir(...)` (the legacy alias used to fold JVM-only code into the Android Library target). Dokka V2's pre-generation validity check rejects a single file appearing in two source sets; suppressing the android docs is the cleanest workaround — they would be byte-identical to jvmCommonMain docs.
- **`.github/workflows/release.yml`**:
  - `dokkaHtmlMultiModule` → `dokkaGenerate` (the V2 root aggregator).
  - `build/dokka/htmlMultiModule/` → `build/dokka/html/` (V2 consolidates publication output under a single `html/` directory).

## Test plan

- [x] `./gradlew :redux-kotlin:javadocJar :redux-kotlin-threadsafe:javadocJar` — both produce non-empty jars
- [x] `./gradlew dokkaGenerate` — populates `build/dokka/html/index.html`
- [x] `./gradlew help :redux-kotlin:jvmTest :redux-kotlin-threadsafe:jvmTest detektAll` — green
- [x] `--warning-mode all` no longer reports the two `dokkaHtml is deprecated` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)