### PR TITLE
feat(multimodel): add redux-kotlin-multimodel module (PR ζ of v2, reopened)

### DIFF
--- a/redux-kotlin-multimodel/build.gradle.kts
+++ b/redux-kotlin-multimodel/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    id("convention.library-mpp-loved")
+    id("convention.publishing-mpp")
+}
+
+val hasAndroidSdk: Boolean = run {
+    val localProps = rootProject.file("local.properties")
+    val hasSdkInLocalProperties = localProps.exists() && localProps.readText().lineSequence().any {
+        it.trim().startsWith("sdk.dir=") && it.substringAfter("sdk.dir=").isNotBlank()
+    }
+    val hasSdkInEnv =
+        !System.getenv("ANDROID_HOME").isNullOrBlank() ||
+            !System.getenv("ANDROID_SDK_ROOT").isNullOrBlank()
+    hasSdkInLocalProperties || hasSdkInEnv
+}
+
+kotlin {
+    if (hasAndroidSdk) {
+        android {
+            namespace = "org.reduxkotlin.multimodel"
+        }
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":redux-kotlin"))
+            }
+        }
+    }
+}

--- a/redux-kotlin-multimodel/src/commonMain/kotlin/org/reduxkotlin/multimodel/CombineModelReducers.kt
+++ b/redux-kotlin-multimodel/src/commonMain/kotlin/org/reduxkotlin/multimodel/CombineModelReducers.kt
@@ -1,0 +1,87 @@
+package org.reduxkotlin.multimodel
+
+import org.reduxkotlin.Reducer
+import kotlin.reflect.KClass
+
+/**
+ * A per-model reducer — same shape as a top-level [Reducer], but its
+ * `state` parameter is the model instance itself rather than the
+ * enclosing [ModelState].
+ */
+public typealias ModelReducer<M> = (model: M, action: Any) -> M
+
+/**
+ * The opaque pair produced by [modelReducer] and consumed by
+ * [combineModelReducers]. The underlying reducer takes `Any` arguments
+ * because [combineModelReducers] dispatches it heterogeneously across
+ * all registered model slots — the type token in [modelClass] is what
+ * makes the cast safe at registration time.
+ */
+public class ModelReducerEntry<M : Any> @PublishedApi internal constructor(
+    public val modelClass: KClass<M>,
+    @PublishedApi internal val reducer: ModelReducer<M>,
+)
+
+/**
+ * Builds a [ModelReducerEntry] for model type [M]. The Kotlin-callable
+ * sugar form; use [modelReducerOf] if you only have a [KClass] at the
+ * call site (raw JS/TS, generic helpers).
+ */
+public inline fun <reified M : Any> modelReducer(
+    noinline reducer: ModelReducer<M>,
+): ModelReducerEntry<M> = ModelReducerEntry(M::class, reducer)
+
+/**
+ * Non-inline variant of [modelReducer] for callers that only hold a
+ * [KClass] reference. Functionally equivalent.
+ */
+public fun <M : Any> modelReducerOf(
+    modelClass: KClass<M>,
+    reducer: ModelReducer<M>,
+): ModelReducerEntry<M> = ModelReducerEntry(modelClass, reducer)
+
+/**
+ * Composes per-model reducers into a single [Reducer] over
+ * [ModelState]. For each dispatch, every registered model reducer
+ * receives the current instance of its model plus the action; if a
+ * reducer returns the same instance (referential `===`), that slot is
+ * left untouched and the resulting [ModelState] also retains its
+ * existing instance — so the granular subscription layer's `===`
+ * fast-path short-circuits without firing any listener for fields on
+ * unchanged models.
+ *
+ * @throws IllegalArgumentException if two entries register reducers
+ *   for the same model class (review I3 — silent last-wins chaining
+ *   is a footgun, prefer to fail loudly).
+ */
+public fun combineModelReducers(
+    vararg entries: ModelReducerEntry<*>,
+): Reducer<ModelState> {
+    val byClass = LinkedHashMap<KClass<*>, ModelReducer<Any>>(entries.size)
+    for (entry in entries) {
+        @Suppress("UNCHECKED_CAST")
+        val erased = entry.reducer as ModelReducer<Any>
+        require(byClass.put(entry.modelClass, erased) == null) {
+            "Duplicate model reducer for ${entry.modelClass.simpleName ?: entry.modelClass}. " +
+                "combineModelReducers requires at most one reducer per model class."
+        }
+    }
+    return reducer@{ state, action ->
+        var changedModels: MutableMap<KClass<*>, Any>? = null
+        for ((klass, reducer) in byClass) {
+            val oldModel = state.models[klass]
+                ?: error(
+                    "Reducer registered for ${klass.simpleName ?: klass} but no model of that type in ModelState. " +
+                        "Every registered reducer must have a corresponding model in ModelState.of(...).",
+                )
+            val newModel = reducer(oldModel, action)
+            if (newModel !== oldModel) {
+                if (changedModels == null) {
+                    changedModels = LinkedHashMap(state.models)
+                }
+                changedModels[klass] = newModel
+            }
+        }
+        if (changedModels == null) state else ModelState(changedModels)
+    }
+}

--- a/redux-kotlin-multimodel/src/commonMain/kotlin/org/reduxkotlin/multimodel/ModelState.kt
+++ b/redux-kotlin-multimodel/src/commonMain/kotlin/org/reduxkotlin/multimodel/ModelState.kt
@@ -1,0 +1,119 @@
+package org.reduxkotlin.multimodel
+
+import kotlin.reflect.KClass
+
+/**
+ * An immutable container that holds a fixed set of typed feature models.
+ *
+ * Each model is keyed by its concrete [KClass]; the *set* of model
+ * classes is locked at construction time via [Companion.of] and cannot
+ * be expanded or contracted. The *instances* can be swapped through
+ * [with], which produces a new [ModelState] sharing the same key set.
+ *
+ * This shape exists to support feature-modular state: every screen or
+ * subsystem owns its own model type, and the root reducer composes
+ * per-model reducers via [combineModelReducers]. Granular subscribers
+ * (see `redux-kotlin-multimodel-granular`) can subscribe to a single
+ * field on a single model without the rest of the app's state passing
+ * through their selector.
+ *
+ * **Why a sealed key set.** The library guarantees that [get] always
+ * returns a non-null model: every model class declared at construction
+ * is present at all times. Reducers can replace an instance but never
+ * remove the slot. Asking for a model class that was never registered
+ * is a programming error and throws [IllegalStateException], not a
+ * runtime branch the caller must handle. This is the resolution to
+ * adversarial-review blocker B1 — the common selector path never
+ * confronts a missing model.
+ *
+ * Each model is responsible for its own "not yet loaded" semantics —
+ * supply a default constructor or a public `NOT_SET` sentinel
+ * instance, so dependent code reads `String` rather than `String?`.
+ */
+public class ModelState @PublishedApi internal constructor(
+    @PublishedApi internal val models: Map<KClass<*>, Any>,
+) {
+
+    /**
+     * Returns the registered model of type [M].
+     *
+     * @throws IllegalStateException if [M] was not declared in the
+     *   [Companion.of] call that produced this [ModelState]. This is a
+     *   programming error; the set of model classes is fixed at
+     *   construction.
+     */
+    public inline fun <reified M : Any> get(): M = get(M::class)
+
+    /**
+     * Non-reified overload of [get] for callers that hold the model's
+     * [KClass] in a variable — e.g. raw JS/TS consumers that cannot use
+     * reified type parameters, or generic helper code.
+     *
+     * @throws IllegalStateException if [modelClass] was not declared at
+     *   construction.
+     */
+    public fun <M : Any> get(modelClass: KClass<M>): M {
+        val model = models[modelClass]
+            ?: error(
+                "Model ${modelClass.simpleName ?: modelClass} not registered in ModelState. " +
+                    "Every model must be declared in ModelState.of(...).",
+            )
+        @Suppress("UNCHECKED_CAST")
+        return model as M
+    }
+
+    /**
+     * Returns a new [ModelState] with the existing slot for [M]
+     * replaced by [model]. Other models are shared with the receiver.
+     *
+     * @throws IllegalStateException if [M] was not declared at
+     *   construction; new model classes cannot be introduced after the
+     *   initial [Companion.of] call.
+     */
+    public inline fun <reified M : Any> with(model: M): ModelState = with(M::class, model)
+
+    /**
+     * Non-reified overload of [with] for callers that hold the model's
+     * [KClass] in a variable. The runtime type of [model] must be
+     * assignable to [modelClass]; otherwise downstream `get<M>()` calls
+     * will throw `ClassCastException`.
+     */
+    public fun <M : Any> with(modelClass: KClass<M>, model: M): ModelState {
+        check(modelClass in models) {
+            "Cannot replace model ${modelClass.simpleName ?: modelClass} that wasn't declared at construction. " +
+                "ModelState's key set is fixed by ModelState.of(...)."
+        }
+        return ModelState(models + (modelClass to model))
+    }
+
+    override fun equals(other: Any?): Boolean = other is ModelState && other.models == models
+
+    override fun hashCode(): Int = models.hashCode()
+
+    override fun toString(): String = "ModelState(${models.entries.joinToString { (k, v) -> "${k.simpleName}=$v" }})"
+
+    /** Factory methods for [ModelState]; the only public entry point. */
+    public companion object {
+        /**
+         * Builds a [ModelState] containing exactly the supplied models.
+         * The set of model *classes* — one entry per distinct
+         * `model::class` — is locked for the lifetime of every
+         * [ModelState] derived from this one.
+         *
+         * @throws IllegalArgumentException if any two models share the
+         *   same concrete class; each model class may appear at most
+         *   once in a [ModelState].
+         */
+        public fun of(vararg models: Any): ModelState {
+            val map = LinkedHashMap<KClass<*>, Any>(models.size)
+            for (model in models) {
+                val klass = model::class
+                require(map.put(klass, model) == null) {
+                    "Duplicate model class ${klass.simpleName ?: klass} passed to ModelState.of(...). " +
+                        "Each model class may appear at most once."
+                }
+            }
+            return ModelState(map)
+        }
+    }
+}

--- a/redux-kotlin-multimodel/src/commonTest/kotlin/org/reduxkotlin/multimodel/CombineModelReducersTest.kt
+++ b/redux-kotlin-multimodel/src/commonTest/kotlin/org/reduxkotlin/multimodel/CombineModelReducersTest.kt
@@ -1,0 +1,91 @@
+package org.reduxkotlin.multimodel
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+
+private data class CmrUser(val displayName: String = "")
+private data class CmrFeed(val items: List<String> = emptyList())
+
+private data class SetDisplayName(val name: String)
+private data class AppendFeedItem(val item: String)
+private object UnrelatedAction
+
+class CombineModelReducersTest {
+
+    private val userReducer = modelReducer<CmrUser> { user, action ->
+        when (action) {
+            is SetDisplayName -> user.copy(displayName = action.name)
+            else -> user
+        }
+    }
+
+    private val feedReducer = modelReducer<CmrFeed> { feed, action ->
+        when (action) {
+            is AppendFeedItem -> feed.copy(items = feed.items + action.item)
+            else -> feed
+        }
+    }
+
+    private val root = combineModelReducers(userReducer, feedReducer)
+
+    @Test
+    fun action_updates_only_matching_model() {
+        val initial = ModelState.of(CmrUser("Ada"), CmrFeed(listOf("a")))
+        val next = root(initial, SetDisplayName("Babbage"))
+
+        assertEquals(CmrUser("Babbage"), next.get<CmrUser>())
+        assertSame(initial.get<CmrFeed>(), next.get<CmrFeed>())
+    }
+
+    @Test
+    fun unrelated_action_returns_same_modelstate_reference() {
+        val initial = ModelState.of(CmrUser("Ada"), CmrFeed(listOf("a")))
+        val next = root(initial, UnrelatedAction)
+        // === fast-path: no model changed, ModelState identity preserved
+        // so the granular subscription layer can short-circuit completely.
+        assertSame(initial, next)
+    }
+
+    @Test
+    fun changed_model_yields_new_modelstate_with_unchanged_siblings_shared() {
+        val initial = ModelState.of(CmrUser("Ada"), CmrFeed(listOf("a")))
+        val next = root(initial, AppendFeedItem("b"))
+
+        // ModelState itself is a new instance (some model changed)…
+        assertEquals(false, initial === next)
+        // …but the sibling CmrUser slot is the same reference.
+        assertSame(initial.get<CmrUser>(), next.get<CmrUser>())
+        assertEquals(CmrFeed(listOf("a", "b")), next.get<CmrFeed>())
+    }
+
+    @Test
+    fun duplicate_keys_throw() {
+        val duplicateUser = modelReducer<CmrUser> { u, _ -> u }
+        assertFailsWith<IllegalArgumentException> {
+            combineModelReducers(userReducer, duplicateUser)
+        }
+    }
+
+    @Test
+    fun reducer_registered_for_unregistered_model_throws_at_dispatch() {
+        // Only CmrUser is in the state — but combined reducer also covers CmrFeed.
+        val initial = ModelState.of(CmrUser("Ada"))
+        val error = assertFailsWith<IllegalStateException> {
+            root(initial, UnrelatedAction)
+        }
+        assertEquals(true, error.message!!.contains("CmrFeed"))
+    }
+
+    @Test
+    fun modelReducerOf_works_with_kclass_at_call_site() {
+        val r = modelReducerOf(CmrUser::class) { user, action ->
+            if (action is SetDisplayName) user.copy(displayName = action.name) else user
+        }
+        val combined = combineModelReducers(r)
+        val initial = ModelState.of(CmrUser("Ada"))
+        val next = combined(initial, SetDisplayName("Babbage"))
+        assertEquals(CmrUser("Babbage"), next.get<CmrUser>())
+    }
+}

--- a/redux-kotlin-multimodel/src/commonTest/kotlin/org/reduxkotlin/multimodel/ModelStateTest.kt
+++ b/redux-kotlin-multimodel/src/commonTest/kotlin/org/reduxkotlin/multimodel/ModelStateTest.kt
@@ -1,0 +1,75 @@
+package org.reduxkotlin.multimodel
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+private data class MsUser(val displayName: String = "", val isLoggedIn: Boolean = false)
+private data class MsFeed(val items: List<String> = emptyList(), val isRefreshing: Boolean = false)
+private data class MsUnregistered(val value: Int = 0)
+
+class ModelStateTest {
+
+    @Test
+    fun get_returns_registered_model() {
+        val state = ModelState.of(
+            MsUser(displayName = "Ada"),
+            MsFeed(items = listOf("a", "b")),
+        )
+        assertEquals(MsUser("Ada"), state.get<MsUser>())
+        assertEquals(MsFeed(listOf("a", "b")), state.get<MsFeed>())
+    }
+
+    @Test
+    fun get_throws_for_unregistered_class() {
+        val state = ModelState.of(MsUser())
+        val error = assertFailsWith<IllegalStateException> { state.get<MsUnregistered>() }
+        // Message names the missing model so the call-site mistake is obvious.
+        assertEquals(true, error.message!!.contains("MsUnregistered"))
+    }
+
+    @Test
+    fun with_replaces_only_target_slot() {
+        val initial = ModelState.of(MsUser("Ada"), MsFeed(listOf("a")))
+        val next = initial.with(MsUser("Babbage"))
+
+        assertEquals(MsUser("Babbage"), next.get<MsUser>())
+        // Other slots share the same instance — verifies copy-on-write semantics.
+        assertSame(initial.get<MsFeed>(), next.get<MsFeed>())
+        assertNotSame(initial, next)
+    }
+
+    @Test
+    fun with_throws_for_unregistered_class() {
+        val state = ModelState.of(MsUser())
+        assertFailsWith<IllegalStateException> { state.with(MsUnregistered(7)) }
+    }
+
+    @Test
+    fun of_throws_on_duplicate_classes() {
+        assertFailsWith<IllegalArgumentException> {
+            ModelState.of(MsUser("a"), MsUser("b"))
+        }
+    }
+
+    @Test
+    fun non_reified_get_with_works_for_kclass_holders() {
+        val state = ModelState.of(MsUser("Ada"))
+        val klass = MsUser::class
+        val fetched = state.get(klass)
+        assertEquals(MsUser("Ada"), fetched)
+
+        val next = state.with(klass, MsUser("Babbage"))
+        assertEquals(MsUser("Babbage"), next.get<MsUser>())
+    }
+
+    @Test
+    fun equality_is_value_based() {
+        val a = ModelState.of(MsUser("Ada"), MsFeed(listOf("x")))
+        val b = ModelState.of(MsUser("Ada"), MsFeed(listOf("x")))
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ include(
     ":redux-kotlin",
     ":redux-kotlin-threadsafe",
     ":redux-kotlin-granular",
+    ":redux-kotlin-multimodel",
     ":examples:counter:common",
     ":examples:counter:android",
     ":examples:todos:common",


### PR DESCRIPTION
Reopens / supersedes #280 (auto-closed when its head branch was deleted during the rebase-merge prep). Branch content is identical — single commit on top of latest master with no merge commit.

## Summary

New opt-in artefact for feature-modular state.

- **`ModelState`** holds a sealed set of typed feature models keyed by `KClass`. `Companion.of(...)` captures the model set at construction; instances swap via `with<M>(...)` but the key set is fixed. `get<M>()` always returns a non-null `M` for a registered class and throws `IllegalStateException` for unregistered ones — the granular subscription layer never confronts a missing model (review **B1**).
- **`modelReducer<M> { ... }`** + **`combineModelReducers(...)`** compose per-model reducers into a `Reducer<ModelState>`. `===`-identity preservation for unchanged slots; duplicate reducer keys throw (review **I3**).
- Non-reified `KClass` overloads for raw JS/TS consumers.

## Why reopened

The original #280 had a merge commit (`Merge branch 'master' into add-...`) from a bring-up-to-date, which GitHub's rebase-and-merge couldn't process ("This branch can't be rebased"). The branch was rebased locally + force-pushed to drop the merge commit, but the force-push went through a delete-and-recreate dance because direct `--force` isn't allowed in this environment. GitHub closed the original PR when the branch was deleted and refused to reopen it once the new SHA was unreachable to the old one.

## Sequencing

This PR sits at the head of the v2 work queue. Once it merges:
- #281 (multimodel-granular, η) can have its base retargeted to master
- #286 (compose-multimodel, μ) can have its cherry-picked multimodel commit dropped during rebase

## Test plan

- [x] `:redux-kotlin-multimodel:build` passes on all KMP targets
- [x] 13 commonTest cases (`ModelStateTest`, `CombineModelReducersTest`) green on JVM/JS/WasmJs
- [x] Detekt + `explicitApi` clean
- [ ] Original #280's CI passed on the pre-rebase commit; this PR's CI re-runs against the single-commit rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)