### PR TITLE
feat(website): port v1 homepage layout to Docusaurus 3 (PR C of 3)

### DIFF
--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -1,23 +1,112 @@
-/**
- * CSS files with the .module.css suffix will be treated as CSS modules
- * and scoped locally.
- */
-
 .heroBanner {
   padding: 4rem 0;
   text-align: center;
-  position: relative;
-  overflow: hidden;
+  background: linear-gradient(180deg, var(--ifm-color-primary-lightest) 0%, transparent 100%);
 }
 
-@media screen and (max-width: 996px) {
-  .heroBanner {
-    padding: 2rem;
-  }
+.heroTitle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.projectTitle {
+  font-size: 3rem;
+  margin: 0;
 }
 
 .buttons {
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-top: 1.5rem;
+}
+
+@media screen and (max-width: 996px) {
+  .heroBanner {
+    padding: 2rem;
+  }
+  .projectTitle {
+    font-size: 2rem;
+  }
+}
+
+.featuresSection {
+  padding: 3rem 0;
+}
+
+.featuresGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2rem;
+}
+
+.featureCard {
+  text-align: center;
+}
+
+.featureImage {
+  max-width: 120px;
+  height: auto;
+  margin-bottom: 1rem;
+}
+
+.librariesSection {
+  padding: 3rem 0;
+  text-align: center;
+}
+
+.librariesGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.libraryCard {
+  display: block;
+  padding: 1.5rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 0.5rem;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.2s, transform 0.2s;
+}
+
+.libraryCard:hover {
+  border-color: var(--ifm-color-primary);
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+
+.libraryCard h3 {
+  color: var(--ifm-color-primary);
+  margin-bottom: 0.5rem;
+}
+
+.surveySection {
+  padding: 3rem 0 5rem;
+}
+
+.surveyGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2rem;
+}
+
+.surveyCard {
+  padding: 1.5rem;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 0.5rem;
+}
+
+@media screen and (max-width: 996px) {
+  .featuresGrid,
+  .librariesGrid {
+    grid-template-columns: 1fr;
+  }
+  .surveyGrid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,37 +1,202 @@
 import type {ReactNode} from 'react';
+import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 
 import styles from './index.module.css';
 
-// PR A placeholder homepage. PR C ports the v1 splash/features layout from
-// the old `pages/en/index.js` (HomeSplash + FeaturesTop + OtherLibraries +
-// DocsSurvey).
+type Feature = {
+  title: string;
+  image: string;
+  description: ReactNode;
+};
+
+type LibraryLink = {
+  title: string;
+  href: string;
+  description: ReactNode;
+};
+
+type SurveyBlock = {
+  title: string;
+  description: ReactNode;
+};
+
+const FEATURES: Feature[] = [
+  {
+    title: 'Multiplatform',
+    image: 'img/multiplatform-screen-512.png',
+    description: (
+      <>
+        ReduxKotlin is written with multiplatform as the top priority. Supports every platform
+        Kotlin targets (JVM, Native, JS, WASM), enabling code sharing.
+      </>
+    ),
+  },
+  {
+    title: 'Predictable',
+    image: 'img/noun_Check_1870817.svg',
+    description: (
+      <>
+        Redux helps you write applications that <strong>behave consistently</strong> and are{' '}
+        <strong>easy to test</strong>.
+      </>
+    ),
+  },
+  {
+    title: 'Centralized',
+    image: 'img/cubes-solid.svg',
+    description: (
+      <>
+        Centralizing your application's state and logic enables easy sharing state between
+        components and lifecycle events.
+      </>
+    ),
+  },
+];
+
+const LIBRARIES: LibraryLink[] = [
+  {
+    title: 'redux-kotlin-thunk',
+    href: 'https://github.com/reduxkotlin/redux-kotlin-thunk',
+    description: 'Async middleware for ReduxKotlin, ported from redux-thunk.',
+  },
+  {
+    title: 'redux-kotlin-compose',
+    href: 'https://github.com/reduxkotlin/redux-kotlin-compose',
+    description: 'Jetpack Compose bindings for ReduxKotlin.',
+  },
+  {
+    title: 'presenter-middleware',
+    href: 'https://github.com/reduxkotlin/presenter-middleware',
+    description: 'A lifecycle-aware presenter pattern built on ReduxKotlin middleware.',
+  },
+];
+
+const SURVEY: SurveyBlock[] = [
+  {
+    title: 'Port of JS Redux',
+    description: (
+      <>
+        ReduxKotlin has the same API as JavaScript Redux. If you're coming from JS or work alongside
+        Redux developers, you'll feel right at home.
+      </>
+    ),
+  },
+  {
+    title: 'Help us improve ReduxKotlin',
+    description: (
+      <>
+        ReduxKotlin can be used today, but we're always looking for ways to improve developer
+        experience and documentation. Please{' '}
+        <a
+          href="https://docs.google.com/forms/d/e/1FAIpQLScEQ9zGndU48AUeGKR6PPE13IqhIFmTL570wDodQUEilhwMzw/viewform"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <strong>fill out this survey.</strong>
+        </a>
+      </>
+    ),
+  },
+];
+
+function HeroSplash(): ReactNode {
+  const {siteConfig} = useDocusaurusContext();
+  const logoUrl = useBaseUrl('img/reduxkotlin.svg');
+  return (
+    <header className={clsx('hero', styles.heroBanner)}>
+      <div className="container">
+        <div className={styles.heroTitle}>
+          <img src={logoUrl} alt="ReduxKotlin logo" width={100} height={100} />
+          <Heading as="h1" className={styles.projectTitle}>
+            {siteConfig.title}
+          </Heading>
+        </div>
+        <p className="hero__subtitle">A predictable state container for Kotlin apps.</p>
+        <div className={styles.buttons}>
+          <Link className="button button--primary button--lg" to="/introduction/getting-started">
+            Get Started →
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function FeatureCard({feature}: {feature: Feature}): ReactNode {
+  const imageUrl = useBaseUrl(feature.image);
+  return (
+    <div className={styles.featureCard}>
+      <img className={styles.featureImage} src={imageUrl} alt="" />
+      <Heading as="h3">{feature.title}</Heading>
+      <p>{feature.description}</p>
+    </div>
+  );
+}
+
+function Features(): ReactNode {
+  return (
+    <section className={clsx('container', styles.featuresSection)}>
+      <div className={styles.featuresGrid}>
+        {FEATURES.map((feature) => (
+          <FeatureCard key={feature.title} feature={feature} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function Libraries(): ReactNode {
+  return (
+    <section className={clsx('container', styles.librariesSection)}>
+      <Heading as="h2">ReduxKotlin Extensions</Heading>
+      <div className={styles.librariesGrid}>
+        {LIBRARIES.map((lib) => (
+          <a
+            key={lib.title}
+            className={styles.libraryCard}
+            href={lib.href}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <Heading as="h3">{lib.title}</Heading>
+            <p>{lib.description}</p>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function Survey(): ReactNode {
+  return (
+    <section className={clsx('container', styles.surveySection)}>
+      <div className={styles.surveyGrid}>
+        {SURVEY.map((entry) => (
+          <div key={entry.title} className={styles.surveyCard}>
+            <Heading as="h3">{entry.title}</Heading>
+            <p>{entry.description}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export default function Home(): ReactNode {
   const {siteConfig} = useDocusaurusContext();
   return (
-    <Layout
-      title={siteConfig.title}
-      description={siteConfig.tagline}
-    >
-      <header className={styles.heroBanner}>
-        <div className="container">
-          <Heading as="h1" className="hero__title">
-            {siteConfig.title}
-          </Heading>
-          <p className="hero__subtitle">{siteConfig.tagline}</p>
-          <div>
-            <Link
-              className="button button--secondary button--lg"
-              to="/introduction/getting-started"
-            >
-              Get started →
-            </Link>
-          </div>
-        </div>
-      </header>
+    <Layout title={siteConfig.title} description={siteConfig.tagline}>
+      <HeroSplash />
+      <main>
+        <Features />
+        <Libraries />
+        <Survey />
+      </main>
     </Layout>
   );
 }


### PR DESCRIPTION
## Summary

**PR C of 3** in the Docusaurus 1 → 3 migration. Stacks on #273 (PR B doc cleanup).

Restores the v1 splash/features layout (logo + tagline, 3-column features, extensions grid, survey blocks) on top of v3's Layout primitives. The v1 homepage used `CompLibrary.{MarkdownBlock, GridBlock, Container}` from Docusaurus 1, none of which have direct v3 equivalents — replaced with plain TSX + CSS module + Infima utility classes.

## Sections

| Section | Content |
|---|---|
| **Hero** | `reduxkotlin.svg` logo + title + "A predictable state container for Kotlin apps" tagline + "Get Started →" button. Gradient background from brand `#137AF9`. |
| **Features (3-column)** | Multiplatform / Predictable / Centralized — same copy and icons as v1 (`multiplatform-screen-512.png`, `noun_Check_1870817.svg`, `cubes-solid.svg`). |
| **Extensions (3-column)** | Replaces the v1 "Other Libraries from the Redux Team" (which pointed at React-Redux + Redux Starter Kit — JavaScript-only). New cards link to redux-kotlin-thunk, redux-kotlin-compose, presenter-middleware. |
| **Survey (2-column)** | Same copy as v1 "Port of JS Redux" + "Help us improve", same Google Forms link. |

Collapses to a single column at `<996px`.

## Footer

Unchanged from PR A — `themeConfig.footer.links` already expresses the v1 footer's Docs / Community / More structure. The review flagged the v1 inline-styled multi-paragraph copyright as config-incompatible; that block has been replaced by the auto-generated copyright line, which is acceptable simplification.

## Test plan

- [x] `yarn build` succeeds with `onBrokenLinks: 'throw'`
- [x] CI green
- [x] `yarn serve` walkthrough: homepage renders all four sections, links resolve, layout collapses correctly on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)