### PR TITLE
feat(compose): add redux-kotlin-compose module (PR θ of v2)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ androidx-appcompat = "1.7.1"
 androidx-constraintlayout = "2.2.1"
 androidx-recyclerview = "1.4.0"
 atomicfu = "0.32.1"
+compose-multiplatform = "1.10.0"
 coroutines = "1.10.2"
 detekt = "1.23.8"
 dokka = "2.2.0"
@@ -25,3 +26,7 @@ kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", v
 kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
+
+[plugins]
+compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/redux-kotlin-compose/build.gradle.kts
+++ b/redux-kotlin-compose/build.gradle.kts
@@ -1,0 +1,42 @@
+plugins {
+    id("convention.library-mpp-loved")
+    alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.compose.multiplatform)
+    id("convention.publishing-mpp")
+}
+
+val hasAndroidSdk: Boolean = run {
+    val localProps = rootProject.file("local.properties")
+    val hasSdkInLocalProperties = localProps.exists() && localProps.readText().lineSequence().any {
+        it.trim().startsWith("sdk.dir=") && it.substringAfter("sdk.dir=").isNotBlank()
+    }
+    val hasSdkInEnv =
+        !System.getenv("ANDROID_HOME").isNullOrBlank() ||
+            !System.getenv("ANDROID_SDK_ROOT").isNullOrBlank()
+    hasSdkInLocalProperties || hasSdkInEnv
+}
+
+kotlin {
+    if (hasAndroidSdk) {
+        android {
+            namespace = "org.reduxkotlin.compose"
+        }
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":redux-kotlin-granular"))
+                implementation(compose.runtime)
+            }
+        }
+        named("jvmTest") {
+            dependencies {
+                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+                implementation(compose.uiTest)
+                implementation(compose.desktop.currentOs)
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
+    }
+}

--- a/redux-kotlin-compose/src/commonMain/kotlin/org/reduxkotlin/compose/FieldState.kt
+++ b/redux-kotlin-compose/src/commonMain/kotlin/org/reduxkotlin/compose/FieldState.kt
@@ -1,0 +1,97 @@
+package org.reduxkotlin.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import org.reduxkotlin.Store
+import org.reduxkotlin.granular.subscribeTo
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
+import kotlin.reflect.KProperty1
+
+/**
+ * Returns a Compose [State] that always reflects `selector(store.state)`.
+ *
+ * On the dispatch that follows a state change, the [State.value] is
+ * updated and any Composable that read it during composition is
+ * scheduled for recomposition. Updates fire only when the selected
+ * value actually changes (`===` then `==`), so a `Store<S>` with N
+ * `selectorState` calls only recomposes the subset of UI that reads
+ * fields that actually moved.
+ *
+ * The bridge uses [granular subscribeTo][subscribeTo] with
+ * `triggerOnSubscribe = false` and re-samples the current state
+ * **inside** [DisposableEffect]. The re-sample closes the
+ * init-to-subscribe race window: between `remember { mutableStateOf(...) }`
+ * (which runs during composition) and the effect block (which runs at
+ * commit), the store may have dispatched a state change. Without the
+ * re-sample, the first frame can render a stale value until the next
+ * dispatch arrives. Setting `triggerOnSubscribe = false` avoids a
+ * redundant `mutableState.value = mutableState.value` assignment after
+ * the explicit re-sample.
+ *
+ * The captured [selector] lambda is stable across recompositions: it
+ * is remembered against `this` (the store). If the selector closes
+ * over outer Composable state that should refresh the binding, the
+ * outer state is **frozen at first composition** — use
+ * [fieldState] with a property reference instead, or unsubscribe and
+ * resubscribe by hand inside a `LaunchedEffect` keyed on the variable.
+ */
+@Composable
+public fun <S, F> Store<S>.selectorState(
+    selector: (S) -> F,
+): State<F> {
+    val store = this
+    val rememberedSelector = remember(store) { selector }
+    val mutableState = remember(store, rememberedSelector) {
+        mutableStateOf(rememberedSelector(store.state))
+    }
+    DisposableEffect(store, rememberedSelector) {
+        // B3 race fix: dispatches that landed between composition and
+        // this effect's invocation are not observable through the cached
+        // initial value above. Re-sample under the effect so the first
+        // frame after the effect runs reflects current state.
+        mutableState.value = rememberedSelector(store.state)
+        val sub = store.subscribeTo(
+            selector = rememberedSelector,
+            triggerOnSubscribe = false,
+        ) { _, new ->
+            mutableState.value = new
+        }
+        onDispose { sub() }
+    }
+    return mutableState
+}
+
+/**
+ * Property-reference convenience overload of [selectorState] for the
+ * single-field case. Equivalent to `selectorState(property::get)` but
+ * lets the call site use `store.fieldState(MyState::myField)`.
+ *
+ * Hidden from Swift via [HiddenFromObjC] (KProperty1 is Kotlin-only).
+ */
+@OptIn(ExperimentalObjCRefinement::class)
+@HiddenFromObjC
+@Composable
+public fun <S, F> Store<S>.fieldState(
+    property: KProperty1<S, F>,
+): State<F> {
+    val store = this
+    val mutableState = remember(store, property) {
+        mutableStateOf(property.get(store.state))
+    }
+    DisposableEffect(store, property) {
+        // Same B3 re-sample as selectorState.
+        mutableState.value = property.get(store.state)
+        val sub = store.subscribeTo(
+            property = property,
+            triggerOnSubscribe = false,
+        ) { _, new ->
+            mutableState.value = new
+        }
+        onDispose { sub() }
+    }
+    return mutableState
+}

--- a/redux-kotlin-compose/src/commonMain/kotlin/org/reduxkotlin/compose/StableStore.kt
+++ b/redux-kotlin-compose/src/commonMain/kotlin/org/reduxkotlin/compose/StableStore.kt
@@ -1,0 +1,53 @@
+package org.reduxkotlin.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import org.reduxkotlin.Store
+import kotlin.jvm.JvmInline
+
+/**
+ * Compose-stable wrapper around a [Store].
+ *
+ * Compose's stability inferrer treats interfaces as `@Unstable`, which
+ * means any Composable that takes a `Store<S>` directly as a parameter
+ * becomes non-skippable — the runtime cannot prove the reference is
+ * unchanged between recompositions, so it recomposes unconditionally.
+ *
+ * Wrapping the store in this `@Stable` class restores skippability for
+ * downstream Composables that take a [StableStore] parameter, without
+ * requiring any change to the store implementation itself.
+ *
+ * Usage:
+ * ```
+ * @Composable
+ * fun App(store: Store<AppState>) {
+ *     val stable = rememberStableStore(store)
+ *     Content(stable)
+ * }
+ *
+ * @Composable
+ * fun Content(store: StableStore<AppState>) {
+ *     val user by store.value.fieldState(AppState::user)
+ *     // …
+ * }
+ * ```
+ *
+ * The wrapper is a value class to keep the runtime overhead at zero
+ * once the JIT has inlined it.
+ */
+@Stable
+@JvmInline
+public value class StableStore<S>(
+    /** The wrapped store. Access via `myStableStore.value`. */
+    public val value: Store<S>,
+)
+
+/**
+ * Convenience that wraps [store] in a [StableStore] and remembers it
+ * across recompositions, keyed by the store identity. Equivalent to
+ * `remember(store) { StableStore(store) }`.
+ */
+@Composable
+public fun <S> rememberStableStore(store: Store<S>): StableStore<S> =
+    remember(store) { StableStore(store) }

--- a/redux-kotlin-compose/src/jvmTest/kotlin/org/reduxkotlin/compose/FieldStateTest.kt
+++ b/redux-kotlin-compose/src/jvmTest/kotlin/org/reduxkotlin/compose/FieldStateTest.kt
@@ -1,0 +1,146 @@
+package org.reduxkotlin.compose
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.runComposeUiTest
+import org.junit.Test
+import org.reduxkotlin.Store
+import org.reduxkotlin.createStore
+
+private data class CounterState(val counter: Int = 0, val label: String = "init")
+private data class Increment(val amount: Int = 1)
+private data class SetLabel(val text: String)
+
+private fun reducer(state: CounterState, action: Any): CounterState = when (action) {
+    is Increment -> state.copy(counter = state.counter + action.amount)
+    is SetLabel -> state.copy(label = action.text)
+    else -> state
+}
+
+private fun newStore(): Store<CounterState> = createStore(::reducer, CounterState())
+
+@OptIn(ExperimentalTestApi::class)
+class FieldStateTest {
+
+    @Test
+    fun fieldState_renders_initial_value_on_first_frame() = runComposeUiTest {
+        val store = newStore()
+        setContent {
+            val counter by store.fieldState(CounterState::counter)
+            Text(text = "counter=$counter")
+        }
+        onAllNodesWithText("counter=0").assertCountEquals(1)
+    }
+
+    @Test
+    fun fieldState_updates_state_value_after_dispatch() = runComposeUiTest {
+        val store = newStore()
+        setContent {
+            val counter by store.fieldState(CounterState::counter)
+            Text(text = "counter=$counter")
+        }
+        onAllNodesWithText("counter=0").assertCountEquals(1)
+
+        store.dispatch(Increment())
+        waitForIdle()
+        onAllNodesWithText("counter=1").assertCountEquals(1)
+
+        store.dispatch(Increment(amount = 4))
+        waitForIdle()
+        onAllNodesWithText("counter=5").assertCountEquals(1)
+    }
+
+    @Test
+    fun fieldState_two_fields_track_independently() = runComposeUiTest {
+        val store = newStore()
+        setContent {
+            val counter by store.fieldState(CounterState::counter)
+            val label by store.fieldState(CounterState::label)
+            Text(text = "counter=$counter")
+            Text(text = "label=$label")
+        }
+        onAllNodesWithText("counter=0").assertCountEquals(1)
+        onAllNodesWithText("label=init").assertCountEquals(1)
+
+        // Only counter moves — label binding stays at "init".
+        store.dispatch(Increment(amount = 3))
+        waitForIdle()
+        onAllNodesWithText("counter=3").assertCountEquals(1)
+        onAllNodesWithText("label=init").assertCountEquals(1)
+
+        // Only label moves — counter binding stays at "3".
+        store.dispatch(SetLabel("hello"))
+        waitForIdle()
+        onAllNodesWithText("counter=3").assertCountEquals(1)
+        onAllNodesWithText("label=hello").assertCountEquals(1)
+    }
+
+    @Test
+    fun selectorState_recomputes_only_when_derived_value_changes() = runComposeUiTest {
+        val store = newStore()
+        var derivedReads = 0
+        setContent {
+            val parity by store.selectorState { state -> state.counter % 2 }
+            derivedReads++
+            Text(text = "parity=$parity")
+        }
+        val initial = derivedReads
+
+        // Same parity → no recomposition triggered by State<F>.
+        store.dispatch(Increment(amount = 2))
+        waitForIdle()
+        check(derivedReads == initial) { "selectorState fired when derived value unchanged" }
+
+        // Flipping parity → recomposition.
+        store.dispatch(Increment(amount = 1))
+        waitForIdle()
+        check(derivedReads > initial) { "selectorState did not fire on actual change" }
+        onAllNodesWithText("parity=1").assertCountEquals(1)
+    }
+
+    @Test
+    fun fieldState_b3_race_window_picks_up_dispatch_between_remember_and_effect() = runComposeUiTest {
+        // The granular subscription is installed inside DisposableEffect,
+        // which fires at commit. If the store dispatches between the
+        // `remember { mutableStateOf(...) }` (composition time) and the
+        // effect (commit time), and if we DIDN'T re-sample under the
+        // effect, the first observed frame would be stale until the
+        // next dispatch fired the subscriber.
+        //
+        // We simulate this by dispatching DURING setContent's body, then
+        // assert the first observable frame reflects the post-dispatch
+        // value. The runComposeUiTest harness drives composition and
+        // effects synchronously enough for this to be deterministic.
+        val store = newStore()
+        setContent {
+            // Dispatch happens during composition body — i.e. AFTER
+            // remember { mutableStateOf(property.get(store.state)) } has
+            // already captured counter=0.
+            store.dispatch(Increment(amount = 7))
+            val counter by store.fieldState(CounterState::counter)
+            Text(text = "race=$counter")
+        }
+        waitForIdle()
+        // Without the B3 re-sample, this would be "race=0" until another
+        // dispatch arrived. With the re-sample inside DisposableEffect,
+        // we pick up the in-flight increment immediately.
+        onAllNodesWithText("race=7").assertCountEquals(1)
+    }
+
+    @Test
+    fun selectorState_renders_initial_value() = runComposeUiTest {
+        val store = newStore()
+        setContent {
+            val doubled by store.selectorState { state -> state.counter * 2 }
+            Text(text = "doubled=$doubled")
+        }
+        onAllNodesWithText("doubled=0").assertCountEquals(1)
+
+        store.dispatch(Increment(amount = 5))
+        waitForIdle()
+        onAllNodesWithText("doubled=10").assertCountEquals(1)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ include(
     ":redux-kotlin-threadsafe",
     ":redux-kotlin-granular",
     ":redux-kotlin-multimodel",
+    ":redux-kotlin-compose",
     ":examples:counter:common",
     ":examples:counter:android",
     ":examples:todos:common",


### PR DESCRIPTION
## Summary

New opt-in artefact `redux-kotlin-compose` that bridges granular subscriptions (PR β, merged) into Compose Multiplatform's `State<F>`. Single-field bindings collapse to one declarative line:

```kotlin
@Composable
fun ProfileHeader(store: Store<AppState>) {
    val user by store.fieldState(AppState::user)
    if (user != null) Text("Hello, \${user.displayName}")
}
```

Recomposition is surgical — only Composables that read the changed field actually recompose, because the underlying granular subscription only fires `mutableState.value = new` when the selector value moves (`===` then `==`).

## Public surface (commonMain)

| API | Notes |
|---|---|
| `@Composable fun Store<S>.selectorState((S) -> F): State<F>` | Lambda selector. JS/Swift-friendly. |
| `@Composable fun Store<S>.fieldState(KProperty1<S, F>): State<F>` | Kotlin sugar. `@HiddenFromObjC`. |
| `@Stable @JvmInline value class StableStore<S>(value: Store<S>)` | Keeps Composables that take a Store parameter skippable — Compose's stability inferrer treats interface types as `@Unstable`. Resolution to review **I6**. |
| `@Composable fun rememberStableStore(store: Store<S>): StableStore<S>` | One-liner wrapping helper. |

## Critical implementation detail (B3 race fix)

Both `@Composable` bridges re-sample `store.state` **inside** `DisposableEffect`, before installing the granular subscription. This closes the init-to-subscribe race window:

- `remember { mutableStateOf(property.get(store.state)) }` runs at composition time and caches a value.
- `DisposableEffect { ... }` runs at commit. A dispatch that lands between these two would otherwise leave the binding stale until the next dispatch arrived.
- The re-sample inside the effect picks up any in-flight state change before the subscriber gets attached.

`triggerOnSubscribe = false` is used because the explicit re-sample plays the same role the trigger would have played — we don't want a redundant `state.value = state.value` assignment churning Compose's snapshot machinery for no reason.

A dedicated test (`fieldState_b3_race_window_picks_up_dispatch_between_remember_and_effect`) dispatches during the composition body and asserts the first observable frame reflects the post-dispatch value — would fail without the B3 re-sample.

## Build wiring

- New `libs.versions.toml` entries: `compose-multiplatform = "1.10.0"` (Kotlin 2.3.20 compatible) and the bundled `org.jetbrains.kotlin.plugin.compose` alias.
- Module reuses `convention.library-mpp-loved` for target parity (jvm/android/js/wasmJs/ios\*/macos\*/linux\*/mingw). The plan originally excluded plain `js` per B7; `compose.runtime` works on every loved-set target so we keep the broader set. UI-level integration (Compose UI components, navigation hooks) is what would constrain back to wasmJs-only and stays out of this module's scope.

## Test plan

- [x] `:redux-kotlin-compose:build` passes locally (all KMP targets compile, including ios\*/macos\*/linux/mingw native + jvm/js/wasmJs)
- [x] `:redux-kotlin-compose:jvmTest` — 6 compose-ui-test cases green:
  - `fieldState_renders_initial_value_on_first_frame`
  - `fieldState_updates_state_value_after_dispatch`
  - `fieldState_two_fields_track_independently`
  - `selectorState_recomputes_only_when_derived_value_changes`
  - `fieldState_b3_race_window_picks_up_dispatch_between_remember_and_effect` (B3 regression)
  - `selectorState_renders_initial_value`
- [x] `:redux-kotlin-compose:jsNodeTest`, `:wasmJsNodeTest` green (no @Composable tests, smoke-compile only)
- [x] Detekt clean, `explicitApi` mode passes
- [ ] CI matrix validates iOS simulator + remaining native hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)