### PR TITLE
feat(compose-multimodel): Compose + multimodel integration (PR μ of v3)

### DIFF
--- a/redux-kotlin-compose-multimodel/build.gradle.kts
+++ b/redux-kotlin-compose-multimodel/build.gradle.kts
@@ -1,0 +1,42 @@
+plugins {
+    id("convention.library-mpp-loved")
+    alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.compose.multiplatform)
+    id("convention.publishing-mpp")
+}
+
+val hasAndroidSdk: Boolean = run {
+    val localProps = rootProject.file("local.properties")
+    val hasSdkInLocalProperties = localProps.exists() && localProps.readText().lineSequence().any {
+        it.trim().startsWith("sdk.dir=") && it.substringAfter("sdk.dir=").isNotBlank()
+    }
+    val hasSdkInEnv =
+        !System.getenv("ANDROID_HOME").isNullOrBlank() ||
+            !System.getenv("ANDROID_SDK_ROOT").isNullOrBlank()
+    hasSdkInLocalProperties || hasSdkInEnv
+}
+
+kotlin {
+    if (hasAndroidSdk) {
+        android {
+            namespace = "org.reduxkotlin.compose.multimodel"
+        }
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":redux-kotlin-compose"))
+                api(project(":redux-kotlin-multimodel"))
+                implementation(compose.runtime)
+            }
+        }
+        named("jvmTest") {
+            dependencies {
+                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+                implementation(compose.uiTest)
+                implementation(compose.desktop.currentOs)
+            }
+        }
+    }
+}

--- a/redux-kotlin-compose-multimodel/src/commonMain/kotlin/org/reduxkotlin/compose/multimodel/ModelFieldState.kt
+++ b/redux-kotlin-compose-multimodel/src/commonMain/kotlin/org/reduxkotlin/compose/multimodel/ModelFieldState.kt
@@ -1,0 +1,53 @@
+package org.reduxkotlin.compose.multimodel
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import org.reduxkotlin.Store
+import org.reduxkotlin.compose.selectorState
+import org.reduxkotlin.multimodel.ModelState
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+
+/**
+ * Returns a Compose [State] that always reflects `state.get<M>().property`
+ * on a `Store<ModelState>`. The model type [M] is inferred from the
+ * property reference's receiver — the call site does not name
+ * [ModelState] at all.
+ *
+ * ```
+ * @Composable
+ * fun ProfileHeader(store: Store<ModelState>) {
+ *     val displayName by store.fieldState(LoggedInUserModel::displayName)
+ *     Text("Hello, $displayName")
+ * }
+ * ```
+ *
+ * Same re-sample-inside-DisposableEffect race fix (review B3) as the
+ * single-model bridge — the implementation forwards to
+ * [selectorState] with a `{ state.get<M>().property }` closure, so the
+ * Compose-side lifecycle and granular-side subscription work identically.
+ *
+ * Hidden from Swift via [HiddenFromObjC] (KProperty1 is Kotlin-only)
+ * and not directly callable from raw JS/TS (inline + reified). The
+ * lambda-form [selectorState] covers both non-Kotlin paths.
+ */
+@OptIn(ExperimentalObjCRefinement::class)
+@HiddenFromObjC
+@Composable
+public inline fun <reified M : Any, F> Store<ModelState>.fieldState(
+    property: KProperty1<M, F>,
+): State<F> = selectorState { state -> property.get(state.get<M>()) }
+
+/**
+ * Non-inline [KClass]-keyed alternative to the reified [fieldState]
+ * overload, for callers that hold the model type as a [KClass] rather
+ * than as a compile-time generic (review I11 — inline reified is
+ * erased from generated `.d.ts` for raw JS/TS consumers).
+ */
+@Composable
+public fun <M : Any, F> Store<ModelState>.fieldStateOf(
+    modelClass: KClass<M>,
+    selector: (M) -> F,
+): State<F> = selectorState { state -> selector(state.get(modelClass)) }

--- a/redux-kotlin-compose-multimodel/src/jvmTest/kotlin/org/reduxkotlin/compose/multimodel/ModelFieldStateTest.kt
+++ b/redux-kotlin-compose-multimodel/src/jvmTest/kotlin/org/reduxkotlin/compose/multimodel/ModelFieldStateTest.kt
@@ -1,0 +1,77 @@
+package org.reduxkotlin.compose.multimodel
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.runComposeUiTest
+import org.junit.Test
+import org.reduxkotlin.Store
+import org.reduxkotlin.createStore
+import org.reduxkotlin.multimodel.ModelState
+import org.reduxkotlin.multimodel.combineModelReducers
+import org.reduxkotlin.multimodel.modelReducer
+
+private data class UserModel(val displayName: String = "")
+private data class FeedModel(val items: List<String> = emptyList())
+
+private data class SetDisplayName(val name: String)
+private data class AppendFeed(val item: String)
+
+@OptIn(ExperimentalTestApi::class)
+class ModelFieldStateTest {
+
+    private fun newStore(): Store<ModelState> = createStore(
+        reducer = combineModelReducers(
+            modelReducer<UserModel> { u, a ->
+                if (a is SetDisplayName) u.copy(displayName = a.name) else u
+            },
+            modelReducer<FeedModel> { f, a ->
+                if (a is AppendFeed) f.copy(items = f.items + a.item) else f
+            },
+        ),
+        preloadedState = ModelState.of(UserModel("Ada"), FeedModel(listOf("a"))),
+    )
+
+    @Test
+    fun reified_fieldState_renders_initial_then_updates() = runComposeUiTest {
+        val store = newStore()
+        setContent {
+            val name by store.fieldState(UserModel::displayName)
+            Text(text = "name=$name")
+        }
+        onAllNodesWithText("name=Ada").assertCountEquals(1)
+
+        store.dispatch(SetDisplayName("Babbage"))
+        waitForIdle()
+        onAllNodesWithText("name=Babbage").assertCountEquals(1)
+    }
+
+    @Test
+    fun unrelated_model_change_does_not_update_field_state() = runComposeUiTest {
+        val store = newStore()
+        setContent {
+            val name by store.fieldState(UserModel::displayName)
+            Text(text = "name=$name")
+        }
+        store.dispatch(AppendFeed("b"))
+        waitForIdle()
+        // UserModel didn't move; the binding stays at the initial value.
+        onAllNodesWithText("name=Ada").assertCountEquals(1)
+    }
+
+    @Test
+    fun kclass_fieldStateOf_shim_routes_to_correct_model() = runComposeUiTest {
+        val store = newStore()
+        setContent {
+            val name by store.fieldStateOf(UserModel::class) { it.displayName }
+            Text(text = "kclass=$name")
+        }
+        onAllNodesWithText("kclass=Ada").assertCountEquals(1)
+
+        store.dispatch(SetDisplayName("Babbage"))
+        waitForIdle()
+        onAllNodesWithText("kclass=Babbage").assertCountEquals(1)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ include(
     ":redux-kotlin-multimodel",
     ":redux-kotlin-compose",
     ":redux-kotlin-multimodel-granular",
+    ":redux-kotlin-compose-multimodel",
     ":examples:counter:common",
     ":examples:counter:android",
     ":examples:todos:common",


### PR DESCRIPTION
## Summary

Tiny integration module bridging `redux-kotlin-compose` (PR θ / #282) and `redux-kotlin-multimodel` (PR ζ / #280). Lets a `@Composable` on a `Store<ModelState>` bind to a single field of a single feature model without naming `ModelState` at the call site:

```kotlin
@Composable
fun ProfileHeader(store: Store<ModelState>) {
    val name by store.fieldState(LoggedInUserModel::displayName)
    Text("Hello, \$name")
}
```

## Public surface

- `@Composable inline fun <reified M, F> Store<ModelState>.fieldState(KProperty1<M, F>): State<F>` — reified Kotlin sugar. Hidden from Swift via `@HiddenFromObjC` (`KProperty1` is Kotlin-only).
- `@Composable fun <M, F> Store<ModelState>.fieldStateOf(KClass<M>, (M) -> F): State<F>` — non-inline `KClass` shim for raw JS/TS (review I11; inline+reified is erased from generated `.d.ts`).

Both forward to `selectorState { state -> property.get(state.get<M>()) }`, so the B3 re-sample-inside-DisposableEffect race fix from the compose module carries over unchanged.

## Tests

3 jvm `compose.uiTest` cases:
- `reified_fieldState_renders_initial_then_updates`
- `unrelated_model_change_does_not_update_field_state` (identity preservation)
- `kclass_fieldStateOf_shim_routes_to_correct_model`

## Stacking

Base branch: `add-redux-kotlin-compose-module` (PR θ / #282). The multimodel commit from PR ζ / #280 is cherry-picked on top so the integration can build. After both prerequisites merge to master, retarget/rebase shrinks the diff to just this module's 4 files.

## Test plan

- [x] `:redux-kotlin-compose-multimodel:build` passes (all KMP targets compile)
- [x] `:jvmTest` 3 cases green
- [x] Detekt + `explicitApi` pass
- [ ] CI matrix iOS/macOS native verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)