### PR TITLE
feat(swiftui): redux-kotlin-swiftui SwiftUI bridge (PR ν of v3)

### DIFF
--- a/swift/redux-kotlin-swiftui/README.md
+++ b/swift/redux-kotlin-swiftui/README.md
@@ -1,0 +1,116 @@
+# redux-kotlin-swiftui
+
+SwiftUI helpers for binding a `redux-kotlin-granular`-style store into a
+SwiftUI view tree without writing the lifecycle boilerplate by hand.
+
+Two pieces, both framework-agnostic — they don't import any specific
+Kotlin-generated type. Wire your own framework's symbol names in at the
+call site.
+
+## `ReduxField<F>` — one field, owned by a view
+
+`@StateObject`-friendly wrapper around a single granular subscription.
+`@Published var value: F` updates on every change; the underlying
+subscription is torn down in `deinit`.
+
+```swift
+@StateObject var displayName = ReduxField<String>(
+    initial: store.state.user.displayName,
+    subscribe: { update in
+        let unsub = SubscribeKt.subscribeTo(
+            store,
+            selector: { stateAny in
+                (stateAny as! AppState).user.displayName
+            },
+            triggerOnSubscribe: false,
+            listener: { _, newValue in
+                update(newValue as! String)
+            }
+        )
+        return { _ = unsub() }
+    }
+)
+
+var body: some View {
+    Text("Hello, \(displayName.value)")
+}
+```
+
+The `update` sink trampolines onto `@MainActor` before mutating
+`@Published value`, so SwiftUI observes the change on the right thread
+regardless of which thread the store dispatched on.
+
+## `.subscribeReduxFields { … }` — N fields tied to a view subtree
+
+`ViewModifier` that installs a `subscribeFields` block at `onAppear`
+and tears down the returned unsubscribe at `onDisappear`. Use this when
+a single screen watches several fields and you want to keep them all
+behind one underlying `store.subscribe`.
+
+```swift
+struct ProfileScreen: View {
+    let store: TypedStore
+    @State private var displayName: String = ""
+    @State private var avatar: String?
+
+    var body: some View {
+        VStack {
+            Text(displayName)
+            AsyncImage(url: avatar.map(URL.init(string:)) ?? nil)
+        }
+        .subscribeReduxFields {
+            SubscribeFieldsKt.subscribeFields(store) { scope in
+                scope.on(
+                    selector: { ($0 as! AppState).user.displayName },
+                    triggerOnSubscribe: true,
+                    listener: { _, new in
+                        DispatchQueue.main.async {
+                            self.displayName = new as! String
+                        }
+                    }
+                )
+                scope.on(
+                    selector: { ($0 as! AppState).user.avatar },
+                    triggerOnSubscribe: true,
+                    listener: { _, new in
+                        DispatchQueue.main.async {
+                            self.avatar = new as? String
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+```
+
+The `subscribe` closure is called once per `onAppear`. If the view
+re-appears after disappearing, a new subscription is installed and a
+new unsubscribe handle is stored. The internal handle is reference-
+boxed so SwiftUI's `@State` diff doesn't churn it.
+
+## Installation
+
+This module ships as **source files only**, not as a Swift Package.
+The two `.swift` files have no external dependencies beyond `SwiftUI`
+and `Foundation`. Drop them into your iOS / macOS / watchOS target
+and import where needed.
+
+A proper SPM package + binary `SharedKotlin.xcframework` distribution
+is on the roadmap once `redux-kotlin` core publishes a hosted
+`xcframework` artefact.
+
+## Scope and limitations
+
+- **No automatic generics**: Swift sees the Kotlin `Store<S>` as
+  `<Framework>TypedStore` with generic erased to `Any?`, so selectors
+  always require `as! YourState` downcasts. This is a Kotlin/Native
+  interop limitation (review B5), not specific to these helpers.
+- **No `KProperty1` references from Swift**: the granular module's
+  property-reference overloads are `@HiddenFromObjC` for that reason.
+  Use the lambda-selector form from Swift.
+- **No multi-model sugar yet**: a `subscribeReduxModelField` shim that
+  consumes the `redux-kotlin-multimodel-granular` `subscribeToModel`
+  shim is straightforward but deferred until a real consumer needs it.
+- **Combine `Publisher`s**: see the sibling `redux-kotlin-combine`
+  module for `AnyPublisher<F, Never>`-shaped bindings.

--- a/swift/redux-kotlin-swiftui/Sources/ReduxField.swift
+++ b/swift/redux-kotlin-swiftui/Sources/ReduxField.swift
@@ -1,0 +1,68 @@
+import Foundation
+import SwiftUI
+
+/// Lightweight `ObservableObject` that wraps a single granular-subscription
+/// field. Use as a `@StateObject` (owned) or `@ObservedObject` (passed in)
+/// inside a SwiftUI view to bind the published `value` into the view tree.
+///
+/// The bridge is intentionally framework-agnostic: this class doesn't
+/// import any Kotlin-generated type. The caller supplies a `subscribe`
+/// closure that hooks into whatever Redux store implementation they're
+/// using (typically `redux-kotlin-granular`'s `subscribeTo` overload on
+/// `Store<S>` from the Kotlin framework) and returns an unsubscribe
+/// callback. ``ReduxField`` invokes the unsubscribe in `deinit`.
+///
+/// Typical wiring against a `redux-kotlin-granular`-emitting framework:
+///
+/// ```swift
+/// @StateObject var displayName = ReduxField<String>(
+///     initial: store.state.user.displayName,
+///     subscribe: { update in
+///         let unsub = SubscribeKt.subscribeTo(
+///             store,
+///             selector: { stateAny in
+///                 (stateAny as! AppState).user.displayName
+///             },
+///             triggerOnSubscribe: false,
+///             listener: { _, newValue in
+///                 update(newValue as! String)
+///             }
+///         )
+///         return { _ = unsub() }
+///     }
+/// )
+/// ```
+@MainActor
+public final class ReduxField<F>: ObservableObject {
+
+    @Published public private(set) var value: F
+
+    private var unsubscribeHandle: (() -> Void)?
+
+    /// Builds a field binding.
+    ///
+    /// - Parameters:
+    ///   - initial: Initial value, typically read off the store's
+    ///     `state.field` synchronously before the subscription is installed.
+    ///   - subscribe: Closure that installs the underlying subscription.
+    ///     It receives a `(F) -> Void` update sink to call with every new
+    ///     value (any thread); it must return an unsubscribe callback to
+    ///     be invoked when this `ReduxField` is deinitialised. The update
+    ///     sink trampolines onto the main actor before mutating `value`,
+    ///     so SwiftUI observes mutations on the right thread.
+    public init(
+        initial: F,
+        subscribe: (@escaping (F) -> Void) -> (() -> Void)
+    ) {
+        self.value = initial
+        self.unsubscribeHandle = subscribe { [weak self] newValue in
+            Task { @MainActor in
+                self?.value = newValue
+            }
+        }
+    }
+
+    deinit {
+        unsubscribeHandle?()
+    }
+}

--- a/swift/redux-kotlin-swiftui/Sources/SubscribeReduxFieldsModifier.swift
+++ b/swift/redux-kotlin-swiftui/Sources/SubscribeReduxFieldsModifier.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// `ViewModifier` that ties a Redux `subscribeFields`-style subscription
+/// to a SwiftUI view's lifecycle. The subscription is installed at
+/// `onAppear` and torn down at `onDisappear`, so the view is entirely
+/// responsible for keeping the Redux side of the binding alive — there
+/// is no manual `init`/`deinit` ceremony in the call site.
+///
+/// Companion to [ReduxField]. Where `ReduxField` owns one binding for the
+/// lifetime of the parent `View`, this modifier owns N bindings for the
+/// lifetime of the modified subtree — typically one
+/// `subscribeFields { scope in scope.on(…); scope.on(…) }` block backed
+/// by a single underlying `store.subscribe`.
+///
+/// Usage against a `redux-kotlin-granular`-emitting framework:
+///
+/// ```swift
+/// struct ProfileScreen: View {
+///     let store: TypedStore
+///     @State private var displayName: String = ""
+///     @State private var avatar: String?
+///
+///     var body: some View {
+///         VStack {
+///             Text(displayName)
+///             AsyncImage(url: avatar.map(URL.init(string:)) ?? nil)
+///         }
+///         .subscribeReduxFields {
+///             SubscribeFieldsKt.subscribeFields(store) { scope in
+///                 scope.on(
+///                     selector: { ($0 as! AppState).user.displayName },
+///                     triggerOnSubscribe: true,
+///                     listener: { _, new in
+///                         DispatchQueue.main.async {
+///                             self.displayName = new as! String
+///                         }
+///                     }
+///                 )
+///                 scope.on(
+///                     selector: { ($0 as! AppState).user.avatar },
+///                     triggerOnSubscribe: true,
+///                     listener: { _, new in
+///                         DispatchQueue.main.async {
+///                             self.avatar = new as? String
+///                         }
+///                     }
+///                 )
+///             }
+///         }
+///     }
+/// }
+/// ```
+public struct SubscribeReduxFieldsModifier: ViewModifier {
+
+    private let subscribe: () -> (() -> Void)
+    @State private var unsubscribe: UnsubscribeBox = UnsubscribeBox()
+
+    public init(subscribe: @escaping () -> (() -> Void)) {
+        self.subscribe = subscribe
+    }
+
+    public func body(content: Content) -> some View {
+        content
+            .onAppear {
+                if unsubscribe.handle == nil {
+                    unsubscribe.handle = subscribe()
+                }
+            }
+            .onDisappear {
+                unsubscribe.handle?()
+                unsubscribe.handle = nil
+            }
+    }
+}
+
+/// Boxed-mutable holder so the modifier can replace the unsubscribe
+/// handle without re-creating its `@State` cell. `@State` requires
+/// `Equatable`-ish value semantics, but the handle is reference-typed
+/// (a closure); boxing inside a `class` sidesteps the diff check.
+private final class UnsubscribeBox {
+    var handle: (() -> Void)?
+}
+
+extension View {
+    /// Attaches a Redux `subscribeFields` subscription to this view's
+    /// lifecycle. See [SubscribeReduxFieldsModifier].
+    public func subscribeReduxFields(
+        _ subscribe: @escaping () -> (() -> Void)
+    ) -> some View {
+        modifier(SubscribeReduxFieldsModifier(subscribe: subscribe))
+    }
+}


### PR DESCRIPTION
## Summary

Resolves adversarial-review item **I9** — no SwiftUI lifecycle helpers had shipped for the granular subscription API. Two source-only Swift files under `swift/redux-kotlin-swiftui/Sources/` provide the missing piece without requiring users to manage `init`/`deinit` subscription teardown by hand.

## What ships

| Symbol | Purpose |
|---|---|
| `ReduxField<F>` (`ObservableObject`) | One field, owned by the view. `@StateObject` it; bind `field.value`. Subscription installed at `init`, torn down at `deinit`. Update sink trampolines onto the main actor. |
| `View.subscribeReduxFields { … }` (`ViewModifier`) | N fields tied to a view subtree's lifecycle. `onAppear` installs the subscription, `onDisappear` tears it down. One ViewModifier owns N bindings behind a single underlying `store.subscribe`. |

## Design — framework-agnostic

Neither file imports any Kotlin-generated type. The user supplies a `subscribe` closure that wires their specific framework's symbols at the call site (per-app framework names: `SharedCounter`, `SharedKotlin`, etc. all vary). This avoids the symbol-name-explosion problem that ships SwiftUI bridges for KMP projects always run into.

## Smoke test

```
xcrun -sdk iphonesimulator swiftc \
  -emit-module -emit-library \
  -target arm64-apple-ios15.0-simulator \
  -o /tmp/ReduxKotlinSwiftUI \
  swift/redux-kotlin-swiftui/Sources/*.swift
```

Compiles cleanly with no diagnostics.

## Distribution

Source files only — no `Package.swift`, no XCFramework. The two `.swift` files have no external dependencies beyond `SwiftUI` and `Foundation`. Drop them into your iOS / macOS / watchOS target. SPM + binary `xcframework` distribution waits on the redux-kotlin core publishing a hosted xcframework artefact.

## Sequencing

Independent of every other v2/v3 PR — depends on no Kotlin module at all (the Swift code is generic over the user's framework). Lands against master directly.

## Test plan

- [x] `swiftc` compile against iPhone simulator SDK succeeds
- [x] README example call sites trace through real `redux-kotlin-granular` Swift bindings
- [ ] Future: a sample app exercising both `ReduxField` and `.subscribeReduxFields` (would supersede a chunk of `examples/counter/ios`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)