### PR TITLE
perf(granular): add kotlinx-benchmark contention benchmarks (PR κ of v2)

### DIFF
--- a/build-conventions/src/main/kotlin/convention.detekt.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.detekt.gradle.kts
@@ -39,7 +39,11 @@ tasks {
             include("**/*.kt", "**/*.kts")
             // `.claude/` holds Claude Code harness worktrees / caches; never
             // scan them. `**/build` is the Gradle output dir.
-            exclude("**/build", "scripts/", ".claude/", "**/.claude/")
+            // jvmBenchmark/ holds JMH benchmarks where the @Benchmark
+            // contract dictates the function-naming and KDoc shape; the
+            // benchmarks are not shipped as library API. Skip rather
+            // than burn the rule budget on paraphrasing method names.
+            exclude("**/build", "scripts/", ".claude/", "**/.claude/", "**/jvmBenchmark/**")
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ detekt = "1.23.8"
 dokka = "2.2.0"
 git-hooks-gradle-plugin = "0.0.2"
 kotlin = "2.3.20"
+kotlinx-benchmark = "0.4.13"
 nexus-publish-plugin = "2.0.0"
 
 [libraries]
@@ -26,7 +27,10 @@ kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", v
 kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
+kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark" }
 
 [plugins]
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlinx-benchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinx-benchmark" }
+kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }

--- a/redux-kotlin-granular/build.gradle.kts
+++ b/redux-kotlin-granular/build.gradle.kts
@@ -1,8 +1,16 @@
+import kotlinx.benchmark.gradle.JvmBenchmarkTarget
 import util.jvmCommonTest
 
 plugins {
     id("convention.library-mpp-loved")
     id("convention.publishing-mpp")
+    alias(libs.plugins.kotlin.allopen)
+    alias(libs.plugins.kotlinx.benchmark)
+}
+
+allOpen {
+    // JMH requires @State-annotated classes to be open so it can subclass them.
+    annotation("org.openjdk.jmh.annotations.State")
 }
 
 val hasAndroidSdk: Boolean = run {
@@ -21,6 +29,16 @@ kotlin {
         namespace = "org.reduxkotlin.granular"
     }
 
+    // Dedicated benchmark compilation under the jvm target, associated
+    // with main so it sees the public API without having to depend on
+    // it transitively. Sources live under src/jvmBenchmark/kotlin.
+    jvm {
+        compilations {
+            val main by getting
+            create("benchmark") { associateWith(main) }
+        }
+    }
+
     sourceSets {
         commonMain {
             dependencies {
@@ -34,6 +52,21 @@ kotlin {
                 // the canonical multi-threaded host.
                 implementation(project(":redux-kotlin-threadsafe"))
             }
+        }
+        named("jvmBenchmark") {
+            dependencies {
+                implementation(libs.kotlinx.benchmark.runtime)
+                implementation(project(":redux-kotlin-threadsafe"))
+            }
+        }
+    }
+}
+
+benchmark {
+    targets {
+        register("jvmBenchmark") {
+            this as JvmBenchmarkTarget
+            jmhVersion = "1.37"
         }
     }
 }

--- a/redux-kotlin-granular/src/jvmBenchmark/kotlin/org/reduxkotlin/granular/benchmarks/ContentionBenchmark.kt
+++ b/redux-kotlin-granular/src/jvmBenchmark/kotlin/org/reduxkotlin/granular/benchmarks/ContentionBenchmark.kt
@@ -1,0 +1,146 @@
+package org.reduxkotlin.granular.benchmarks
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.annotations.Warmup
+import org.reduxkotlin.Reducer
+import org.reduxkotlin.Store
+import org.reduxkotlin.StoreSubscription
+import org.reduxkotlin.granular.subscribeTo
+import org.reduxkotlin.threadsafe.createThreadSafeStore
+import java.util.concurrent.TimeUnit
+
+/**
+ * Contention benchmark for granular subscriptions on [createThreadSafeStore].
+ *
+ * Measures how dispatch throughput scales as:
+ *  - the number of granular subscriptions grows (`subCount` = 0, 10, 100), and
+ *  - the number of concurrent dispatcher threads grows (`@Threads(1, 2, 4, 8)`).
+ *
+ * Two workloads:
+ *  - `dispatch_noChange_*`: the action returns the same state instance, so
+ *    every granular entry's `===` fast-path hits and no listener fires.
+ *    Measures pure framework overhead (lock acquisition + entry walk + diff).
+ *  - `dispatch_mixedChange_*`: the action mutates ~50% of the underlying
+ *    [WideState.values] list, so ~50% of subscribers see a real change
+ *    and fire their listener. Measures the realistic ceiling consumers
+ *    should plan against — the per-target budget from the plan is
+ *    "≤5 µs at 100 entries on JVM 21" against this workload.
+ *
+ * The 100 selectors used at `subCount = 100` are 100 distinct lambdas, each
+ * indexing into a different position of [WideState.values]. Distinct
+ * lambda identities make the underlying `Function1.invoke` call site
+ * megamorphic — JIT inline caches saturate after ~8 different targets,
+ * which is the realistic shape of a UI screen subscribing to many
+ * different fields. The plan originally specified 100 distinct
+ * `KProperty1` references; using lambdas with the same underlying
+ * indexed reads achieves the same call-site behaviour without requiring
+ * a 100-field data class. KProperty1-specific overhead is measured
+ * separately by [PropertyRefBenchmark].
+ *
+ * Run with:
+ * ```
+ * ./gradlew :redux-kotlin-granular:jvmBenchmarkBenchmark
+ * ```
+ *
+ * This task is NOT part of `:build` — benchmarks take several minutes
+ * (warm-up + measurement iterations) and would block CI. The default
+ * configuration runs only when explicitly requested.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 2)
+@State(Scope.Benchmark)
+open class ContentionBenchmark {
+
+    @Param("0", "10", "100")
+    var subCount: Int = 0
+
+    private lateinit var store: Store<WideState>
+    private lateinit var subs: List<StoreSubscription>
+
+    @Setup(Level.Trial)
+    fun setUp() {
+        store = createThreadSafeStore(reducer, WideState())
+        subs = (0 until subCount).map { idx ->
+            store.subscribeTo({ state -> state.values[idx] }, triggerOnSubscribe = false) { _, _ -> }
+        }
+    }
+
+    @TearDown(Level.Trial)
+    fun tearDown() {
+        subs.forEach { it() }
+    }
+
+    // ---- noChange workload: action returns same state instance.
+    @Benchmark
+    @Threads(1)
+    fun dispatch_noChange_1t() = store.dispatch(NoopAction)
+
+    @Benchmark
+    @Threads(2)
+    fun dispatch_noChange_2t() = store.dispatch(NoopAction)
+
+    @Benchmark
+    @Threads(4)
+    fun dispatch_noChange_4t() = store.dispatch(NoopAction)
+
+    @Benchmark
+    @Threads(8)
+    fun dispatch_noChange_8t() = store.dispatch(NoopAction)
+
+    // ---- mixedChange workload: 50% of entries see a real value change.
+    @Benchmark
+    @Threads(1)
+    fun dispatch_mixedChange_1t() = store.dispatch(MixedChangeAction)
+
+    @Benchmark
+    @Threads(2)
+    fun dispatch_mixedChange_2t() = store.dispatch(MixedChangeAction)
+
+    @Benchmark
+    @Threads(4)
+    fun dispatch_mixedChange_4t() = store.dispatch(MixedChangeAction)
+
+    @Benchmark
+    @Threads(8)
+    fun dispatch_mixedChange_8t() = store.dispatch(MixedChangeAction)
+}
+
+internal data class WideState(
+    val tick: Int = 0,
+    val values: List<Int> = List(WIDE_STATE_SIZE) { 0 },
+)
+
+internal object NoopAction
+internal object MixedChangeAction
+
+internal val reducer: Reducer<WideState> = { state, action ->
+    when (action) {
+        is MixedChangeAction -> {
+            val nextTick = state.tick + 1
+            // Mutate every other entry: half the granular subscribers see
+            // a value change, half see the same value (===-fast-path hits).
+            val nextValues = ArrayList<Int>(state.values.size).apply {
+                for (i in state.values.indices) {
+                    add(if (i % 2 == 0) nextTick else state.values[i])
+                }
+            }
+            state.copy(tick = nextTick, values = nextValues)
+        }
+        else -> state
+    }
+}
+
+internal const val WIDE_STATE_SIZE = 100

--- a/redux-kotlin-granular/src/jvmBenchmark/kotlin/org/reduxkotlin/granular/benchmarks/PropertyRefBenchmark.kt
+++ b/redux-kotlin-granular/src/jvmBenchmark/kotlin/org/reduxkotlin/granular/benchmarks/PropertyRefBenchmark.kt
@@ -1,0 +1,79 @@
+package org.reduxkotlin.granular.benchmarks
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.annotations.Warmup
+import org.reduxkotlin.Reducer
+import org.reduxkotlin.Store
+import org.reduxkotlin.granular.subscribeTo
+import org.reduxkotlin.threadsafe.createThreadSafeStore
+import java.util.concurrent.TimeUnit
+
+/**
+ * Isolated comparison between two selector shapes used by granular
+ * subscriptions:
+ *
+ *  - **Property-reference selector** (`subscribeTo(MyState::field)`).
+ *    Internally this is `property::get`, which JIT can specialise per
+ *    property singleton. The call site sees the same `KProperty1`
+ *    instance every time, so dispatch tends to monomorphise.
+ *
+ *  - **Boxed-primitive selector** (`subscribeTo { state -> state.counter }`
+ *    returning `Int`). Because `Function1.invoke` operates on `Any?`,
+ *    every primitive return is autoboxed into an `Integer`; the granular
+ *    layer's `===` fast-path then misses (different `Integer` instances),
+ *    falls through to `==`, which unboxes both sides for comparison.
+ *
+ * Both benchmarks subscribe a single granular entry against the same
+ * counter field. The delta between them is the autoboxing-plus-fallback
+ * cost surfaced by review B2.
+ *
+ * Single-threaded; the contention story is covered by
+ * [ContentionBenchmark].
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 2)
+@State(Scope.Benchmark)
+@Threads(1)
+open class PropertyRefBenchmark {
+
+    private lateinit var propertyRefStore: Store<CounterState>
+    private lateinit var lambdaStore: Store<CounterState>
+
+    @Setup(Level.Trial)
+    fun setUp() {
+        propertyRefStore = createThreadSafeStore(counterReducer, CounterState())
+        lambdaStore = createThreadSafeStore(counterReducer, CounterState())
+
+        // Property-reference subscription — KProperty1<CounterState, Int>.
+        propertyRefStore.subscribeTo(CounterState::counter, triggerOnSubscribe = false) { _, _ -> }
+
+        // Lambda selector returning a primitive Int — boxes through Function1.
+        lambdaStore.subscribeTo({ state -> state.counter }, triggerOnSubscribe = false) { _, _ -> }
+    }
+
+    @Benchmark
+    fun dispatch_propertyRefSelector() = propertyRefStore.dispatch(IncrementAction)
+
+    @Benchmark
+    fun dispatch_lambdaPrimitiveSelector() = lambdaStore.dispatch(IncrementAction)
+}
+
+internal data class CounterState(val counter: Int = 0)
+internal object IncrementAction
+internal val counterReducer: Reducer<CounterState> = { state, action ->
+    when (action) {
+        is IncrementAction -> state.copy(counter = state.counter + 1)
+        else -> state
+    }
+}


### PR DESCRIPTION
## Summary

Two JMH benchmark suites under a new `src/jvmBenchmark` source set in the granular module:

- **`ContentionBenchmark`** — dispatch throughput as subscriber count grows (`@Param("0", "10", "100")`) × dispatcher thread count grows (`@Threads(1, 2, 4, 8)`). Two workloads:
  - `dispatch_noChange_*`: action returns the same state instance, all `===` fast-paths hit, no listener fires. Measures the framework-overhead floor.
  - `dispatch_mixedChange_*`: action mutates 50% of `WideState.values`. ~50% of subscribers fire their listener. Measures the realistic ceiling — what the plan's "≤5 µs at 100 entries on JVM 21" budget is checked against.

  100 distinct lambda selectors index into separate positions of `WideState.values`, so the underlying `Function1.invoke` call site is **megamorphic** (review B2 — JIT inline caches saturate after ~8 different targets, matching the realistic shape of a UI screen subscribing to many distinct fields).

- **`PropertyRefBenchmark`** — single-threaded comparison between `subscribeTo(KProperty1)` and `subscribeTo({ state -> state.counter })` returning a primitive `Int`. Surfaces the autoboxing + `===`-miss + `==`-fallback cost from the `Function1<Any?, Any?, Unit>` shape.

## Sample numbers (local JVM 21 run, mixedChange workload, 100 subs)

| Threads | Latency |
|---|---|
| 1 | **3.34 µs** |
| 2 | 6.39 µs |
| 4 | 14.3 µs |
| 8 | 31.4 µs |

Meets the plan's budget at 1 thread. The sub-linear scaling under contention is the `ThreadSafeStore.synchronized(this)` bottleneck the `@Threads` matrix was designed to surface — useful evidence for any future "ThreadSafeStore needs read-write lock or coroutine-serialized impl" PR.

`PropertyRefBenchmark` shows lambda-primitive at 50 ns vs property-ref at 53 ns — within noise. JIT inlines both paths; no measurable autoboxing penalty in the single-subscription case.

## Build wiring

- `libs.versions.toml`: `kotlinx-benchmark` 0.4.13 (plugin + runtime), `kotlin-allopen` alias (Kotlin-bundled, opens `@State` classes for JMH subclassing).
- Dedicated `jvm.compilations.create(\"benchmark\")` associated with `main` — benchmark sources see the public granular API without depending on internals or polluting the main classpath.
- Global detekt exclude for `**/jvmBenchmark/**` (added to `convention.detekt`) — `@Benchmark`-shaped methods would otherwise trip `FunctionNaming` and `UndocumentedPublic*` rules that matter only on shipped library code.

## Running locally

```
./gradlew :redux-kotlin-granular:jvmBenchmarkBenchmark
```

NOT part of `:build` — benchmarks take several minutes (warm-up + measurement iterations) and would block CI. Opt-in only.

## Sequencing

Independent of the v2 multimodel (#280, #281), compose (#282), and threadsafe race-fix (#283) PRs. Can land any order against master.

## Test plan

- [x] `:redux-kotlin-granular:jvmBenchmarkClasses` compiles cleanly
- [x] Full benchmark run completes locally (~6 minutes) producing the numbers above
- [x] `:redux-kotlin-granular:jvmTest` + `detektAll` still pass
- [ ] CI compile-only check of the benchmark source set (no execution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)