### PR TITLE
docs(samples): add iOS Swift counter sample (PR λ of v2)

### DIFF
--- a/examples/counter/common/build.gradle.kts
+++ b/examples/counter/common/build.gradle.kts
@@ -11,14 +11,25 @@ kotlin {
         binaries.executable()
     }
 
-    iosArm64()
-    iosSimulatorArm64()
-    iosX64()
+    listOf(iosArm64(), iosSimulatorArm64(), iosX64()).forEach { iosTarget ->
+        iosTarget.binaries.framework {
+            baseName = "SharedCounter"
+            isStatic = true
+            // Export the public APIs the Swift sample consumes directly,
+            // so call sites like `store.subscribeFields { ... }` resolve
+            // without re-exporting boilerplate.
+            export(project(":redux-kotlin"))
+            export(project(":redux-kotlin-granular"))
+            export(project(":redux-kotlin-threadsafe"))
+        }
+    }
 
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project(":redux-kotlin"))
+                api(project(":redux-kotlin"))
+                api(project(":redux-kotlin-granular"))
+                api(project(":redux-kotlin-threadsafe"))
             }
         }
         commonTest {

--- a/examples/counter/common/src/commonMain/kotlin/org/reduxkotlin/examples/counter/GranularCounterState.kt
+++ b/examples/counter/common/src/commonMain/kotlin/org/reduxkotlin/examples/counter/GranularCounterState.kt
@@ -1,0 +1,46 @@
+package org.reduxkotlin.examples.counter
+
+import org.reduxkotlin.Reducer
+
+/**
+ * A richer counter state than the [Int] used by [reducer] above, designed
+ * specifically to exercise granular subscriptions: multiple fields whose
+ * values move independently in response to different actions, plus a
+ * derived field (`isEven`) suitable for `subscribeTo({ selector })` /
+ * `selectorState { … }` demos.
+ *
+ * Used by the `examples/counter/ios` Swift sample to validate the
+ * `redux-kotlin-granular` Swift API ergonomics (`subscribeFields`,
+ * lambda-overload `subscribeTo`, `@HiddenFromObjC` KProperty1 path).
+ */
+public data class GranularCounterState(
+    val count: Int = 0,
+    val label: String = "Counter",
+    val lastAction: String = "<none>",
+) {
+    val isEven: Boolean get() = count % 2 == 0
+}
+
+public class GranularIncrement(public val amount: Int = 1)
+public class GranularDecrement(public val amount: Int = 1)
+public class GranularSetLabel(public val label: String)
+public object GranularReset
+
+public val granularCounterReducer: Reducer<GranularCounterState> = { state, action ->
+    when (action) {
+        is GranularIncrement -> state.copy(
+            count = state.count + action.amount,
+            lastAction = "Increment(${action.amount})",
+        )
+        is GranularDecrement -> state.copy(
+            count = state.count - action.amount,
+            lastAction = "Decrement(${action.amount})",
+        )
+        is GranularSetLabel -> state.copy(
+            label = action.label,
+            lastAction = "SetLabel(${action.label})",
+        )
+        is GranularReset -> GranularCounterState(lastAction = "Reset")
+        else -> state
+    }
+}

--- a/examples/counter/ios/README.md
+++ b/examples/counter/ios/README.md
@@ -1,0 +1,118 @@
+# Counter — iOS sample
+
+This sample validates the `redux-kotlin-granular` Swift call site
+ergonomics. It demonstrates the canonical UI binding pattern
+documented in adversarial-review items B4 (`@HiddenFromObjC` on the
+property-reference overload) and B5 (`FieldSubscriptionScope`'s
+generic erasure to `Any?` requiring an explicit downcast inside
+Swift selectors).
+
+No `.xcodeproj` is checked in — the goal is to show the working
+Swift call site, not to maintain a brittle hand-generated
+`project.pbxproj`. Drop the sources into any SwiftUI App template
+to run.
+
+**Deployment target: iOS 15+** (the `ContentView` uses
+`.buttonStyle(.bordered)` / `.borderedProminent`, both 15.0+). The
+granular library itself has no iOS-version floor of its own.
+
+## What it shows
+
+`CounterViewModel.swift` registers one `subscribeFields` block with
+four entries — count, label, `isEven` (derived), `lastAction`
+(change-only). All four `@Published` properties update behind a
+single underlying `store.subscribe` listener, which is the same
+"one underlying subscriber per screen" guarantee documented for the
+Kotlin call site.
+
+The `selector` closure inside each `scope.on(...)` call takes the
+state as `Any?` (Kotlin generics on classes erase across the Native
+ABI) and downcasts to `GranularCounterState`. This is the realistic
+Swift call site — the plan's earlier draft incorrectly implied
+`{ $0.count }` worked directly. The downcast is the v1 friction price
+of Kotlin generics from Swift; a future `redux-kotlin-swift`
+companion module could wrap `Store<S>` in a typed `final class` to
+remove it.
+
+## Build the framework
+
+From the repo root:
+
+```
+./gradlew :examples:counter:common:linkReleaseFrameworkIosSimulatorArm64
+```
+
+Outputs `SharedCounter.framework` under:
+
+```
+examples/counter/common/build/bin/iosSimulatorArm64/releaseFramework/
+```
+
+Substitute `IosArm64` or `IosX64` for device / Intel-sim builds. Or
+just run `assemble` to build all variants:
+
+```
+./gradlew :examples:counter:common:assemble
+```
+
+## Smoke compile the Swift sources
+
+Standalone compile against the simulator framework (no Xcode project
+required) — useful as a CI gate that the Swift API surface still
+links:
+
+```
+xcrun -sdk iphonesimulator swiftc \
+  -emit-module -emit-library \
+  -target arm64-apple-ios15.0-simulator \
+  -F examples/counter/common/build/bin/iosSimulatorArm64/releaseFramework \
+  -framework SharedCounter \
+  -o /tmp/CounterSample \
+  examples/counter/ios/Sources/*.swift
+```
+
+A clean exit with no diagnostics means the Kotlin-exported headers
+match the call site this sample documents.
+
+## Plug into Xcode
+
+1. **Create a new SwiftUI App project** in Xcode (File → New → Project
+   → iOS → App → SwiftUI lifecycle). Bundle ID and signing are your
+   choice — none required for the simulator.
+2. **Drop the Swift files in:** copy `Sources/*.swift` into the new
+   project's source group.
+3. **Remove Xcode's stock `<ProjectName>App.swift` and `ContentView.swift`** —
+   the sample's `CounterApp.swift` is the new `@main`.
+4. **Embed the framework:**
+   - In the project's target settings → "Frameworks, Libraries, and
+     Embedded Content" → click `+` → "Add Other…" → "Add Files…"
+   - Pick `SharedCounter.framework` from the Gradle output path above.
+   - Set "Embed & Sign" so it's bundled into the app.
+5. **Set Framework Search Paths** under Build Settings to the
+   framework's parent directory.
+6. Build & run. The counter increments / decrements drive Redux
+   actions; the UI updates via the granular subscription bridge.
+
+## What to look for when reviewing
+
+- **Single `subscribeFields` block** — registers four field bindings,
+  unsubscribes through a single returned handle in `deinit`.
+- **`scope.on` lambda overload only** — no KProperty1 references
+  appear in Swift autocomplete (hidden via `@HiddenFromObjC`).
+- **`as!` downcast inside selector closures** — B5's call-site
+  friction is right here, in line.
+- **`triggerOnSubscribe: false` on the `lastAction` binding** —
+  shows the change-only path (analytics-style logger).
+- **`DispatchQueue.main.async` inside listeners** — the store's
+  listener runs on whatever thread dispatched; SwiftUI mutates
+  `@Published` from the main thread.
+
+## Caveats / known limitations
+
+- No Combine `Publisher` bridge yet (review I8). Each `@Published`
+  is wired through a granular listener manually. Future
+  `redux-kotlin-combine` would supply `PassthroughSubject` plumbing.
+- No SwiftUI `View.subscribeFields { … }` `ViewModifier` (review I9).
+  When that ships in `redux-kotlin-swiftui`, the view-model layer
+  here would shrink to a single modifier call.
+- Generics-erasure downcast: see B5 commentary above.

--- a/examples/counter/ios/Sources/ContentView.swift
+++ b/examples/counter/ios/Sources/ContentView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// Counter UI driven entirely by the @Published bindings exposed by
+/// [CounterViewModel]. Each Text view reads exactly the field it
+/// displays, so when (for example) `lastAction` changes, the views that
+/// render `count` / `label` / `isEven` are not re-evaluated unless
+/// SwiftUI's diff also says they changed.
+///
+/// This mirrors the surgical-recomposition story documented for the
+/// redux-kotlin-compose bridge, but in SwiftUI's view-tree shape.
+struct ContentView: View {
+    @ObservedObject var viewModel: CounterViewModel
+    @State private var labelDraft: String = "Counter"
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text(viewModel.label)
+                .font(.title2)
+
+            Text("\(viewModel.count)")
+                .font(.system(size: 64, weight: .bold))
+                .foregroundColor(viewModel.isEven ? .blue : .orange)
+
+            Text(viewModel.isEven ? "even" : "odd")
+                .font(.headline)
+                .foregroundColor(.secondary)
+
+            HStack(spacing: 12) {
+                Button("-") { viewModel.decrement() }
+                    .buttonStyle(.bordered)
+                Button("+") { viewModel.increment() }
+                    .buttonStyle(.borderedProminent)
+                Button("+10") { viewModel.increment(by: 10) }
+                    .buttonStyle(.bordered)
+                Button("Reset") { viewModel.reset() }
+                    .buttonStyle(.bordered)
+            }
+            .font(.title3)
+
+            HStack {
+                TextField("label", text: $labelDraft)
+                    .textFieldStyle(.roundedBorder)
+                Button("Set") { viewModel.setLabel(labelDraft) }
+                    .buttonStyle(.bordered)
+            }
+            .padding(.horizontal)
+
+            Text("last action: \(viewModel.lastAction)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding()
+    }
+}

--- a/examples/counter/ios/Sources/CounterApp.swift
+++ b/examples/counter/ios/Sources/CounterApp.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+import SharedCounter
+
+/// SwiftUI entry point for the granular-subscriptions iOS demo.
+///
+/// The store is created once at app launch and held by the SceneDelegate-
+/// equivalent root. ``CounterViewModel`` wires Redux state into SwiftUI's
+/// `@Published` ergonomics via a single `subscribeFields` block — the
+/// canonical pattern this sample is designed to validate.
+@main
+struct CounterApp: App {
+    @StateObject private var viewModel = CounterViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView(viewModel: viewModel)
+        }
+    }
+}

--- a/examples/counter/ios/Sources/CounterViewModel.swift
+++ b/examples/counter/ios/Sources/CounterViewModel.swift
@@ -1,0 +1,140 @@
+import Foundation
+import SwiftUI
+import SharedCounter
+
+/// SwiftUI bridge for the redux-kotlin store.
+///
+/// This view model is the proof-of-concept for the granular-subscriptions
+/// Swift API: a single `subscribeFields` block batches four field
+/// bindings behind one underlying `store.subscribe` listener, each
+/// `@Published` property updates exactly when its source field moves.
+///
+/// What's exercised here:
+///
+/// - The **lambda-selector** overload of `scope.on(...)`. KProperty1
+///   references are `@HiddenFromObjC` and can't appear from Swift
+///   anyway — the Kotlin compiler exports the lambda-form overload as
+///   `on(selector:triggerOnSubscribe:listener:)` and Swift consumers
+///   use it directly.
+///
+/// - The explicit downcast required by `FieldSubscriptionScope<State>`
+///   generic erasure on the Native target. The `state` argument arrives
+///   as `Any?` and is cast back to `GranularCounterState` inside the
+///   selector closure. Documented in adversarial-review item B5.
+///
+/// - A derived value (`isEven`) read by an in-block selector lambda
+///   rather than a property reference — same path as the Kotlin
+///   `selectorState`-style call site.
+///
+/// - The `ThreadSafeStore` (via `createThreadSafeStore`), because
+///   subscriber invocation needs to be serial per dispatch for the
+///   granular layer's `@Volatile var last` visibility contract to
+///   hold across threads.
+///
+/// - The Reducer-typealias-from-Swift quirk: Kotlin
+///   `granularCounterReducer` is typed `(GranularCounterState, Any) ->
+///   GranularCounterState`, but `createThreadSafeStore` takes a generic
+///   `(Any?, Any) -> Any?`. Swift closures aren't covariant in
+///   parameter types, so we wrap the typed reducer in an Any-shaped
+///   adapter closure right at the call site.
+final class CounterViewModel: ObservableObject {
+
+    @Published private(set) var count: Int32 = 0
+    @Published private(set) var label: String = ""
+    @Published private(set) var isEven: Bool = true
+    @Published private(set) var lastAction: String = "<none>"
+
+    private let store: any TypedStore
+    private var unsubscribe: (() -> Void)?
+
+    init() {
+        let typedReducer = GranularCounterStateKt.granularCounterReducer
+        let reducerAdapter: (Any?, Any) -> Any? = { state, action in
+            typedReducer(state as! GranularCounterState, action)
+        }
+        store = CreateThreadSafeStoreKt.createThreadSafeStore(
+            reducer: reducerAdapter,
+            preloadedState: GranularCounterState(count: 0, label: "Counter", lastAction: "<none>"),
+            enhancer: nil
+        )
+
+        // ONE underlying store.subscribe listener, FOUR Published
+        // properties driven by it. triggerOnSubscribe: true for the
+        // UI-binding fields so the first frame has real values;
+        // triggerOnSubscribe: false on the analytics-style logger.
+        unsubscribe = SubscribeFieldsKt.subscribeFields(
+            store,
+            onSelectorError: { error in
+                NSLog("granular selector error: \(String(describing: error))")
+            }
+        ) { scope in
+            // count — primitive Int32 (Kotlin Int) crosses the Any?
+            // boundary as a boxed Integer; the listener receives it
+            // as Any? and unboxes.
+            scope.on(
+                selector: { stateAny in
+                    let state = stateAny as! GranularCounterState
+                    return KotlinInt(value: state.count)
+                },
+                triggerOnSubscribe: true,
+                listener: { [weak self] _, new in
+                    guard let boxed = new as? KotlinInt else { return }
+                    DispatchQueue.main.async { self?.count = boxed.int32Value }
+                }
+            )
+
+            // label — String round-trips as NSString through Any?.
+            scope.on(
+                selector: { stateAny in (stateAny as! GranularCounterState).label },
+                triggerOnSubscribe: true,
+                listener: { [weak self] _, new in
+                    guard let s = new as? String else { return }
+                    DispatchQueue.main.async { self?.label = s }
+                }
+            )
+
+            // isEven — derived from count, never written directly to
+            // the model. selectorState-style demo.
+            scope.on(
+                selector: { stateAny in
+                    KotlinBoolean(value: (stateAny as! GranularCounterState).isEven)
+                },
+                triggerOnSubscribe: true,
+                listener: { [weak self] _, new in
+                    guard let b = new as? KotlinBoolean else { return }
+                    DispatchQueue.main.async { self?.isEven = b.boolValue }
+                }
+            )
+
+            // lastAction — analytics logger pattern, change-only.
+            scope.on(
+                selector: { stateAny in (stateAny as! GranularCounterState).lastAction },
+                triggerOnSubscribe: false,
+                listener: { [weak self] _, new in
+                    guard let s = new as? String else { return }
+                    DispatchQueue.main.async { self?.lastAction = s }
+                }
+            )
+        }
+    }
+
+    deinit {
+        unsubscribe?()
+    }
+
+    func increment(by amount: Int = 1) {
+        _ = store.dispatch(GranularIncrement(amount: Int32(amount)))
+    }
+
+    func decrement(by amount: Int = 1) {
+        _ = store.dispatch(GranularDecrement(amount: Int32(amount)))
+    }
+
+    func setLabel(_ text: String) {
+        _ = store.dispatch(GranularSetLabel(label: text))
+    }
+
+    func reset() {
+        _ = store.dispatch(GranularReset())
+    }
+}


### PR DESCRIPTION
## Summary

Resolves adversarial-review item **I10** — `examples/counter/ios` was an acceptance criterion for the granular-subs v1 to validate Swift call-site ergonomics, particularly the `@HiddenFromObjC` overload hiding (**B4**) and the `FieldSubscriptionScope` generic-erasure downcast (**B5**).

The sample is a SwiftUI app powered by a single `subscribeFields` block on a Kotlin store. Four `@Published` properties — `count`, `label`, `isEven` (derived), `lastAction` (change-only) — are driven by **one** underlying `store.subscribe` listener via four `scope.on` entries.

## What this proves

| Concern | How the sample exercises it |
|---|---|
| **B4** — `@HiddenFromObjC` on `KProperty1` overload | Swift call site uses only `on(selector:triggerOnSubscribe:listener:)`; KProperty1 form doesn't appear in autocomplete |
| **B5** — `FieldSubscriptionScope` generic erasure | Each selector closure does `state as! GranularCounterState` — the friction is documented and right there in line |
| Lambda selector + structural diff | Listener fires only when the selected field actually moves; sibling-field changes don't recompose unrelated `@Published`s |
| `triggerOnSubscribe` defaults | UI fields (`count`, `label`, `isEven`) use `true` so initial frame has real values; `lastAction` uses `false` for the analytics-logger pattern |
| `createThreadSafeStore` from Swift | Wraps the typed `granularCounterReducer` in an `Any?`-shaped adapter at the call site (Swift closures aren't covariant on parameter types) |

## Files

- `examples/counter/common/src/commonMain/kotlin/.../GranularCounterState.kt` — richer state class (count + label + lastAction + derived isEven) and reducer for the granular demo. The existing `Reducer.kt` (Int state, used by the android sample) is untouched.
- `examples/counter/common/build.gradle.kts` — three iOS targets emit a static `SharedCounter.framework` exporting `redux-kotlin`, `redux-kotlin-granular`, and `redux-kotlin-threadsafe`.
- `examples/counter/ios/Sources/CounterApp.swift` — SwiftUI `@main` entry.
- `examples/counter/ios/Sources/CounterViewModel.swift` — the load-bearing file. ~120 LOC.
- `examples/counter/ios/Sources/ContentView.swift` — minimal counter UI. Reads only the `@Published`s.
- `examples/counter/ios/README.md` — Xcode plug-in instructions + a standalone `swiftc` smoke-compile command.

## Local verification

```
# Build the iOS-sim framework
./gradlew :examples:counter:common:linkReleaseFrameworkIosSimulatorArm64

# Compile the Swift sources against it — no .xcodeproj needed
xcrun -sdk iphonesimulator swiftc \
  -emit-module -emit-library \
  -target arm64-apple-ios15.0-simulator \
  -F examples/counter/common/build/bin/iosSimulatorArm64/releaseFramework \
  -framework SharedCounter \
  -o /tmp/CounterSample \
  examples/counter/ios/Sources/*.swift
```

Both succeed cleanly (Xcode 26.2, iOS SDK 26.2, Kotlin 2.3.20, Apple Silicon).

## Why no `.xcodeproj`

Generating a `project.pbxproj` would lock the sample to one Xcode version and rot fast. The Swift sources are the load-bearing artefact — anyone can drop them into a fresh SwiftUI App template. The README walks through that in five steps.

## Sequencing

Independent of the v2 multimodel (#280, #281), compose (#282), threadsafe race-fix (#283), and benchmarks (#284) PRs. Lands against master directly.

## Test plan

- [x] Gradle framework build succeeds for `iosSimulatorArm64`
- [x] `swiftc` smoke compile of all three Swift sources links clean against the framework headers
- [x] Detekt + existing CI gates on the gradle change pass
- [ ] CI matrix exercises `linkReleaseFrameworkIosArm64` (device) + `linkReleaseFrameworkIosX64` (Intel sim)
- [ ] Manual: drop into a SwiftUI App template and confirm the counter UI behaves as described

🤖 Generated with [Claude Code](https://claude.com/claude-code)