### PR TITLE
build: add wasmJs target to redux-kotlin core + threadsafe

### DIFF
--- a/build-conventions/src/main/kotlin/convention.detekt.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.detekt.gradle.kts
@@ -37,7 +37,9 @@ tasks {
                 sarif.required.set(true)
             }
             include("**/*.kt", "**/*.kts")
-            exclude("**/build", "scripts/")
+            // `.claude/` holds Claude Code harness worktrees / caches; never
+            // scan them. `**/build` is the Gradle output dir.
+            exclude("**/build", "scripts/", ".claude/", "**/.claude/")
         }
     }
 }

--- a/build-conventions/src/main/kotlin/convention.mpp-loved.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.mpp-loved.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -19,6 +20,11 @@ kotlin {
     js {
         useCommonJs()
         browser { testTask { useKarma() } }
+        nodejs()
+    }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
         nodejs()
     }
     jvm {

--- a/redux-kotlin/src/wasmJsMain/kotlin/org/reduxkotlin/utils/ThreadUtilWasmJs.kt
+++ b/redux-kotlin/src/wasmJsMain/kotlin/org/reduxkotlin/utils/ThreadUtilWasmJs.kt
@@ -1,0 +1,9 @@
+package org.reduxkotlin.utils
+
+/**
+ * Returns the name of the current thread.
+ *
+ * Kotlin/Wasm-JS is single-threaded (no Worker shared-state); the main
+ * task is the only execution context. Mirrors the Kotlin/JS actual.
+ */
+public actual fun getThreadName(): String = "main"


### PR DESCRIPTION
## Summary

Foundation for the upcoming `redux-kotlin-granular` module, which targets `wasmJs` so Compose Multiplatform's wasmJs renderer — the actual Compose-UI-on-the-web target, not plain Kotlin/JS-IR — can consume the granular subscriptions API. Also unblocks any future browser consumers that prefer Wasm over JS-IR.

Part of the granular-subscriptions plan: this is PR α of 5 in that series, the prerequisite for the granular module itself.

## Changes

- `convention.mpp-loved.gradle.kts` — enable `wasmJs` (browser + nodejs binaries) under the existing default hierarchy template. `wasmWasi` deliberately stays out (thinner ecosystem; `kotlinx-benchmark` doesn't yet support it).
- `redux-kotlin/src/wasmJsMain/.../ThreadUtilWasmJs.kt` — actual for `expect fun getThreadName()`. Wasm-JS is single-threaded; mirrors the Kotlin/JS actual.
- `convention.detekt.gradle.kts` — exclude `.claude/` from `detektAll`. The Claude Code harness keeps worktrees there, which were producing 85 unrelated detekt findings.

`redux-kotlin-threadsafe` doesn't need its own ThreadUtil actual — its public API doesn't reference `getThreadName`, and the upstream core module now provides the wasmJs implementation transitively.

## Test plan

- [x] `./gradlew :redux-kotlin:compileKotlinWasmJs :redux-kotlin-threadsafe:compileKotlinWasmJs` clean
- [x] `./gradlew :redux-kotlin:compileTestKotlinWasmJs :redux-kotlin-threadsafe:compileTestKotlinWasmJs` clean
- [x] `./gradlew jvmTest detektAll` still green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)