### PR TITLE
feat(multimodel-granular): add typed subscribeTo(Model::field) overload (PR η of v2)

### DIFF
--- a/redux-kotlin-granular/build.gradle.kts
+++ b/redux-kotlin-granular/build.gradle.kts
@@ -1,0 +1,36 @@
+import util.jvmCommonTest
+
+plugins {
+    id("convention.library-mpp-loved")
+    id("convention.publishing-mpp")
+}
+
+val hasAndroidSdk: Boolean = run {
+    val localProps = rootProject.file("local.properties")
+    val hasSdkInLocalProperties = localProps.exists() && localProps.readText().lineSequence().any {
+        it.trim().startsWith("sdk.dir=") && it.substringAfter("sdk.dir=").isNotBlank()
+    }
+    val hasSdkInEnv =
+        !System.getenv("ANDROID_HOME").isNullOrBlank() ||
+            !System.getenv("ANDROID_SDK_ROOT").isNullOrBlank()
+    hasSdkInLocalProperties || hasSdkInEnv
+}
+
+kotlin {
+    android {
+        namespace = "org.reduxkotlin.granular"
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":redux-kotlin"))
+            }
+        }
+        jvmCommonTest {
+            dependencies {
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
+    }
+}

--- a/redux-kotlin-granular/src/commonMain/kotlin/org/reduxkotlin/granular/FieldSubscriptionScope.kt
+++ b/redux-kotlin-granular/src/commonMain/kotlin/org/reduxkotlin/granular/FieldSubscriptionScope.kt
@@ -1,0 +1,48 @@
+package org.reduxkotlin.granular
+
+import kotlin.reflect.KProperty1
+
+/**
+ * DSL receiver for [subscribeFields]. Each [on] registration adds one
+ * entry to a single underlying `store.subscribe` listener, so a batch of
+ * N fields incurs the cost of one underlying subscriber instead of N.
+ *
+ * The scope is sealed at the end of the [subscribeFields] block — there is
+ * no public way to add or remove entries after activation. This is by
+ * design: it lets us iterate the entry list without copying on the hot
+ * dispatch path, and it bounds the surface of the API in v1. Callers
+ * that need to swap inner subscriptions mid-flight should use separate
+ * [subscribeFields] blocks or independent [subscribeTo] calls.
+ */
+public interface FieldSubscriptionScope<State> {
+
+    /**
+     * Registers a granular subscription against a derived value. The
+     * listener fires when `selector(newState)` differs from the previously
+     * observed value (referential `===` first, then structural `==`).
+     *
+     * If [triggerOnSubscribe] is `true` (the default), the listener fires
+     * once immediately after the [subscribeFields] block completes, with
+     * both `oldValue` and `newValue` set to the current selector result.
+     */
+    public fun <F> on(
+        selector: (State) -> F,
+        triggerOnSubscribe: Boolean = true,
+        listener: (oldValue: F, newValue: F) -> Unit,
+    )
+
+    /**
+     * Property-reference convenience overload. Kotlin call sites can write
+     * `on(MyState::myField) { o, n -> ... }`; equivalent to passing
+     * `MyState::myField::get` to the selector overload.
+     *
+     * Hidden from Swift via [@HiddenFromObjC] on the call site and not
+     * `@JsExport`ed, because [KProperty1] is Kotlin-only — non-Kotlin
+     * consumers should use the lambda selector overload above.
+     */
+    public fun <F> on(
+        property: KProperty1<State, F>,
+        triggerOnSubscribe: Boolean = true,
+        listener: (oldValue: F, newValue: F) -> Unit,
+    )
+}

--- a/redux-kotlin-granular/src/commonMain/kotlin/org/reduxkotlin/granular/GranularSubscriptionsEnhancer.kt
+++ b/redux-kotlin-granular/src/commonMain/kotlin/org/reduxkotlin/granular/GranularSubscriptionsEnhancer.kt
@@ -1,0 +1,22 @@
+package org.reduxkotlin.granular
+
+import org.reduxkotlin.StoreEnhancer
+
+/**
+ * No-op store enhancer intended for use in `createStore(..., compose(applyMiddleware(...),
+ * granularSubscriptionsEnhancer()))` chains where the author wants to
+ * advertise that granular subscriptions are in use.
+ *
+ * The granular API itself is a set of extension functions on
+ * [org.reduxkotlin.Store]; no store wrapping is needed for correctness.
+ * This marker exists so future per-store optimisations (e.g. folding a
+ * field registry directly into a store wrapper instead of attaching a
+ * separate subscriber per [subscribeFields] block) can take advantage of
+ * the enhancer hook without breaking call sites that already use it.
+ */
+public fun <State> granularSubscriptionsEnhancer(): StoreEnhancer<State> = { storeCreator ->
+    {
+            reducer, initialState, en ->
+        storeCreator(reducer, initialState, en)
+    }
+}

--- a/redux-kotlin-granular/src/commonMain/kotlin/org/reduxkotlin/granular/SubscribeFields.kt
+++ b/redux-kotlin-granular/src/commonMain/kotlin/org/reduxkotlin/granular/SubscribeFields.kt
@@ -1,0 +1,166 @@
+package org.reduxkotlin.granular
+
+import org.reduxkotlin.Store
+import org.reduxkotlin.StoreSubscription
+import kotlin.concurrent.Volatile
+
+/**
+ * Subscribes to a single derived value of the store's state. The
+ * [listener] fires only when `selector(newState)` differs from the
+ * previously observed value (referential `===` first, then structural).
+ *
+ * If [triggerOnSubscribe] is `true` (the default), the listener fires
+ * once immediately after subscription with both `oldValue` and
+ * `newValue` set to the current selector result. This matches the
+ * convention of `StateFlow`, `LiveData`, and RxJava's `BehaviorSubject`,
+ * and removes the typical "render once + subscribe to changes" two-step
+ * in UI binding code.
+ *
+ * Returns a [StoreSubscription] (`() -> Unit`) that tears down the
+ * subscription when invoked.
+ */
+public fun <State, F> Store<State>.subscribeTo(
+    selector: (State) -> F,
+    triggerOnSubscribe: Boolean = true,
+    listener: (oldValue: F, newValue: F) -> Unit,
+): StoreSubscription = subscribeFields { on(selector, triggerOnSubscribe, listener) }
+
+/**
+ * Registers multiple granular subscriptions backed by a *single*
+ * underlying `store.subscribe` listener. Best for components that watch
+ * several fields.
+ *
+ * Returns one combined [StoreSubscription]; invoking it tears down every
+ * inner subscription and the single underlying listener.
+ *
+ * The optional `onSelectorError` parameter is a handler invoked when a
+ * selector evaluation throws inside the dispatch hot path (or at
+ * registration time). The default is `null` — exceptions are silently
+ * swallowed and the offending entry is skipped, so an uncaught
+ * exception from one selector never breaks other subscribers. Pass a
+ * custom handler to capture errors to a crash reporter or fail-fast in
+ * tests.
+ */
+public fun <State> Store<State>.subscribeFields(
+    onSelectorError: ((cause: Throwable) -> Unit)? = null,
+    block: (FieldSubscriptionScope<State>) -> Unit,
+): StoreSubscription {
+    val registry = FieldSubscriptionRegistry(this, onSelectorError)
+    block(registry)
+    return registry.activate()
+}
+
+/**
+ * Kotlin-only overload accepting a lambda-with-receiver block. Compiles
+ * away to the lambda-form overload above; not `@JsExport`ed because
+ * Kotlin/JS lambda-with-receiver export semantics are awkward in raw JS.
+ *
+ * Non-Kotlin consumers (Swift, JS, TS) use the [block] / [onSelectorError]
+ * pair above directly.
+ */
+public inline fun <State> Store<State>.subscribeFields(
+    crossinline block: FieldSubscriptionScope<State>.() -> Unit,
+): StoreSubscription = subscribeFields(onSelectorError = null) { scope -> scope.block() }
+
+internal class FieldSubscriptionRegistry<State>(
+    private val store: Store<State>,
+    private val onSelectorError: ((Throwable) -> Unit)?,
+) : FieldSubscriptionScope<State> {
+
+    internal class Entry<State, F>(
+        val selector: (State) -> F,
+        @Volatile var last: F,
+        val triggerOnSubscribe: Boolean,
+        val listener: (F, F) -> Unit,
+    )
+
+    private val entries = ArrayList<Entry<State, *>>(INITIAL_CAPACITY)
+
+    @Volatile
+    private var sealed: Boolean = false
+
+    override fun <F> on(
+        selector: (State) -> F,
+        triggerOnSubscribe: Boolean,
+        listener: (F, F) -> Unit,
+    ) {
+        check(!sealed) {
+            "FieldSubscriptionScope.on() called after subscribeFields block completed. " +
+                "Register all subscriptions inside the block."
+        }
+        // If the selector throws during initial evaluation (before activate),
+        // forward the error and skip this entry rather than aborting the
+        // whole block — same defence-in-depth promise as the dispatch loop.
+        val initial: F = try {
+            selector(store.state)
+        } catch (@Suppress("TooGenericExceptionCaught") cause: Throwable) {
+            onSelectorError?.invoke(cause)
+            return
+        }
+        entries += Entry(selector, initial, triggerOnSubscribe, listener)
+    }
+
+    override fun <F> on(
+        property: kotlin.reflect.KProperty1<State, F>,
+        triggerOnSubscribe: Boolean,
+        listener: (F, F) -> Unit,
+    ) {
+        on(selector = property::get, triggerOnSubscribe = triggerOnSubscribe, listener = listener)
+    }
+
+    fun activate(): StoreSubscription {
+        sealed = true
+
+        val storeSub = store.subscribe {
+            val state = store.state
+            // `entries` is sealed (no further mutation). The only mutable
+            // field per entry is `entry.last`, which is @Volatile and
+            // written serially because the store contract guarantees
+            // subscribers are invoked serially within a dispatch.
+            for (i in entries.indices) {
+                @Suppress("UNCHECKED_CAST")
+                val entry = entries[i] as Entry<State, Any?>
+                val next: Any?
+                try {
+                    next = entry.selector(state)
+                } catch (@Suppress("TooGenericExceptionCaught") cause: Throwable) {
+                    onSelectorError?.invoke(cause)
+                    continue
+                }
+                val prev = entry.last
+                if (next !== prev && next != prev) {
+                    entry.last = next
+                    try {
+                        entry.listener(prev, next)
+                    } catch (@Suppress("TooGenericExceptionCaught") cause: Throwable) {
+                        onSelectorError?.invoke(cause)
+                    }
+                }
+            }
+        }
+
+        // Fire triggerOnSubscribe=true entries AFTER the underlying
+        // subscriber is installed, so a racing dispatch can't be silently
+        // dropped (the worst case is the listener fires twice — once from
+        // the dispatch with a real diff, once from the trigger with
+        // (current, current) — which is harmless).
+        for (i in entries.indices) {
+            @Suppress("UNCHECKED_CAST")
+            val entry = entries[i] as Entry<State, Any?>
+            if (entry.triggerOnSubscribe) {
+                val current = entry.last
+                try {
+                    entry.listener(current, current)
+                } catch (@Suppress("TooGenericExceptionCaught") cause: Throwable) {
+                    onSelectorError?.invoke(cause)
+                }
+            }
+        }
+
+        return { storeSub() }
+    }
+
+    private companion object {
+        private const val INITIAL_CAPACITY = 4
+    }
+}

--- a/redux-kotlin-granular/src/commonMain/kotlin/org/reduxkotlin/granular/SubscribeFieldsKProperty.kt
+++ b/redux-kotlin-granular/src/commonMain/kotlin/org/reduxkotlin/granular/SubscribeFieldsKProperty.kt
@@ -1,0 +1,28 @@
+package org.reduxkotlin.granular
+
+import org.reduxkotlin.Store
+import org.reduxkotlin.StoreSubscription
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
+import kotlin.reflect.KProperty1
+
+/**
+ * Property-reference convenience: subscribe to a single field, identified
+ * by a Kotlin property reference like `AppState::user`.
+ *
+ * Kotlin call sites benefit from `::field` syntax sugar. From Swift this
+ * overload is hidden via [@HiddenFromObjC] (KProperty1 is not constructible
+ * from Swift); from JavaScript / TypeScript it lives in a file without
+ * `@JsExport`, so it's only callable from Kotlin/JS code, not raw JS.
+ */
+@OptIn(ExperimentalObjCRefinement::class)
+@HiddenFromObjC
+public fun <State, F> Store<State>.subscribeTo(
+    property: KProperty1<State, F>,
+    triggerOnSubscribe: Boolean = true,
+    listener: (oldValue: F, newValue: F) -> Unit,
+): StoreSubscription = subscribeTo(
+    selector = property::get,
+    triggerOnSubscribe = triggerOnSubscribe,
+    listener = listener,
+)

--- a/redux-kotlin-granular/src/commonTest/kotlin/org/reduxkotlin/granular/FieldSubscriptionTest.kt
+++ b/redux-kotlin-granular/src/commonTest/kotlin/org/reduxkotlin/granular/FieldSubscriptionTest.kt
@@ -1,0 +1,201 @@
+package org.reduxkotlin.granular
+
+import org.reduxkotlin.Reducer
+import org.reduxkotlin.createStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+private data class TestState(
+    val counter: Int = 0,
+    val label: String = "",
+    val items: List<String> = emptyList(),
+)
+
+private sealed class TestAction {
+    object Increment : TestAction()
+
+    data class SetLabel(val label: String) : TestAction()
+
+    data class AppendItem(val item: String) : TestAction()
+
+    object Noop : TestAction()
+}
+
+private val reducer: Reducer<TestState> = { state, action ->
+    when (action) {
+        is TestAction.Increment -> state.copy(counter = state.counter + 1)
+        is TestAction.SetLabel -> state.copy(label = action.label)
+        is TestAction.AppendItem -> state.copy(items = state.items + action.item)
+        else -> state
+    }
+}
+
+class FieldSubscriptionTest {
+
+    @Test
+    fun subscribeTo_fires_when_field_changes() {
+        val store = createStore(reducer, TestState())
+        val seen = mutableListOf<Pair<Int, Int>>()
+        store.subscribeTo(TestState::counter, triggerOnSubscribe = false) { old, new ->
+            seen += old to new
+        }
+        store.dispatch(TestAction.Increment)
+        store.dispatch(TestAction.Increment)
+        assertEquals(listOf(0 to 1, 1 to 2), seen)
+    }
+
+    @Test
+    fun subscribeTo_does_not_fire_when_field_unchanged() {
+        val store = createStore(reducer, TestState(label = "hello"))
+        val seen = mutableListOf<Pair<String, String>>()
+        store.subscribeTo(TestState::label, triggerOnSubscribe = false) { old, new ->
+            seen += old to new
+        }
+        store.dispatch(TestAction.Increment) // counter changes, label doesn't
+        store.dispatch(TestAction.Increment)
+        assertTrue(seen.isEmpty(), "label listener fired despite no label change: $seen")
+    }
+
+    @Test
+    fun triggerOnSubscribe_true_fires_once_with_current_value() {
+        val store = createStore(reducer, TestState(counter = 7))
+        val seen = mutableListOf<Pair<Int, Int>>()
+        store.subscribeTo(TestState::counter, triggerOnSubscribe = true) { old, new ->
+            seen += old to new
+        }
+        assertEquals(listOf(7 to 7), seen)
+    }
+
+    @Test
+    fun triggerOnSubscribe_false_waits_for_first_change() {
+        val store = createStore(reducer, TestState(counter = 7))
+        val seen = mutableListOf<Pair<Int, Int>>()
+        store.subscribeTo(TestState::counter, triggerOnSubscribe = false) { old, new ->
+            seen += old to new
+        }
+        assertTrue(seen.isEmpty())
+        store.dispatch(TestAction.Increment)
+        assertEquals(listOf(7 to 8), seen)
+    }
+
+    @Test
+    fun referential_fast_path_skips_listener_when_state_reference_unchanged() {
+        // Reducer returns the same instance for unknown action → reference
+        // equality kicks in and no listener should fire.
+        val store = createStore(reducer, TestState(counter = 5))
+        var fired = false
+        store.subscribeTo(TestState::counter, triggerOnSubscribe = false) { _, _ -> fired = true }
+        store.dispatch(TestAction.Noop)
+        assertFalse(fired, "listener fired despite identical state reference")
+    }
+
+    @Test
+    fun subscribeFields_batches_multiple_entries_under_one_underlying_subscriber() {
+        val store = createStore(reducer, TestState())
+        val counterEvents = mutableListOf<Pair<Int, Int>>()
+        val labelEvents = mutableListOf<Pair<String, String>>()
+        store.subscribeFields {
+            on(TestState::counter, triggerOnSubscribe = false) { o, n -> counterEvents += o to n }
+            on(TestState::label, triggerOnSubscribe = false) { o, n -> labelEvents += o to n }
+        }
+        store.dispatch(TestAction.Increment)
+        store.dispatch(TestAction.SetLabel("hi"))
+        store.dispatch(TestAction.Increment)
+        assertEquals(listOf(0 to 1, 1 to 2), counterEvents)
+        assertEquals(listOf("" to "hi"), labelEvents)
+    }
+
+    @Test
+    fun subscribeFields_returns_combined_unsubscribe() {
+        val store = createStore(reducer, TestState())
+        val counterEvents = mutableListOf<Int>()
+        val labelEvents = mutableListOf<String>()
+        val unsubscribe = store.subscribeFields {
+            on(TestState::counter, triggerOnSubscribe = false) { _, n -> counterEvents += n }
+            on(TestState::label, triggerOnSubscribe = false) { _, n -> labelEvents += n }
+        }
+        store.dispatch(TestAction.Increment)
+        unsubscribe()
+        store.dispatch(TestAction.Increment)
+        store.dispatch(TestAction.SetLabel("after"))
+        assertEquals(listOf(1), counterEvents)
+        assertTrue(labelEvents.isEmpty(), "label listener fired after unsubscribe")
+    }
+
+    @Test
+    fun selector_exception_does_not_break_other_subscribers() {
+        val store = createStore(reducer, TestState())
+        var goodCount = 0
+        var capturedError: Throwable? = null
+        store.subscribeFields(onSelectorError = { capturedError = it }) { scope ->
+            scope.on<String>(
+                selector = { error("boom") },
+                triggerOnSubscribe = false,
+            ) { _, _ -> fail("listener should never fire because selector threw") }
+            scope.on(TestState::counter, triggerOnSubscribe = false) { _, _ -> goodCount += 1 }
+        }
+        store.dispatch(TestAction.Increment)
+        store.dispatch(TestAction.Increment)
+        assertEquals(2, goodCount, "the well-behaved listener must still see both ticks")
+        assertEquals("boom", capturedError?.message)
+    }
+
+    @Test
+    fun on_after_block_completes_throws() {
+        val store = createStore(reducer, TestState())
+        val capturedScope = arrayOfNulls<FieldSubscriptionScope<TestState>>(1)
+        store.subscribeFields { scope -> capturedScope[0] = scope }
+        val outOfBandError = runCatching {
+            capturedScope[0]!!.on(TestState::counter, triggerOnSubscribe = false) { _, _ -> }
+        }.exceptionOrNull()
+        assertNull(
+            outOfBandError?.let { it as? AssertionError },
+            "registering after activate() must throw, not silently no-op (was: $outOfBandError)",
+        )
+        assertTrue(outOfBandError is IllegalStateException)
+    }
+
+    @Test
+    fun lambda_selector_overload_matches_property_ref_overload() {
+        val store = createStore(reducer, TestState(counter = 3))
+        val a = mutableListOf<Int>()
+        val b = mutableListOf<Int>()
+        store.subscribeTo(TestState::counter, triggerOnSubscribe = false) { _, n -> a += n }
+        store.subscribeTo({ it.counter }, triggerOnSubscribe = false) { _, n -> b += n }
+        store.dispatch(TestAction.Increment)
+        store.dispatch(TestAction.Increment)
+        assertEquals(a, b)
+        assertEquals(listOf(4, 5), a)
+    }
+
+    @Test
+    fun derived_selector_with_computed_value() {
+        val store = createStore(reducer, TestState())
+        val sizes = mutableListOf<Int>()
+        store.subscribeTo({ it.items.size }, triggerOnSubscribe = true) { _, n -> sizes += n }
+        store.dispatch(TestAction.AppendItem("a"))
+        store.dispatch(TestAction.AppendItem("b"))
+        store.dispatch(TestAction.Increment) // size unchanged
+        assertEquals(listOf(0, 1, 2), sizes)
+    }
+
+    @Test
+    fun granular_enhancer_is_a_noop() {
+        // Verifies the marker enhancer doesn't break the store's identity.
+        val baseStore = createStore(reducer, TestState())
+        val sub = baseStore.subscribeTo(TestState::counter, triggerOnSubscribe = false) { _, _ -> }
+        baseStore.dispatch(TestAction.Increment)
+        sub()
+        // marker exists; just smoke-call to confirm it compiles + returns a creator
+        val enhancer = granularSubscriptionsEnhancer<TestState>()
+
+        @Suppress("UNCHECKED_CAST")
+        val wrapped = enhancer({ r, init, _ -> baseStore as org.reduxkotlin.Store<TestState> })
+        assertSame(baseStore, wrapped(reducer, TestState(), null))
+    }
+}

--- a/redux-kotlin-multimodel-granular/build.gradle.kts
+++ b/redux-kotlin-multimodel-granular/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    id("convention.library-mpp-loved")
+    id("convention.publishing-mpp")
+}
+
+val hasAndroidSdk: Boolean = run {
+    val localProps = rootProject.file("local.properties")
+    val hasSdkInLocalProperties = localProps.exists() && localProps.readText().lineSequence().any {
+        it.trim().startsWith("sdk.dir=") && it.substringAfter("sdk.dir=").isNotBlank()
+    }
+    val hasSdkInEnv =
+        !System.getenv("ANDROID_HOME").isNullOrBlank() ||
+            !System.getenv("ANDROID_SDK_ROOT").isNullOrBlank()
+    hasSdkInLocalProperties || hasSdkInEnv
+}
+
+kotlin {
+    if (hasAndroidSdk) {
+        android {
+            namespace = "org.reduxkotlin.multimodel.granular"
+        }
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":redux-kotlin-granular"))
+                api(project(":redux-kotlin-multimodel"))
+            }
+        }
+    }
+}

--- a/redux-kotlin-multimodel-granular/src/commonMain/kotlin/org/reduxkotlin/multimodel/granular/SubscribeToModel.kt
+++ b/redux-kotlin-multimodel-granular/src/commonMain/kotlin/org/reduxkotlin/multimodel/granular/SubscribeToModel.kt
@@ -1,0 +1,59 @@
+package org.reduxkotlin.multimodel.granular
+
+import org.reduxkotlin.Store
+import org.reduxkotlin.StoreSubscription
+import org.reduxkotlin.granular.FieldSubscriptionScope
+import org.reduxkotlin.granular.subscribeTo
+import org.reduxkotlin.multimodel.ModelState
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
+import kotlin.reflect.KProperty1
+
+/**
+ * Property-reference convenience for [ModelState]-shaped stores:
+ * subscribe to a single field of model type [M], identified by a Kotlin
+ * property reference like `LoggedInUserModel::displayName`.
+ *
+ * The model type [M] is inferred from the property reference's receiver
+ * — the call site does not need to name [ModelState] at all. Internally
+ * the selector is `state.get<M>().property`: two field reads instead of
+ * one.
+ *
+ * Hidden from Swift via [HiddenFromObjC] (KProperty1 is not
+ * constructible from Swift) and not `@JsExport`ed (inline + reified
+ * cannot be exported). Raw JS/TS / Swift consumers should use
+ * [subscribeToModel].
+ */
+@OptIn(ExperimentalObjCRefinement::class)
+@HiddenFromObjC
+public inline fun <reified M : Any, F> Store<ModelState>.subscribeTo(
+    property: KProperty1<M, F>,
+    triggerOnSubscribe: Boolean = true,
+    noinline listener: (oldValue: F, newValue: F) -> Unit,
+): StoreSubscription = subscribeTo(
+    selector = { state -> property.get(state.get<M>()) },
+    triggerOnSubscribe = triggerOnSubscribe,
+    listener = listener,
+)
+
+/**
+ * DSL counterpart of [subscribeTo] above, for use inside a
+ * `subscribeFields { … }` block on a `Store<ModelState>`. Lets a single
+ * batch of subscriptions mix fields from multiple feature models while
+ * still backed by one underlying `store.subscribe`.
+ *
+ * Same Swift / JS visibility rules as the standalone overload.
+ */
+@OptIn(ExperimentalObjCRefinement::class)
+@HiddenFromObjC
+public inline fun <reified M : Any, F> FieldSubscriptionScope<ModelState>.on(
+    property: KProperty1<M, F>,
+    triggerOnSubscribe: Boolean = true,
+    noinline listener: (oldValue: F, newValue: F) -> Unit,
+) {
+    on(
+        selector = { state -> property.get(state.get<M>()) },
+        triggerOnSubscribe = triggerOnSubscribe,
+        listener = listener,
+    )
+}

--- a/redux-kotlin-multimodel-granular/src/commonMain/kotlin/org/reduxkotlin/multimodel/granular/SubscribeToModelByClass.kt
+++ b/redux-kotlin-multimodel-granular/src/commonMain/kotlin/org/reduxkotlin/multimodel/granular/SubscribeToModelByClass.kt
@@ -1,0 +1,57 @@
+package org.reduxkotlin.multimodel.granular
+
+import org.reduxkotlin.Store
+import org.reduxkotlin.StoreSubscription
+import org.reduxkotlin.granular.FieldSubscriptionScope
+import org.reduxkotlin.granular.subscribeTo
+import org.reduxkotlin.multimodel.ModelState
+import kotlin.reflect.KClass
+
+/**
+ * Non-inline alternative to the reified [subscribeTo] overload, for
+ * callers that hold the model type as a [KClass] rather than as a
+ * compile-time generic — i.e. raw JS/TS consumers (`inline reified` is
+ * Kotlin-only and is erased from the generated `.d.ts`), Swift
+ * consumers, and generic helper code that re-dispatches across
+ * dynamically chosen models.
+ *
+ * Functionally equivalent to:
+ * ```
+ * store.subscribeTo<M>(M::someProperty) { old, new -> … }
+ * ```
+ * but with the model class threaded through as a runtime argument:
+ * ```
+ * store.subscribeToModel(M::class, { it.someProperty }) { old, new -> … }
+ * ```
+ *
+ * This is the resolution to adversarial-review item I11 — the inline
+ * reified overload doesn't survive to the JS boundary, so a non-inline
+ * pathway must exist for non-Kotlin consumers.
+ */
+public fun <M : Any, F> Store<ModelState>.subscribeToModel(
+    modelClass: KClass<M>,
+    selector: (M) -> F,
+    triggerOnSubscribe: Boolean = true,
+    listener: (oldValue: F, newValue: F) -> Unit,
+): StoreSubscription = subscribeTo(
+    selector = { state -> selector(state.get(modelClass)) },
+    triggerOnSubscribe = triggerOnSubscribe,
+    listener = listener,
+)
+
+/**
+ * DSL counterpart of [subscribeToModel] for use inside a
+ * `subscribeFields { … }` block on a `Store<ModelState>`.
+ */
+public fun <M : Any, F> FieldSubscriptionScope<ModelState>.onModel(
+    modelClass: KClass<M>,
+    selector: (M) -> F,
+    triggerOnSubscribe: Boolean = true,
+    listener: (oldValue: F, newValue: F) -> Unit,
+) {
+    on(
+        selector = { state -> selector(state.get(modelClass)) },
+        triggerOnSubscribe = triggerOnSubscribe,
+        listener = listener,
+    )
+}

--- a/redux-kotlin-multimodel-granular/src/commonTest/kotlin/org/reduxkotlin/multimodel/granular/SubscribeToModelTest.kt
+++ b/redux-kotlin-multimodel-granular/src/commonTest/kotlin/org/reduxkotlin/multimodel/granular/SubscribeToModelTest.kt
@@ -1,0 +1,151 @@
+package org.reduxkotlin.multimodel.granular
+
+import org.reduxkotlin.createStore
+import org.reduxkotlin.granular.subscribeFields
+import org.reduxkotlin.multimodel.ModelState
+import org.reduxkotlin.multimodel.combineModelReducers
+import org.reduxkotlin.multimodel.modelReducer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private data class UserModel(val displayName: String = "")
+private data class FeedModel(val items: List<String> = emptyList())
+private data class UnregisteredModel(val value: Int = 0)
+
+private data class SetDisplayName(val name: String)
+private data class AppendFeedItem(val item: String)
+private object UnrelatedAction
+
+class SubscribeToModelTest {
+
+    private fun newStore() = createStore(
+        reducer = combineModelReducers(
+            modelReducer<UserModel> { user, action ->
+                if (action is SetDisplayName) user.copy(displayName = action.name) else user
+            },
+            modelReducer<FeedModel> { feed, action ->
+                if (action is AppendFeedItem) feed.copy(items = feed.items + action.item) else feed
+            },
+        ),
+        preloadedState = ModelState.of(UserModel("Ada"), FeedModel(listOf("a"))),
+    )
+
+    @Test
+    fun reified_subscribeTo_fires_only_for_matching_model_field() {
+        val store = newStore()
+        val updates = mutableListOf<String>()
+        // Drop the initial trigger fire so we're only measuring change-only events.
+        val unsubscribe = store.subscribeTo(UserModel::displayName, triggerOnSubscribe = false) { _, new ->
+            updates += new
+        }
+
+        store.dispatch(AppendFeedItem("b")) // unrelated model — must not fire
+        store.dispatch(SetDisplayName("Babbage"))
+        store.dispatch(SetDisplayName("Babbage")) // same value — must not fire (=== short-circuit)
+        store.dispatch(SetDisplayName("Lovelace"))
+
+        unsubscribe()
+        assertEquals(listOf("Babbage", "Lovelace"), updates)
+    }
+
+    @Test
+    fun reified_subscribeTo_fires_initial_value_when_trigger_default() {
+        val store = newStore()
+        val updates = mutableListOf<String>()
+        store.subscribeTo(UserModel::displayName) { _, new -> updates += new }
+        // First entry is the trigger-on-subscribe fire with the current value.
+        assertEquals(listOf("Ada"), updates)
+    }
+
+    @Test
+    fun dsl_on_mixes_fields_from_multiple_models() {
+        val store = newStore()
+        val nameUpdates = mutableListOf<String>()
+        val feedUpdates = mutableListOf<List<String>>()
+
+        store.subscribeFields {
+            on(UserModel::displayName, triggerOnSubscribe = false) { _, new -> nameUpdates += new }
+            on(FeedModel::items, triggerOnSubscribe = false) { _, new -> feedUpdates += new }
+        }
+
+        store.dispatch(SetDisplayName("Babbage"))
+        store.dispatch(AppendFeedItem("b"))
+        store.dispatch(UnrelatedAction) // === fast-path: no model changes, no listener fires
+
+        assertEquals(listOf("Babbage"), nameUpdates)
+        assertEquals(listOf(listOf("a", "b")), feedUpdates)
+    }
+
+    @Test
+    fun unrelated_action_does_not_fire_any_listener() {
+        val store = newStore()
+        var fired = 0
+        store.subscribeTo(UserModel::displayName, triggerOnSubscribe = false) { _, _ -> fired++ }
+        store.subscribeTo(FeedModel::items, triggerOnSubscribe = false) { _, _ -> fired++ }
+
+        store.dispatch(UnrelatedAction)
+        assertEquals(0, fired)
+    }
+
+    @Test
+    fun subscribeToModel_kclass_shim_routes_to_correct_model() {
+        val store = newStore()
+        val updates = mutableListOf<String>()
+        val unsubscribe = store.subscribeToModel(
+            modelClass = UserModel::class,
+            selector = { it.displayName },
+            triggerOnSubscribe = false,
+            listener = { _, new -> updates += new },
+        )
+
+        store.dispatch(AppendFeedItem("b"))
+        store.dispatch(SetDisplayName("Babbage"))
+        unsubscribe()
+
+        assertEquals(listOf("Babbage"), updates)
+    }
+
+    @Test
+    fun onModel_kclass_dsl_shim_works_inside_subscribeFields() {
+        val store = newStore()
+        val updates = mutableListOf<String>()
+        store.subscribeFields {
+            onModel(UserModel::class, { it.displayName }, triggerOnSubscribe = false) { _, new ->
+                updates += new
+            }
+        }
+        store.dispatch(SetDisplayName("Babbage"))
+        assertEquals(listOf("Babbage"), updates)
+    }
+
+    @Test
+    fun unsubscribe_stops_further_notifications() {
+        val store = newStore()
+        val updates = mutableListOf<String>()
+        val unsubscribe = store.subscribeTo(
+            UserModel::displayName,
+            triggerOnSubscribe = false,
+        ) { _, new -> updates += new }
+
+        store.dispatch(SetDisplayName("Babbage"))
+        unsubscribe()
+        store.dispatch(SetDisplayName("Lovelace"))
+
+        assertEquals(listOf("Babbage"), updates)
+    }
+
+    @Test
+    fun selector_throws_when_model_class_not_registered() {
+        // Build a ModelState that DOES NOT have UnregisteredModel registered.
+        val store = newStore()
+        var captured: Throwable? = null
+
+        store.subscribeFields(onSelectorError = { captured = it }) { scope ->
+            scope.on(UnregisteredModel::value, triggerOnSubscribe = false) { _, _ -> }
+        }
+
+        assertTrue(captured is IllegalStateException, "expected IllegalStateException for unregistered model")
+        assertEquals(true, captured!!.message!!.contains("UnregisteredModel"))
+    }
+}

--- a/redux-kotlin-multimodel/build.gradle.kts
+++ b/redux-kotlin-multimodel/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    id("convention.library-mpp-loved")
+    id("convention.publishing-mpp")
+}
+
+val hasAndroidSdk: Boolean = run {
+    val localProps = rootProject.file("local.properties")
+    val hasSdkInLocalProperties = localProps.exists() && localProps.readText().lineSequence().any {
+        it.trim().startsWith("sdk.dir=") && it.substringAfter("sdk.dir=").isNotBlank()
+    }
+    val hasSdkInEnv =
+        !System.getenv("ANDROID_HOME").isNullOrBlank() ||
+            !System.getenv("ANDROID_SDK_ROOT").isNullOrBlank()
+    hasSdkInLocalProperties || hasSdkInEnv
+}
+
+kotlin {
+    if (hasAndroidSdk) {
+        android {
+            namespace = "org.reduxkotlin.multimodel"
+        }
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":redux-kotlin"))
+            }
+        }
+    }
+}

--- a/redux-kotlin-multimodel/src/commonMain/kotlin/org/reduxkotlin/multimodel/CombineModelReducers.kt
+++ b/redux-kotlin-multimodel/src/commonMain/kotlin/org/reduxkotlin/multimodel/CombineModelReducers.kt
@@ -1,0 +1,87 @@
+package org.reduxkotlin.multimodel
+
+import org.reduxkotlin.Reducer
+import kotlin.reflect.KClass
+
+/**
+ * A per-model reducer — same shape as a top-level [Reducer], but its
+ * `state` parameter is the model instance itself rather than the
+ * enclosing [ModelState].
+ */
+public typealias ModelReducer<M> = (model: M, action: Any) -> M
+
+/**
+ * The opaque pair produced by [modelReducer] and consumed by
+ * [combineModelReducers]. The underlying reducer takes `Any` arguments
+ * because [combineModelReducers] dispatches it heterogeneously across
+ * all registered model slots — the type token in [modelClass] is what
+ * makes the cast safe at registration time.
+ */
+public class ModelReducerEntry<M : Any> @PublishedApi internal constructor(
+    public val modelClass: KClass<M>,
+    @PublishedApi internal val reducer: ModelReducer<M>,
+)
+
+/**
+ * Builds a [ModelReducerEntry] for model type [M]. The Kotlin-callable
+ * sugar form; use [modelReducerOf] if you only have a [KClass] at the
+ * call site (raw JS/TS, generic helpers).
+ */
+public inline fun <reified M : Any> modelReducer(
+    noinline reducer: ModelReducer<M>,
+): ModelReducerEntry<M> = ModelReducerEntry(M::class, reducer)
+
+/**
+ * Non-inline variant of [modelReducer] for callers that only hold a
+ * [KClass] reference. Functionally equivalent.
+ */
+public fun <M : Any> modelReducerOf(
+    modelClass: KClass<M>,
+    reducer: ModelReducer<M>,
+): ModelReducerEntry<M> = ModelReducerEntry(modelClass, reducer)
+
+/**
+ * Composes per-model reducers into a single [Reducer] over
+ * [ModelState]. For each dispatch, every registered model reducer
+ * receives the current instance of its model plus the action; if a
+ * reducer returns the same instance (referential `===`), that slot is
+ * left untouched and the resulting [ModelState] also retains its
+ * existing instance — so the granular subscription layer's `===`
+ * fast-path short-circuits without firing any listener for fields on
+ * unchanged models.
+ *
+ * @throws IllegalArgumentException if two entries register reducers
+ *   for the same model class (review I3 — silent last-wins chaining
+ *   is a footgun, prefer to fail loudly).
+ */
+public fun combineModelReducers(
+    vararg entries: ModelReducerEntry<*>,
+): Reducer<ModelState> {
+    val byClass = LinkedHashMap<KClass<*>, ModelReducer<Any>>(entries.size)
+    for (entry in entries) {
+        @Suppress("UNCHECKED_CAST")
+        val erased = entry.reducer as ModelReducer<Any>
+        require(byClass.put(entry.modelClass, erased) == null) {
+            "Duplicate model reducer for ${entry.modelClass.simpleName ?: entry.modelClass}. " +
+                "combineModelReducers requires at most one reducer per model class."
+        }
+    }
+    return reducer@{ state, action ->
+        var changedModels: MutableMap<KClass<*>, Any>? = null
+        for ((klass, reducer) in byClass) {
+            val oldModel = state.models[klass]
+                ?: error(
+                    "Reducer registered for ${klass.simpleName ?: klass} but no model of that type in ModelState. " +
+                        "Every registered reducer must have a corresponding model in ModelState.of(...).",
+                )
+            val newModel = reducer(oldModel, action)
+            if (newModel !== oldModel) {
+                if (changedModels == null) {
+                    changedModels = LinkedHashMap(state.models)
+                }
+                changedModels[klass] = newModel
+            }
+        }
+        if (changedModels == null) state else ModelState(changedModels)
+    }
+}

--- a/redux-kotlin-multimodel/src/commonMain/kotlin/org/reduxkotlin/multimodel/ModelState.kt
+++ b/redux-kotlin-multimodel/src/commonMain/kotlin/org/reduxkotlin/multimodel/ModelState.kt
@@ -1,0 +1,119 @@
+package org.reduxkotlin.multimodel
+
+import kotlin.reflect.KClass
+
+/**
+ * An immutable container that holds a fixed set of typed feature models.
+ *
+ * Each model is keyed by its concrete [KClass]; the *set* of model
+ * classes is locked at construction time via [Companion.of] and cannot
+ * be expanded or contracted. The *instances* can be swapped through
+ * [with], which produces a new [ModelState] sharing the same key set.
+ *
+ * This shape exists to support feature-modular state: every screen or
+ * subsystem owns its own model type, and the root reducer composes
+ * per-model reducers via [combineModelReducers]. Granular subscribers
+ * (see `redux-kotlin-multimodel-granular`) can subscribe to a single
+ * field on a single model without the rest of the app's state passing
+ * through their selector.
+ *
+ * **Why a sealed key set.** The library guarantees that [get] always
+ * returns a non-null model: every model class declared at construction
+ * is present at all times. Reducers can replace an instance but never
+ * remove the slot. Asking for a model class that was never registered
+ * is a programming error and throws [IllegalStateException], not a
+ * runtime branch the caller must handle. This is the resolution to
+ * adversarial-review blocker B1 — the common selector path never
+ * confronts a missing model.
+ *
+ * Each model is responsible for its own "not yet loaded" semantics —
+ * supply a default constructor or a public `NOT_SET` sentinel
+ * instance, so dependent code reads `String` rather than `String?`.
+ */
+public class ModelState @PublishedApi internal constructor(
+    @PublishedApi internal val models: Map<KClass<*>, Any>,
+) {
+
+    /**
+     * Returns the registered model of type [M].
+     *
+     * @throws IllegalStateException if [M] was not declared in the
+     *   [Companion.of] call that produced this [ModelState]. This is a
+     *   programming error; the set of model classes is fixed at
+     *   construction.
+     */
+    public inline fun <reified M : Any> get(): M = get(M::class)
+
+    /**
+     * Non-reified overload of [get] for callers that hold the model's
+     * [KClass] in a variable — e.g. raw JS/TS consumers that cannot use
+     * reified type parameters, or generic helper code.
+     *
+     * @throws IllegalStateException if [modelClass] was not declared at
+     *   construction.
+     */
+    public fun <M : Any> get(modelClass: KClass<M>): M {
+        val model = models[modelClass]
+            ?: error(
+                "Model ${modelClass.simpleName ?: modelClass} not registered in ModelState. " +
+                    "Every model must be declared in ModelState.of(...).",
+            )
+        @Suppress("UNCHECKED_CAST")
+        return model as M
+    }
+
+    /**
+     * Returns a new [ModelState] with the existing slot for [M]
+     * replaced by [model]. Other models are shared with the receiver.
+     *
+     * @throws IllegalStateException if [M] was not declared at
+     *   construction; new model classes cannot be introduced after the
+     *   initial [Companion.of] call.
+     */
+    public inline fun <reified M : Any> with(model: M): ModelState = with(M::class, model)
+
+    /**
+     * Non-reified overload of [with] for callers that hold the model's
+     * [KClass] in a variable. The runtime type of [model] must be
+     * assignable to [modelClass]; otherwise downstream `get<M>()` calls
+     * will throw `ClassCastException`.
+     */
+    public fun <M : Any> with(modelClass: KClass<M>, model: M): ModelState {
+        check(modelClass in models) {
+            "Cannot replace model ${modelClass.simpleName ?: modelClass} that wasn't declared at construction. " +
+                "ModelState's key set is fixed by ModelState.of(...)."
+        }
+        return ModelState(models + (modelClass to model))
+    }
+
+    override fun equals(other: Any?): Boolean = other is ModelState && other.models == models
+
+    override fun hashCode(): Int = models.hashCode()
+
+    override fun toString(): String = "ModelState(${models.entries.joinToString { (k, v) -> "${k.simpleName}=$v" }})"
+
+    /** Factory methods for [ModelState]; the only public entry point. */
+    public companion object {
+        /**
+         * Builds a [ModelState] containing exactly the supplied models.
+         * The set of model *classes* — one entry per distinct
+         * `model::class` — is locked for the lifetime of every
+         * [ModelState] derived from this one.
+         *
+         * @throws IllegalArgumentException if any two models share the
+         *   same concrete class; each model class may appear at most
+         *   once in a [ModelState].
+         */
+        public fun of(vararg models: Any): ModelState {
+            val map = LinkedHashMap<KClass<*>, Any>(models.size)
+            for (model in models) {
+                val klass = model::class
+                require(map.put(klass, model) == null) {
+                    "Duplicate model class ${klass.simpleName ?: klass} passed to ModelState.of(...). " +
+                        "Each model class may appear at most once."
+                }
+            }
+            return ModelState(map)
+        }
+    }
+}

--- a/redux-kotlin-multimodel/src/commonTest/kotlin/org/reduxkotlin/multimodel/CombineModelReducersTest.kt
+++ b/redux-kotlin-multimodel/src/commonTest/kotlin/org/reduxkotlin/multimodel/CombineModelReducersTest.kt
@@ -1,0 +1,91 @@
+package org.reduxkotlin.multimodel
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+
+private data class CmrUser(val displayName: String = "")
+private data class CmrFeed(val items: List<String> = emptyList())
+
+private data class SetDisplayName(val name: String)
+private data class AppendFeedItem(val item: String)
+private object UnrelatedAction
+
+class CombineModelReducersTest {
+
+    private val userReducer = modelReducer<CmrUser> { user, action ->
+        when (action) {
+            is SetDisplayName -> user.copy(displayName = action.name)
+            else -> user
+        }
+    }
+
+    private val feedReducer = modelReducer<CmrFeed> { feed, action ->
+        when (action) {
+            is AppendFeedItem -> feed.copy(items = feed.items + action.item)
+            else -> feed
+        }
+    }
+
+    private val root = combineModelReducers(userReducer, feedReducer)
+
+    @Test
+    fun action_updates_only_matching_model() {
+        val initial = ModelState.of(CmrUser("Ada"), CmrFeed(listOf("a")))
+        val next = root(initial, SetDisplayName("Babbage"))
+
+        assertEquals(CmrUser("Babbage"), next.get<CmrUser>())
+        assertSame(initial.get<CmrFeed>(), next.get<CmrFeed>())
+    }
+
+    @Test
+    fun unrelated_action_returns_same_modelstate_reference() {
+        val initial = ModelState.of(CmrUser("Ada"), CmrFeed(listOf("a")))
+        val next = root(initial, UnrelatedAction)
+        // === fast-path: no model changed, ModelState identity preserved
+        // so the granular subscription layer can short-circuit completely.
+        assertSame(initial, next)
+    }
+
+    @Test
+    fun changed_model_yields_new_modelstate_with_unchanged_siblings_shared() {
+        val initial = ModelState.of(CmrUser("Ada"), CmrFeed(listOf("a")))
+        val next = root(initial, AppendFeedItem("b"))
+
+        // ModelState itself is a new instance (some model changed)…
+        assertEquals(false, initial === next)
+        // …but the sibling CmrUser slot is the same reference.
+        assertSame(initial.get<CmrUser>(), next.get<CmrUser>())
+        assertEquals(CmrFeed(listOf("a", "b")), next.get<CmrFeed>())
+    }
+
+    @Test
+    fun duplicate_keys_throw() {
+        val duplicateUser = modelReducer<CmrUser> { u, _ -> u }
+        assertFailsWith<IllegalArgumentException> {
+            combineModelReducers(userReducer, duplicateUser)
+        }
+    }
+
+    @Test
+    fun reducer_registered_for_unregistered_model_throws_at_dispatch() {
+        // Only CmrUser is in the state — but combined reducer also covers CmrFeed.
+        val initial = ModelState.of(CmrUser("Ada"))
+        val error = assertFailsWith<IllegalStateException> {
+            root(initial, UnrelatedAction)
+        }
+        assertEquals(true, error.message!!.contains("CmrFeed"))
+    }
+
+    @Test
+    fun modelReducerOf_works_with_kclass_at_call_site() {
+        val r = modelReducerOf(CmrUser::class) { user, action ->
+            if (action is SetDisplayName) user.copy(displayName = action.name) else user
+        }
+        val combined = combineModelReducers(r)
+        val initial = ModelState.of(CmrUser("Ada"))
+        val next = combined(initial, SetDisplayName("Babbage"))
+        assertEquals(CmrUser("Babbage"), next.get<CmrUser>())
+    }
+}

--- a/redux-kotlin-multimodel/src/commonTest/kotlin/org/reduxkotlin/multimodel/ModelStateTest.kt
+++ b/redux-kotlin-multimodel/src/commonTest/kotlin/org/reduxkotlin/multimodel/ModelStateTest.kt
@@ -1,0 +1,75 @@
+package org.reduxkotlin.multimodel
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+private data class MsUser(val displayName: String = "", val isLoggedIn: Boolean = false)
+private data class MsFeed(val items: List<String> = emptyList(), val isRefreshing: Boolean = false)
+private data class MsUnregistered(val value: Int = 0)
+
+class ModelStateTest {
+
+    @Test
+    fun get_returns_registered_model() {
+        val state = ModelState.of(
+            MsUser(displayName = "Ada"),
+            MsFeed(items = listOf("a", "b")),
+        )
+        assertEquals(MsUser("Ada"), state.get<MsUser>())
+        assertEquals(MsFeed(listOf("a", "b")), state.get<MsFeed>())
+    }
+
+    @Test
+    fun get_throws_for_unregistered_class() {
+        val state = ModelState.of(MsUser())
+        val error = assertFailsWith<IllegalStateException> { state.get<MsUnregistered>() }
+        // Message names the missing model so the call-site mistake is obvious.
+        assertEquals(true, error.message!!.contains("MsUnregistered"))
+    }
+
+    @Test
+    fun with_replaces_only_target_slot() {
+        val initial = ModelState.of(MsUser("Ada"), MsFeed(listOf("a")))
+        val next = initial.with(MsUser("Babbage"))
+
+        assertEquals(MsUser("Babbage"), next.get<MsUser>())
+        // Other slots share the same instance — verifies copy-on-write semantics.
+        assertSame(initial.get<MsFeed>(), next.get<MsFeed>())
+        assertNotSame(initial, next)
+    }
+
+    @Test
+    fun with_throws_for_unregistered_class() {
+        val state = ModelState.of(MsUser())
+        assertFailsWith<IllegalStateException> { state.with(MsUnregistered(7)) }
+    }
+
+    @Test
+    fun of_throws_on_duplicate_classes() {
+        assertFailsWith<IllegalArgumentException> {
+            ModelState.of(MsUser("a"), MsUser("b"))
+        }
+    }
+
+    @Test
+    fun non_reified_get_with_works_for_kclass_holders() {
+        val state = ModelState.of(MsUser("Ada"))
+        val klass = MsUser::class
+        val fetched = state.get(klass)
+        assertEquals(MsUser("Ada"), fetched)
+
+        val next = state.with(klass, MsUser("Babbage"))
+        assertEquals(MsUser("Babbage"), next.get<MsUser>())
+    }
+
+    @Test
+    fun equality_is_value_based() {
+        val a = ModelState.of(MsUser("Ada"), MsFeed(listOf("x")))
+        val b = ModelState.of(MsUser("Ada"), MsFeed(listOf("x")))
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ includeBuild("build-conventions/")
 include(
     ":redux-kotlin",
     ":redux-kotlin-threadsafe",
+    ":redux-kotlin-granular",
     ":examples:counter:common",
     ":examples:counter:android",
     ":examples:todos:common",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ include(
     ":redux-kotlin-threadsafe",
     ":redux-kotlin-granular",
     ":redux-kotlin-multimodel",
+    ":redux-kotlin-multimodel-granular",
     ":examples:counter:common",
     ":examples:counter:android",
     ":examples:todos:common",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ include(
     ":redux-kotlin",
     ":redux-kotlin-threadsafe",
     ":redux-kotlin-granular",
+    ":redux-kotlin-multimodel",
     ":examples:counter:common",
     ":examples:counter:android",
     ":examples:todos:common",


### PR DESCRIPTION
## Summary

Tiny integration module — `redux-kotlin-multimodel-granular` — that bridges the just-merged granular subscriptions module (PR β / #277) and the multimodel state container (PR ζ / #280). The call site doesn't need to name `ModelState` at all:

```kotlin
store.subscribeFields {
    on(LoggedInUserModel::displayName) { _, name -> nameLabel.text = name }
    on(LoggedInUserModel::avatar)      { _, url -> avatar.load(url) }
    on(RssFeedModel::items)            { _, items -> feedAdapter.submit(items) }
    on(RssFeedModel::isRefreshing)     { _, busy -> spinner.isVisible = busy }
}
```

The model type `M` is inferred from each property reference's receiver; internally the selector walks `state.get<M>().property`. One underlying `store.subscribe` listener fans out per-model-per-field updates only when the value differs (`===` then `==`), and `combineModelReducers`' identity preservation guarantees `===` short-circuits all the way through for unrelated actions.

## Public surface

| Function | Use case |
|---|---|
| `Store<ModelState>.subscribeTo(KProperty1<M, F>, …)` | Reified inline Kotlin sugar. `@HiddenFromObjC` (KProperty1 not constructible from Swift). |
| `FieldSubscriptionScope<ModelState>.on(KProperty1<M, F>, …)` | DSL counterpart for batching across multiple models. |
| `Store<ModelState>.subscribeToModel(KClass<M>, selector, …)` | Non-inline `KClass`-keyed shim for raw JS/TS and generic helper code. Resolution to adversarial-review item **I11** — inline reified is erased from the generated `.d.ts`. |
| `FieldSubscriptionScope<ModelState>.onModel(KClass<M>, selector, …)` | DSL counterpart of `subscribeToModel`. |

## Stacking

Stacked on **PR ζ / #280** (`add-redux-kotlin-multimodel-module`) — that's the `base` branch. PR β / #277 (granular module) already merged to master, so the only outstanding dep is #280. After #280 merges to master, retargeting this PR's base to master shrinks the diff to just this module's 5 files.

## Test plan

- [x] `:redux-kotlin-multimodel-granular:build` passes locally (all KMP targets compile)
- [x] `:redux-kotlin-multimodel-granular:jvmTest`, `:jsNodeTest`, `:wasmJsNodeTest` green
- [x] Detekt clean, `explicitApi` mode passes
- [ ] CI matrix confirms iOS simulator + the rest of the KMP grid
- [ ] 8 commonTest cases cover:
  - Reified `subscribeTo` fires only when the targeted field changes
  - Reified `subscribeTo` fires the initial value when `triggerOnSubscribe` is default
  - DSL `on` batches subscriptions across multiple feature models
  - `===` fast-path: unrelated action fires zero listeners
  - `subscribeToModel` and `onModel` `KClass` shims route to the right model
  - Unsubscribe stops further notifications
  - Selector that touches an unregistered model is caught by `onSelectorError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)