### PR TITLE
fix(threadsafe): synchronize unsubscribe with dispatch (PR ι of v2)

### DIFF
--- a/redux-kotlin-granular/src/jvmTest/kotlin/org/reduxkotlin/granular/concurrency/ConcurrencyStressTest.kt
+++ b/redux-kotlin-granular/src/jvmTest/kotlin/org/reduxkotlin/granular/concurrency/ConcurrencyStressTest.kt
@@ -162,18 +162,75 @@ class ConcurrencyStressTest {
         }
     }
 
-    // NOTE: A subscribe/unsubscribe-churn-during-dispatch-storm scenario
-    // was prototyped here but surfaces a pre-existing race in
-    // `ThreadSafeStore`: the unsubscribe lambda returned by
-    // `store.subscribe(...)` mutates the listener list without
-    // re-acquiring `synchronized(this)`, so churning subs from one
-    // thread while dispatching from another can throw
-    // `ConcurrentModificationException` from inside the upstream
-    // store's iteration loop. That's a finding worth its own
-    // follow-up patch against the threadsafe module; it is NOT
-    // introduced by the granular layer (which itself never mutates
-    // the entries list after `activate()`). Tracking issue: see
-    // redux-kotlin-threadsafe README.
+    /**
+     * Scenario 4 from the plan: subscribe/unsubscribe churn while a
+     * dispatch storm runs from peer threads. Regression test for the
+     * ThreadSafeStore unsubscribe-race fix — without that fix, the
+     * teardown lambda returned by `store.subscribe(...)` mutates the
+     * underlying listener list without re-acquiring the lock, so a
+     * concurrent dispatch's iteration through the list can throw
+     * `ConcurrentModificationException`.
+     *
+     * After the fix, churners can subscribe-and-immediately-unsubscribe
+     * indefinitely while dispatchers fire, with no exceptions and a
+     * clean listener-list state at teardown.
+     */
+    @Test
+    fun subscribe_unsubscribe_churn_during_dispatch_storm_does_not_throw() {
+        val store = createThreadSafeStore(reducer, CounterState())
+        val dispatcherThreads = 4
+        val churnerThreads = 2
+        val totalThreads = dispatcherThreads + churnerThreads
+        val dispatchesPerThread = 1_000
+        val churnCyclesPerThread = 1_000
+        val failures = AtomicLong()
+        val churnCount = AtomicLong()
+
+        val executor = daemonExecutor(totalThreads)
+        val start = CyclicBarrier(totalThreads)
+        try {
+            val dispatcherFutures = (1..dispatcherThreads).map {
+                executor.submit {
+                    start.await(SCENARIO_TIMEOUT_S, TimeUnit.SECONDS)
+                    repeat(dispatchesPerThread) {
+                        try {
+                            store.dispatch(IncrementAction)
+                        } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+                            failures.incrementAndGet()
+                            throw t
+                        }
+                    }
+                }
+            }
+            val churnerFutures = (1..churnerThreads).map {
+                executor.submit {
+                    start.await(SCENARIO_TIMEOUT_S, TimeUnit.SECONDS)
+                    repeat(churnCyclesPerThread) {
+                        try {
+                            val sub = store.subscribe { /* no-op */ }
+                            sub()
+                            churnCount.incrementAndGet()
+                        } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+                            failures.incrementAndGet()
+                            throw t
+                        }
+                    }
+                }
+            }
+            for (f in dispatcherFutures + churnerFutures) f.get(SCENARIO_TIMEOUT_S, TimeUnit.SECONDS)
+        } finally {
+            executor.shutdown()
+            assertTrue(executor.awaitTermination(SCENARIO_TIMEOUT_S, TimeUnit.SECONDS))
+        }
+
+        assertEquals(0L, failures.get(), "subscribe/unsubscribe churn raced with dispatch")
+        assertEquals(
+            (churnerThreads * churnCyclesPerThread).toLong(),
+            churnCount.get(),
+            "Churn count didn't reach expected total",
+        )
+        assertEquals(dispatcherThreads * dispatchesPerThread, store.state.counter)
+    }
 
     /**
      * Re-entrancy canary: a granular listener calls `store.dispatch()`

--- a/redux-kotlin-threadsafe/src/commonMain/kotlin/org/reduxkotlin/threadsafe/ThreadSafeStore.kt
+++ b/redux-kotlin-threadsafe/src/commonMain/kotlin/org/reduxkotlin/threadsafe/ThreadSafeStore.kt
@@ -32,7 +32,15 @@ public class ThreadSafeStore<State>(override val store: Store<State>) :
     }
 
     override val subscribe: (StoreSubscriber) -> StoreSubscription = { storeSubscriber ->
-        synchronized(this) { store.subscribe(storeSubscriber) }
+        val inner = synchronized(this) { store.subscribe(storeSubscriber) }
+        // The returned StoreSubscription mutates the underlying store's
+        // listener list when invoked; without re-acquiring the lock, a
+        // teardown racing against a concurrent dispatch can corrupt the
+        // list or throw ConcurrentModificationException from inside the
+        // upstream store's iteration loop. Wrap it so unsubscribe takes
+        // the same lock as subscribe and dispatch.
+        val unsubscribe: StoreSubscription = { synchronized(this) { inner() } }
+        unsubscribe
     }
 }
 


### PR DESCRIPTION
## Summary

`ThreadSafeStore` wraps `subscribe` in `synchronized(this)`, but the `StoreSubscription` it returns (the unsubscribe lambda) was not wrapped — it called back into the underlying store's listener-list mutation without re-acquiring the lock. Under churn during a dispatch storm, the underlying `CreateStore`'s `nextListeners.forEach` iterates the same list a churner thread's `nextListeners.removeAt(...)` is mutating, throwing `ConcurrentModificationException`.

The granular module's stress-test suite (PR γ, merged) flagged this as a follow-up via a `NOTE` block; this commit fixes it.

## The fix

```kotlin
override val subscribe: (StoreSubscriber) -> StoreSubscription = { storeSubscriber ->
    val inner = synchronized(this) { store.subscribe(storeSubscriber) }
    // Wrap the returned subscription so unsubscribe takes the same lock
    // as subscribe and dispatch.
    val unsubscribe: StoreSubscription = { synchronized(this) { inner() } }
    unsubscribe
}
```

Two extra method dispatches per unsubscribe — but unsubscribe is a cold path (tear-down), so the overhead is uninteresting compared to the correctness gain.

## Regression test

The `NOTE` block in `ConcurrencyStressTest.kt` is replaced with an actual test (`subscribe_unsubscribe_churn_during_dispatch_storm_does_not_throw`) implementing scenario 4 from the original granular plan:

- 4 dispatcher threads × 1,000 `dispatch(IncrementAction)` each
- 2 churner threads × 1,000 `subscribe { } → unsubscribe()` cycles each
- All started via a `CyclicBarrier` so contention is real
- Asserts zero exceptions, expected churn count, expected final counter

Passed three back-to-back local runs. The pre-existing `NOTE` documents that the equivalent scenario would throw without the fix.

## Sequencing

This is independent of the v2 multimodel (#280, #281) and compose (#282) work — it only touches `ThreadSafeStore` and the existing stress-test file. Can land before, alongside, or after any of those.

## Test plan

- [x] `:redux-kotlin-threadsafe:build` passes
- [x] `:redux-kotlin-granular:jvmTest` — full suite passes including new churn test
- [x] New test runs cleanly 3× in a row
- [ ] CI matrix confirms behavior on Linux/Windows hosts where dispatch scheduling may surface the race more aggressively

🤖 Generated with [Claude Code](https://claude.com/claude-code)