### PR TITLE
build: bump Gradle 9.4.1 → 9.5.1, AGP 9.1.0 → 9.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-android-gradle-plugin = "9.1.0"
+android-gradle-plugin = "9.2.0"
 androidx-activity = "1.10.1"
 androidx-appcompat = "1.7.1"
 androidx-constraintlayout = "2.2.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

- Gradle wrapper 9.4.1 → **9.5.1** (released 2026-05-14, latest patch on 9.5).
- AGP 9.1.0 → **9.2.0** (released April 2026, current stable on 9.x).
- Adds `distributionSha256Sum` to the wrapper for tamper-resistant downloads.

Both bumps are drop-in for this module set — no source changes needed. Gradle 9.5.x tests as compatible with AGP 9.0–9.2.0-alpha05; min Gradle for AGP 9.x is 9.1.0, so we're well above the floor.

## Test plan

- [x] `./gradlew --version` resolves to 9.5.1 with checksum match
- [ ] CI green on JDK 17 + JDK 21
- [ ] Android sample assembleDebug passes
- [ ] Gradle 8 trial lane (non-blocking) still runs

## Context for upcoming Gradle 10

Gradle 10 is targeted for 2026 (Provider API migration). No GA/preview yet. Once it lands it will require AGP 10, and several of our build-conventions plugins will need eager → lazy Provider API rewrites. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)