### PR TITLE
build: migrate detekt 1.23.8 → 2.0.0-alpha.3

### DIFF
--- a/build-conventions/build.gradle.kts
+++ b/build-conventions/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 dependencies {
     implementation(libs.android.gradle.plugin)
     implementation(libs.kotlin.gradle.plugin)
-    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${libs.versions.detekt.get()}")
+    implementation("dev.detekt:detekt-gradle-plugin:${libs.versions.detekt.get()}")
     implementation(libs.gradle.nexus.publish.plugin)
     implementation(libs.dokka.gradle.plugin)
 }

--- a/build-conventions/src/main/kotlin/convention.common.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.common.gradle.kts
@@ -24,7 +24,7 @@ printlnCI(
   hostIsLinux: ${HostManager.hostIsLinux}
   hostIsMac: ${HostManager.hostIsMac}
   hostIsMingw: ${HostManager.hostIsMingw}
-    """.trimIndent()
+    """.trimIndent(),
 )
 
 idea {

--- a/build-conventions/src/main/kotlin/convention.detekt.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.detekt.gradle.kts
@@ -1,11 +1,11 @@
-import io.gitlab.arturbosch.detekt.Detekt
+import dev.detekt.gradle.Detekt
 
 plugins {
-    id("io.gitlab.arturbosch.detekt")
+    id("dev.detekt")
 }
 
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.8")
+    detektPlugins("dev.detekt:detekt-rules-ktlint-wrapper:2.0.0-alpha.3")
 }
 
 detekt {
@@ -29,12 +29,13 @@ tasks {
             reports {
                 // observe findings in your browser with structure and code snippets
                 html.required.set(true)
-                // checkstyle like format mainly for integrations like Jenkins
-                xml.required.set(true)
-                // similar to the console output, contains issue signature to manually edit baseline files
-                txt.required.set(true)
-                // standardized SARIF format (https://sarifweb.azurewebsites.net/) to support integrations with Github Code Scanning
+                // checkstyle-like format mainly for Jenkins-style integrations
+                // (renamed from `xml` in detekt 2.0).
+                checkstyle.required.set(true)
+                // standardized SARIF format (https://sarifweb.azurewebsites.net/) for GitHub Code Scanning.
                 sarif.required.set(true)
+                // markdown report (renamed from `md` in detekt 2.0).
+                markdown.required.set(true)
             }
             include("**/*.kt", "**/*.kts")
             // `.claude/` holds Claude Code harness worktrees / caches; never

--- a/build-conventions/src/main/kotlin/convention.git-hooks.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.git-hooks.gradle.kts
@@ -8,27 +8,29 @@
 
 val hooks = mapOf(
     "pre-commit" to "detektAll --auto-correct",
-    "pre-push" to "detektAll"
+    "pre-push" to "detektAll",
 )
 
 fun hookBody(gradleArgs: String): String = """
     |#!/usr/bin/env sh
     |# Managed by convention.git-hooks. Do not edit by hand.
     |exec "${'$'}(git rev-parse --show-toplevel)/gradlew" $gradleArgs
-    |""".trimMargin()
+    |
+""".trimMargin()
 
-fun resolveHooksDir(): java.io.File? {
-    return try {
-        val process = ProcessBuilder("git", "rev-parse", "--git-path", "hooks")
-            .directory(layout.projectDirectory.asFile)
-            .redirectErrorStream(true)
-            .start()
-        val rel = process.inputStream.bufferedReader().readText().trim()
-        if (process.waitFor() != 0 || rel.isEmpty()) null
-        else layout.projectDirectory.asFile.resolve(rel)
-    } catch (_: Exception) {
+fun resolveHooksDir(): java.io.File? = try {
+    val process = ProcessBuilder("git", "rev-parse", "--git-path", "hooks")
+        .directory(layout.projectDirectory.asFile)
+        .redirectErrorStream(true)
+        .start()
+    val rel = process.inputStream.bufferedReader().readText().trim()
+    if (process.waitFor() != 0 || rel.isEmpty()) {
         null
+    } else {
+        layout.projectDirectory.asFile.resolve(rel)
     }
+} catch (_: Exception) {
+    null
 }
 
 fun writeHooks(dir: java.io.File) {

--- a/build-conventions/src/main/kotlin/convention.publishing.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.publishing.gradle.kts
@@ -33,7 +33,7 @@ tasks {
                 "Build-Jdk" to System.getProperty("java.version"),
                 "Implementation-Version" to project.version,
                 "Created-By" to "${GradleVersion.current()}",
-                "Created-From" to "${Git.headCommitHash}"
+                "Created-From" to "${Git.headCommitHash}",
             )
         }
     }

--- a/build-conventions/src/main/kotlin/util/KotlinTargetDetails.kt
+++ b/build-conventions/src/main/kotlin/util/KotlinTargetDetails.kt
@@ -8,10 +8,12 @@ val KonanTarget.buildHost: Family
         Family.OSX,
         Family.IOS,
         Family.TVOS,
-        Family.WATCHOS -> Family.OSX
+        Family.WATCHOS,
+        -> Family.OSX
 
         Family.ANDROID,
-        Family.LINUX -> Family.LINUX
+        Family.LINUX,
+        -> Family.LINUX
 
         Family.MINGW -> Family.MINGW
     }

--- a/examples/counter/android/src/main/java/org/reduxkotlin/example/counter/MainActivity.kt
+++ b/examples/counter/android/src/main/java/org/reduxkotlin/example/counter/MainActivity.kt
@@ -59,7 +59,7 @@ class MainActivity : AppCompatActivity() {
             {
                 store.dispatch(Increment())
             },
-            1000
+            1000,
         )
     }
 }

--- a/examples/todos/android/src/main/java/org/reduxkotlin/example/todos/MainActivity.kt
+++ b/examples/todos/android/src/main/java/org/reduxkotlin/example/todos/MainActivity.kt
@@ -57,24 +57,23 @@ class MainActivity : AppCompatActivity() {
         setFilterButtons(state.visibilityFilter)
     }
 
-    private fun setFilterButtons(visibilityFilter: VisibilityFilter) =
-        when (visibilityFilter) {
-            VisibilityFilter.SHOW_ALL -> {
-                binding.btnSelectAll.isSelected = true
-                binding.btnActive.isSelected = false
-                binding.btnCompleted.isSelected = false
-            }
-
-            VisibilityFilter.SHOW_ACTIVE -> {
-                binding.btnActive.isSelected = true
-                binding.btnSelectAll.isSelected = false
-                binding.btnCompleted.isSelected = false
-            }
-
-            VisibilityFilter.SHOW_COMPLETED -> {
-                binding.btnCompleted.isSelected = true
-                binding.btnSelectAll.isSelected = false
-                binding.btnActive.isSelected = false
-            }
+    private fun setFilterButtons(visibilityFilter: VisibilityFilter) = when (visibilityFilter) {
+        VisibilityFilter.SHOW_ALL -> {
+            binding.btnSelectAll.isSelected = true
+            binding.btnActive.isSelected = false
+            binding.btnCompleted.isSelected = false
         }
+
+        VisibilityFilter.SHOW_ACTIVE -> {
+            binding.btnActive.isSelected = true
+            binding.btnSelectAll.isSelected = false
+            binding.btnCompleted.isSelected = false
+        }
+
+        VisibilityFilter.SHOW_COMPLETED -> {
+            binding.btnCompleted.isSelected = true
+            binding.btnSelectAll.isSelected = false
+            binding.btnActive.isSelected = false
+        }
+    }
 }

--- a/examples/todos/android/src/main/java/org/reduxkotlin/example/todos/TodoAdapter.kt
+++ b/examples/todos/android/src/main/java/org/reduxkotlin/example/todos/TodoAdapter.kt
@@ -39,11 +39,7 @@ class TodoViewHolder(view: View) : RecyclerView.ViewHolder(view) {
 }
 
 class DiffCallback : DiffUtil.ItemCallback<Todo>() {
-    override fun areItemsTheSame(oldItem: Todo, newItem: Todo): Boolean {
-        return oldItem.id == newItem.id
-    }
+    override fun areItemsTheSame(oldItem: Todo, newItem: Todo): Boolean = oldItem.id == newItem.id
 
-    override fun areContentsTheSame(oldItem: Todo, newItem: Todo): Boolean {
-        return oldItem == newItem
-    }
+    override fun areContentsTheSame(oldItem: Todo, newItem: Todo): Boolean = oldItem == newItem
 }

--- a/examples/todos/common/src/commonMain/kotlin/org/reduxkotlin/examples/todos/AppState.kt
+++ b/examples/todos/common/src/commonMain/kotlin/org/reduxkotlin/examples/todos/AppState.kt
@@ -5,7 +5,7 @@ package org.reduxkotlin.examples.todos
  */
 data class AppState(
     val todos: List<Todo> = listOf(),
-    val visibilityFilter: VisibilityFilter = VisibilityFilter.SHOW_ALL
+    val visibilityFilter: VisibilityFilter = VisibilityFilter.SHOW_ALL,
 ) {
     val visibleTodos: List<Todo>
         get() = getVisibleTodos(visibilityFilter)
@@ -21,14 +21,10 @@ data class AppState(
  * A model used in the app state. Where these types of models are located is up to you and your team
  * It will likely make sense to place separate file in a real project.
  */
-data class Todo(
-    val text: String,
-    val completed: Boolean = false,
-    val id: Int
-)
+data class Todo(val text: String, val completed: Boolean = false, val id: Int)
 
 enum class VisibilityFilter {
     SHOW_ALL,
     SHOW_COMPLETED,
-    SHOW_ACTIVE
+    SHOW_ACTIVE,
 }

--- a/examples/todos/common/src/commonMain/kotlin/org/reduxkotlin/examples/todos/RootReducer.kt
+++ b/examples/todos/common/src/commonMain/kotlin/org/reduxkotlin/examples/todos/RootReducer.kt
@@ -6,5 +6,5 @@ package org.reduxkotlin.examples.todos
  */
 fun rootReducer(state: AppState, action: Any) = AppState(
     todos = todosReducer(state.todos, action),
-    visibilityFilter = visibilityFilterReducer(state.visibilityFilter, action)
+    visibilityFilter = visibilityFilterReducer(state.visibilityFilter, action),
 )

--- a/examples/todos/common/src/commonMain/kotlin/org/reduxkotlin/examples/todos/TodosReducer.kt
+++ b/examples/todos/common/src/commonMain/kotlin/org/reduxkotlin/examples/todos/TodosReducer.kt
@@ -1,14 +1,15 @@
 package org.reduxkotlin.examples.todos
 
-fun todosReducer(state: List<Todo>, action: Any) =
-    when (action) {
-        is AddTodo -> state + Todo(action.text, id = state.size)
-        is ToggleTodo -> state.mapIndexed { index, todo ->
-            if (index == action.index) {
-                todo.copy(completed = !todo.completed)
-            } else {
-                todo
-            }
+fun todosReducer(state: List<Todo>, action: Any) = when (action) {
+    is AddTodo -> state + Todo(action.text, id = state.size)
+
+    is ToggleTodo -> state.mapIndexed { index, todo ->
+        if (index == action.index) {
+            todo.copy(completed = !todo.completed)
+        } else {
+            todo
         }
-        else -> state
     }
+
+    else -> state
+}

--- a/examples/todos/common/src/commonMain/kotlin/org/reduxkotlin/examples/todos/VisibilityFilterReducer.kt
+++ b/examples/todos/common/src/commonMain/kotlin/org/reduxkotlin/examples/todos/VisibilityFilterReducer.kt
@@ -1,7 +1,6 @@
 package org.reduxkotlin.examples.todos
 
-fun visibilityFilterReducer(state: VisibilityFilter, action: Any) =
-    when (action) {
-        is SetVisibilityFilter -> action.visibilityFilter
-        else -> state
-    }
+fun visibilityFilterReducer(state: VisibilityFilter, action: Any) = when (action) {
+    is SetVisibilityFilter -> action.visibilityFilter
+    else -> state
+}

--- a/examples/todos/common/src/commonTest/kotlin/org/reduxkotlin/examples/todos/TodosReducerTest.kt
+++ b/examples/todos/common/src/commonTest/kotlin/org/reduxkotlin/examples/todos/TodosReducerTest.kt
@@ -9,30 +9,30 @@ class TodosReducerTest {
     fun shouldHandleAddToDo() {
         assertEquals(
             todosReducer(emptyList(), AddTodo(text = "Run the tests")),
-            listOf(Todo(text = "Run the tests", completed = false, id = 0))
+            listOf(Todo(text = "Run the tests", completed = false, id = 0)),
         )
 
         assertEquals(
             todosReducer(listOf(Todo(text = "Run the tests", completed = false, id = 0)), AddTodo(text = "Use Redux")),
             listOf(
                 Todo(text = "Run the tests", completed = false, id = 0),
-                Todo(text = "Use Redux", completed = false, id = 1)
-            )
+                Todo(text = "Use Redux", completed = false, id = 1),
+            ),
         )
 
         assertEquals(
             todosReducer(
                 listOf(
                     Todo(text = "Run the tests", completed = false, id = 0),
-                    Todo(text = "Use Redux", completed = false, id = 1)
+                    Todo(text = "Use Redux", completed = false, id = 1),
                 ),
-                AddTodo(text = "Fix the tests")
+                AddTodo(text = "Fix the tests"),
             ),
             listOf(
                 Todo(text = "Run the tests", completed = false, id = 0),
                 Todo(text = "Use Redux", completed = false, id = 1),
-                Todo(text = "Fix the tests", completed = false, id = 2)
-            )
+                Todo(text = "Fix the tests", completed = false, id = 2),
+            ),
         )
     }
 
@@ -42,14 +42,14 @@ class TodosReducerTest {
             todosReducer(
                 listOf(
                     Todo(text = "Run the tests", completed = false, id = 0),
-                    Todo(text = "Use Redux", completed = false, id = 1)
+                    Todo(text = "Use Redux", completed = false, id = 1),
                 ),
-                ToggleTodo(index = 0)
+                ToggleTodo(index = 0),
             ),
             listOf(
                 Todo(text = "Run the tests", completed = true, id = 0),
-                Todo(text = "Use Redux", completed = false, id = 1)
-            )
+                Todo(text = "Use Redux", completed = false, id = 1),
+            ),
         )
     }
 }

--- a/gradle/detekt.yml
+++ b/gradle/detekt.yml
@@ -6,9 +6,9 @@ complexity:
 
 comments:
   active: true
-  CommentOverPrivateFunction:
+  DocumentationOverPrivateFunction:
     active: false
-  CommentOverPrivateProperty:
+  DocumentationOverPrivateProperty:
     active: false
   DeprecatedBlockTag:
     active: true
@@ -45,14 +45,14 @@ style:
     active: false
   WildcardImport:
     active: false
-  UnnecessaryAbstractClass:
-    active: false
   MaxLineLength:
     active: false
   MagicNumber:
     active: false
 
-formatting:
+# Renamed from `formatting` -> `ktlint` in detekt 2.0
+# (rules now provided by the `dev.detekt:detekt-rules-ktlint-wrapper` plugin).
+ktlint:
   Filename:
     active: false
   NoWildcardImports:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ androidx-constraintlayout = "2.2.1"
 androidx-recyclerview = "1.4.0"
 atomicfu = "0.32.1"
 coroutines = "1.10.2"
-detekt = "1.23.8"
+detekt = "2.0.0-alpha.3"
 dokka = "2.2.0"
 kotlin = "2.3.20"
 nexus-publish-plugin = "2.0.0"
@@ -17,7 +17,7 @@ androidx-activity = { module = "androidx.activity:activity-ktx", version.ref = "
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
-detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+detekt-formatting = { module = "dev.detekt:detekt-rules-ktlint-wrapper", version.ref = "detekt" }
 gradle-nexus-publish-plugin = { module = "io.github.gradle-nexus:publish-plugin", version.ref = "nexus-publish-plugin" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }

--- a/redux-kotlin-granular/src/commonMain/kotlin/org/reduxkotlin/granular/GranularSubscriptionsEnhancer.kt
+++ b/redux-kotlin-granular/src/commonMain/kotlin/org/reduxkotlin/granular/GranularSubscriptionsEnhancer.kt
@@ -15,8 +15,7 @@ import org.reduxkotlin.StoreEnhancer
  * the enhancer hook without breaking call sites that already use it.
  */
 public fun <State> granularSubscriptionsEnhancer(): StoreEnhancer<State> = { storeCreator ->
-    {
-            reducer, initialState, en ->
+    { reducer, initialState, en ->
         storeCreator(reducer, initialState, en)
     }
 }

--- a/redux-kotlin-granular/src/commonMain/kotlin/org/reduxkotlin/granular/SubscribeFields.kt
+++ b/redux-kotlin-granular/src/commonMain/kotlin/org/reduxkotlin/granular/SubscribeFields.kt
@@ -79,11 +79,7 @@ internal class FieldSubscriptionRegistry<State>(
     @Volatile
     private var sealed: Boolean = false
 
-    override fun <F> on(
-        selector: (State) -> F,
-        triggerOnSubscribe: Boolean,
-        listener: (F, F) -> Unit,
-    ) {
+    override fun <F> on(selector: (State) -> F, triggerOnSubscribe: Boolean, listener: (F, F) -> Unit) {
         check(!sealed) {
             "FieldSubscriptionScope.on() called after subscribeFields block completed. " +
                 "Register all subscriptions inside the block."

--- a/redux-kotlin-granular/src/commonTest/kotlin/org/reduxkotlin/granular/FieldSubscriptionTest.kt
+++ b/redux-kotlin-granular/src/commonTest/kotlin/org/reduxkotlin/granular/FieldSubscriptionTest.kt
@@ -10,11 +10,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
-private data class TestState(
-    val counter: Int = 0,
-    val label: String = "",
-    val items: List<String> = emptyList(),
-)
+private data class TestState(val counter: Int = 0, val label: String = "", val items: List<String> = emptyList())
 
 private sealed class TestAction {
     object Increment : TestAction()

--- a/redux-kotlin-granular/src/jvmTest/kotlin/org/reduxkotlin/granular/concurrency/ConcurrencyStressTest.kt
+++ b/redux-kotlin-granular/src/jvmTest/kotlin/org/reduxkotlin/granular/concurrency/ConcurrencyStressTest.kt
@@ -48,8 +48,7 @@ class ConcurrencyStressTest {
         }
     }
 
-    private fun daemonExecutor(threads: Int) =
-        Executors.newFixedThreadPool(threads, DaemonThreadFactory())!!
+    private fun daemonExecutor(threads: Int) = Executors.newFixedThreadPool(threads, DaemonThreadFactory())!!
 
     /**
      * Scenario 5a (per the plan). 100 separate `subscribeTo` calls (so the

--- a/redux-kotlin-threadsafe/src/commonMain/kotlin/org/reduxkotlin/threadsafe/CreateThreadSafeStore.kt
+++ b/redux-kotlin-threadsafe/src/commonMain/kotlin/org/reduxkotlin/threadsafe/CreateThreadSafeStore.kt
@@ -35,7 +35,7 @@ import org.reduxkotlin.typedReducer
 public fun <State> createThreadSafeStore(
     reducer: Reducer<State>,
     preloadedState: State,
-    enhancer: StoreEnhancer<State>? = null
+    enhancer: StoreEnhancer<State>? = null,
 ): Store<State> = ThreadSafeStore(createStore(reducer, preloadedState, enhancer))
 
 /**
@@ -44,12 +44,10 @@ public fun <State> createThreadSafeStore(
 public inline fun <State, reified Action : Any> createTypedThreadSafeStore(
     crossinline reducer: TypedReducer<State, Action>,
     preloadedState: State,
-    noinline enhancer: StoreEnhancer<State>? = null
-): TypedStore<State, Action> =
-    createThreadSafeStore(typedReducer(reducer), preloadedState, enhancer).asTyped()
+    noinline enhancer: StoreEnhancer<State>? = null,
+): TypedStore<State, Action> = createThreadSafeStore(typedReducer(reducer), preloadedState, enhancer).asTyped()
 
 /**
  * Converts a given [Store] to a [ThreadSafeStore].
  */
-public fun <State> Store<State>.asThreadSafe(): ThreadSafeStore<State> =
-    ThreadSafeStore(store)
+public fun <State> Store<State>.asThreadSafe(): ThreadSafeStore<State> = ThreadSafeStore(store)

--- a/redux-kotlin-threadsafe/src/commonMain/kotlin/org/reduxkotlin/threadsafe/Enhancers.kt
+++ b/redux-kotlin-threadsafe/src/commonMain/kotlin/org/reduxkotlin/threadsafe/Enhancers.kt
@@ -13,14 +13,11 @@ import org.reduxkotlin.StoreEnhancer
 
  * @returns {StoreEnhancer} A store enhancer that synchronizes the store.
  */
-public fun <State> createThreadSafeStoreEnhancer(): StoreEnhancer<State> {
-    return { storeCreator ->
-        {
-                reducer, initialState, en: Any? ->
-            val store = storeCreator(reducer, initialState, en)
-            val synchronizedStore = ThreadSafeStore(store)
-            synchronizedStore
-        }
+public fun <State> createThreadSafeStoreEnhancer(): StoreEnhancer<State> = { storeCreator ->
+    { reducer, initialState, en: Any? ->
+        val store = storeCreator(reducer, initialState, en)
+        val synchronizedStore = ThreadSafeStore(store)
+        synchronizedStore
     }
 }
 
@@ -28,8 +25,7 @@ public fun <State> createThreadSafeStoreEnhancer(): StoreEnhancer<State> {
     "Renamed to createThreadSafeStoreEnhancer",
     replaceWith = ReplaceWith(
         expression = "createThreadSafeStoreEnhancer",
-        "org.reduxkotlin.threadsafe.createThreadSafeStoreEnhancer"
-    )
+        "org.reduxkotlin.threadsafe.createThreadSafeStoreEnhancer",
+    ),
 )
-public fun <State> createSynchronizedStoreEnhancer(): StoreEnhancer<State> =
-    createThreadSafeStoreEnhancer()
+public fun <State> createSynchronizedStoreEnhancer(): StoreEnhancer<State> = createThreadSafeStoreEnhancer()

--- a/redux-kotlin-threadsafe/src/commonMain/kotlin/org/reduxkotlin/threadsafe/ThreadSafeStore.kt
+++ b/redux-kotlin-threadsafe/src/commonMain/kotlin/org/reduxkotlin/threadsafe/ThreadSafeStore.kt
@@ -17,8 +17,8 @@ import org.reduxkotlin.StoreSubscription
  * TODO more info at [https://ReduxKotlin.org]
  */
 public class ThreadSafeStore<State>(override val store: Store<State>) :
-    Store<State>,
-    SynchronizedObject() {
+    SynchronizedObject(),
+    Store<State> {
     override var dispatch: Dispatcher = { action ->
         synchronized(this) { store.dispatch(action) }
     }
@@ -40,7 +40,7 @@ public class ThreadSafeStore<State>(override val store: Store<State>) :
     "Renamed to ThreadSafeStore",
     replaceWith = ReplaceWith(
         expression = "ThreadSafeStore",
-        "org.reduxkotlin.threadsafe.ThreadSafeStore"
-    )
+        "org.reduxkotlin.threadsafe.ThreadSafeStore",
+    ),
 )
 public typealias SynchronizedStore<State> = ThreadSafeStore<State>

--- a/redux-kotlin-threadsafe/src/jvmCommonTest/kotlin/org/reduxkotlin/threadsafe/CreateThreadSafeStoreTest.kt
+++ b/redux-kotlin-threadsafe/src/jvmCommonTest/kotlin/org/reduxkotlin/threadsafe/CreateThreadSafeStoreTest.kt
@@ -16,11 +16,7 @@ import kotlin.system.measureTimeMillis
 import kotlin.test.assertEquals
 
 class CreateThreadSafeStoreTest {
-    private suspend fun massiveRun(
-        numCoroutines: Int,
-        numRepeats: Int,
-        action: suspend () -> Unit
-    ) {
+    private suspend fun massiveRun(numCoroutines: Int, numRepeats: Int, action: suspend () -> Unit) {
         val time = measureTimeMillis {
             coroutineScope {
                 repeat(numCoroutines) {
@@ -55,8 +51,8 @@ class CreateThreadSafeStoreTest {
             compose(
                 applyMiddleware(TestApp.createTestThunkMiddleware()),
                 // needs to be placed after enhancers that requires synchronized store methods
-                createThreadSafeStoreEnhancer()
-            )
+                createThreadSafeStoreEnhancer(),
+            ),
         )
         runBlocking {
             withContext(Dispatchers.Default) {
@@ -69,7 +65,7 @@ class CreateThreadSafeStoreTest {
                 timerTask {
                     assertEquals(10000, store.state.counter)
                 },
-                50
+                50,
             )
         }
     }

--- a/redux-kotlin-threadsafe/src/jvmCommonTest/kotlin/test/TestApp.kt
+++ b/redux-kotlin-threadsafe/src/jvmCommonTest/kotlin/test/TestApp.kt
@@ -21,10 +21,8 @@ object TestApp {
     }
 
     fun <State> createTestThunkMiddleware(): Middleware<State> = { store ->
-        {
-                next: Dispatcher ->
-            {
-                    action: Any ->
+        { next: Dispatcher ->
+            { action: Any ->
                 if (action is Function<*>) {
                     @Suppress("UNCHECKED_CAST")
                     val thunk = try {
@@ -45,7 +43,7 @@ object TestApp {
             timerTask {
                 dispatch(Increment)
             },
-            50
+            50,
         )
         getState()
     }

--- a/redux-kotlin/src/commonMain/kotlin/org/reduxkotlin/ApplyMiddleware.kt
+++ b/redux-kotlin/src/commonMain/kotlin/org/reduxkotlin/ApplyMiddleware.kt
@@ -16,22 +16,19 @@ package org.reduxkotlin
  * @param {vararg Middleware} [middleware] The middleware chain to be applied.
  * @returns {StoreEnhancer} A store enhancer applying the middleware.
  */
-public fun <State> applyMiddleware(vararg middlewares: Middleware<State>): StoreEnhancer<State> {
-    return { storeCreator ->
-        {
-                reducer, initialState, en: Any? ->
-            val store = storeCreator(reducer, initialState, en)
-            val origDispatch = store.dispatch
-            val dispatch: Dispatcher = {
-                throw IllegalStateException(
-                    """Dispatching while constructing your middleware is not allowed.
-                    Other middleware would not be applied to this dispatch."""
-                )
-            }
-            store.dispatch = dispatch
-            val chain = middlewares.map { middleware -> middleware(store) }
-            store.dispatch = compose(chain)(origDispatch)
-            store
+public fun <State> applyMiddleware(vararg middlewares: Middleware<State>): StoreEnhancer<State> = { storeCreator ->
+    { reducer, initialState, en: Any? ->
+        val store = storeCreator(reducer, initialState, en)
+        val origDispatch = store.dispatch
+        val dispatch: Dispatcher = {
+            throw IllegalStateException(
+                """Dispatching while constructing your middleware is not allowed.
+                    Other middleware would not be applied to this dispatch.""",
+            )
         }
+        store.dispatch = dispatch
+        val chain = middlewares.map { middleware -> middleware(store) }
+        store.dispatch = compose(chain)(origDispatch)
+        store
     }
 }

--- a/redux-kotlin/src/commonMain/kotlin/org/reduxkotlin/CreateSameThreadEnforcedStore.kt
+++ b/redux-kotlin/src/commonMain/kotlin/org/reduxkotlin/CreateSameThreadEnforcedStore.kt
@@ -16,7 +16,7 @@ import org.reduxkotlin.utils.stripCoroutineName
 public fun <State> createSameThreadEnforcedStore(
     reducer: Reducer<State>,
     preloadedState: State,
-    enhancer: StoreEnhancer<State>? = null
+    enhancer: StoreEnhancer<State>? = null,
 ): Store<State> {
     val store = createStore(reducer, preloadedState, enhancer)
     val storeThreadName = stripCoroutineName(getThreadName())
@@ -60,7 +60,7 @@ public fun <State> createSameThreadEnforcedStore(
 public inline fun <State, reified Action : Any> createTypedSameThreadEnforcedStore(
     crossinline reducer: TypedReducer<State, Action>,
     preloadedState: State,
-    noinline enhancer: StoreEnhancer<State>? = null
+    noinline enhancer: StoreEnhancer<State>? = null,
 ): TypedStore<State, Action> = createSameThreadEnforcedStore(
     reducer = typedReducer(reducer),
     preloadedState,

--- a/redux-kotlin/src/commonMain/kotlin/org/reduxkotlin/CreateStore.kt
+++ b/redux-kotlin/src/commonMain/kotlin/org/reduxkotlin/CreateStore.kt
@@ -33,13 +33,13 @@ import org.reduxkotlin.utils.isPlainObject
 public fun <State> createStore(
     reducer: Reducer<State>,
     preloadedState: State,
-    enhancer: StoreEnhancer<State>? = null
+    enhancer: StoreEnhancer<State>? = null,
 ): Store<State> {
     if (enhancer != null) {
         return enhancer { r, initialState, _ -> createStore(r, initialState) }(
             reducer,
             preloadedState,
-            null
+            null,
         )
     }
 
@@ -224,13 +224,12 @@ public fun <State> createStore(
         dispatch(ActionTypes.REPLACE)
     }
 
-    /**
+    /*
      * Interoperability point for observable/reactive libraries.
-     * @returns {observable} A minimal observable of state changes.
-     * For more information, see the observable proposal:
-     * https://github.com/tc39/proposal-observable
+     * Returns a minimal observable of state changes.
+     * See https://github.com/tc39/proposal-observable for context.
+     * TODO: consider kotlinx.coroutines.flow?
      */
-    /* TODO: consider kotlinx.coroutines.flow? */
 
     // When a store is created, an "INIT" action is dispatched so that every
     // reducer returns their initial state. This effectively populates
@@ -252,7 +251,7 @@ public fun <State> createStore(
 public inline fun <State, reified Action : Any> createTypedStore(
     crossinline reducer: TypedReducer<State, Action>,
     preloadedState: State,
-    noinline enhancer: StoreEnhancer<State>? = null
+    noinline enhancer: StoreEnhancer<State>? = null,
 ): TypedStore<State, Action> = createStore(
     reducer = typedReducer(reducer),
     preloadedState,

--- a/redux-kotlin/src/commonMain/kotlin/org/reduxkotlin/Definitions.kt
+++ b/redux-kotlin/src/commonMain/kotlin/org/reduxkotlin/Definitions.kt
@@ -16,7 +16,7 @@ public typealias TypedReducer<State, Action> = (state: State, action: Action) ->
     replaceWith = ReplaceWith(
         expression = "TypedReducer",
         imports = arrayOf("org.reduxkotlin.TypedReducer"),
-    )
+    ),
 )
 public typealias ReducerForActionType<TState, TAction> = (state: TState, action: TAction) -> TState
 
@@ -30,7 +30,7 @@ public typealias TypedDispatcher<Action> = (Action) -> Any
 public typealias StoreCreator<State> = (
     reducer: Reducer<State>,
     initialState: State,
-    enhancer: Any?
+    enhancer: Any?,
 ) -> Store<State>
 
 /**
@@ -106,10 +106,8 @@ public interface TypedStore<State, Action> {
  */
 public fun <State> middleware(dispatch: (Store<State>, next: Dispatcher, action: Any) -> Any): Middleware<State> =
     { store ->
-        {
-                next ->
-            {
-                    action: Any ->
+        { next ->
+            { action: Any ->
                 dispatch(store, next, action)
             }
         }
@@ -144,7 +142,7 @@ public fun <State> middleware(dispatch: (Store<State>, next: Dispatcher, action:
  *   val store = createThreadSafeStore(rootReducer, AppState())
  */
 public inline fun <State, reified Action> typedReducer(
-    crossinline reducer: TypedReducer<State, Action>
+    crossinline reducer: TypedReducer<State, Action>,
 ): Reducer<State> = { state, action ->
     when (action) {
         is Action -> reducer(state, action)
@@ -157,7 +155,7 @@ public inline fun <State, reified Action> typedReducer(
     replaceWith = ReplaceWith(
         expression = "typedReducer",
         imports = arrayOf("org.reduxkotlin.typedReducer"),
-    )
+    ),
 )
 public inline fun <TState, reified TAction> reducerForActionType(
     crossinline reducer: TypedReducer<TState, TAction>,

--- a/redux-kotlin/src/commonTest/kotlin/org/reduxkotlin/ApplyMiddlewareTest.kt
+++ b/redux-kotlin/src/commonTest/kotlin/org/reduxkotlin/ApplyMiddlewareTest.kt
@@ -10,8 +10,7 @@ class ApplyMiddlewareTest {
         fun dispatchingMiddleware(store: Store<TodoApp.TodoState>): (next: Dispatcher) -> (action: Any) -> Any {
             store.dispatch(TodoApp.AddTodo("1", "Dont dispatch in middleware setup"))
             return { next ->
-                {
-                        action ->
+                { action ->
                     {
                         next(action)
                     }

--- a/redux-kotlin/src/commonTest/kotlin/org/reduxkotlin/CreateStoreTest.kt
+++ b/redux-kotlin/src/commonTest/kotlin/org/reduxkotlin/CreateStoreTest.kt
@@ -13,10 +13,10 @@ class CreateStoreTest {
                 listOf(
                     TodoApp.Todo(
                         id = "1",
-                        text = "Hello"
-                    )
-                )
-            )
+                        text = "Hello",
+                    ),
+                ),
+            ),
         )
 
         assertEquals(
@@ -25,10 +25,10 @@ class CreateStoreTest {
                 listOf(
                     TodoApp.Todo(
                         id = "1",
-                        text = "Hello"
-                    )
-                )
-            )
+                        text = "Hello",
+                    ),
+                ),
+            ),
         )
     }
 
@@ -47,10 +47,10 @@ class CreateStoreTest {
                 listOf(
                     TodoApp.Todo(
                         id = "1",
-                        text = "Hello"
-                    )
-                )
-            )
+                        text = "Hello",
+                    ),
+                ),
+            ),
         )
 
         // TODO are ids autoincrement?
@@ -61,14 +61,14 @@ class CreateStoreTest {
                 listOf(
                     TodoApp.Todo(
                         id = "1",
-                        text = "Hello"
+                        text = "Hello",
                     ),
                     TodoApp.Todo(
                         id = "2",
-                        text = "World"
-                    )
-                )
-            )
+                        text = "World",
+                    ),
+                ),
+            ),
         )
     }
 
@@ -80,10 +80,10 @@ class CreateStoreTest {
                 listOf(
                     TodoApp.Todo(
                         id = "1",
-                        text = "Hello"
-                    )
-                )
-            )
+                        text = "Hello",
+                    ),
+                ),
+            ),
         )
         assertEquals(
             store.getState(),
@@ -91,10 +91,10 @@ class CreateStoreTest {
                 listOf(
                     TodoApp.Todo(
                         id = "1",
-                        text = "Hello"
-                    )
-                )
-            )
+                        text = "Hello",
+                    ),
+                ),
+            ),
         )
 
         store.dispatch(Any())
@@ -104,10 +104,10 @@ class CreateStoreTest {
                 listOf(
                     TodoApp.Todo(
                         id = "1",
-                        text = "Hello"
-                    )
-                )
-            )
+                        text = "Hello",
+                    ),
+                ),
+            ),
         )
 
         store.dispatch(TodoApp.AddTodo("2", "World"))
@@ -117,14 +117,14 @@ class CreateStoreTest {
                 listOf(
                     TodoApp.Todo(
                         id = "1",
-                        text = "Hello"
+                        text = "Hello",
                     ),
                     TodoApp.Todo(
                         id = "2",
-                        text = "World"
-                    )
-                )
-            )
+                        text = "World",
+                    ),
+                ),
+            ),
         )
     }
 }

--- a/redux-kotlin/src/commonTest/kotlin/org/reduxkotlin/TypedReducerTest.kt
+++ b/redux-kotlin/src/commonTest/kotlin/org/reduxkotlin/TypedReducerTest.kt
@@ -15,10 +15,10 @@ class TypedReducerTest {
                 listOf(
                     TodoApp.Todo(
                         id = "1",
-                        text = "Hello"
-                    )
-                )
-            )
+                        text = "Hello",
+                    ),
+                ),
+            ),
         )
 
         assertEquals(
@@ -27,10 +27,10 @@ class TypedReducerTest {
                 listOf(
                     TodoApp.Todo(
                         id = "1",
-                        text = "Hello"
-                    )
-                )
-            )
+                        text = "Hello",
+                    ),
+                ),
+            ),
         )
     }
 
@@ -46,10 +46,10 @@ class TypedReducerTest {
                 listOf(
                     TodoApp.Todo(
                         id = "1",
-                        text = "Hello"
-                    )
-                )
-            )
+                        text = "Hello",
+                    ),
+                ),
+            ),
         )
 
         // TODO are ids autoincrement?
@@ -60,14 +60,14 @@ class TypedReducerTest {
                 listOf(
                     TodoApp.Todo(
                         id = "1",
-                        text = "Hello"
+                        text = "Hello",
                     ),
                     TodoApp.Todo(
                         id = "2",
-                        text = "World"
-                    )
-                )
-            )
+                        text = "World",
+                    ),
+                ),
+            ),
         )
     }
 
@@ -79,10 +79,10 @@ class TypedReducerTest {
                 listOf(
                     TodoApp.Todo(
                         id = "1",
-                        text = "Hello"
-                    )
-                )
-            )
+                        text = "Hello",
+                    ),
+                ),
+            ),
         )
         assertEquals(
             store.getState(),
@@ -90,10 +90,10 @@ class TypedReducerTest {
                 listOf(
                     TodoApp.Todo(
                         id = "1",
-                        text = "Hello"
-                    )
-                )
-            )
+                        text = "Hello",
+                    ),
+                ),
+            ),
         )
 
         store.dispatch(TodoApp.AddTodo("2", "World"))
@@ -103,14 +103,14 @@ class TypedReducerTest {
                 listOf(
                     TodoApp.Todo(
                         id = "1",
-                        text = "Hello"
+                        text = "Hello",
                     ),
                     TodoApp.Todo(
                         id = "2",
-                        text = "World"
-                    )
-                )
-            )
+                        text = "World",
+                    ),
+                ),
+            ),
         )
     }
 }

--- a/redux-kotlin/src/commonTest/kotlin/test/TodoApp.kt
+++ b/redux-kotlin/src/commonTest/kotlin/test/TodoApp.kt
@@ -15,6 +15,7 @@ object TodoApp {
     val todoReducer: Reducer<TodoState> = { state: TodoState, action: Any ->
         when (action) {
             is AddTodo -> state.copy(todos = state.todos.plus(Todo(action.id, action.text, false)))
+
             is ToggleTodo -> state.copy(
                 todos = state.todos.map {
                     if (it.id == action.id) {
@@ -22,7 +23,7 @@ object TodoApp {
                     } else {
                         it
                     }
-                }
+                },
             )
 
             else -> state

--- a/redux-kotlin/src/jvmCommonTest/kotlin/org/reduxkotlin/CreateSameThreadEnforcedStoreTest.kt
+++ b/redux-kotlin/src/jvmCommonTest/kotlin/org/reduxkotlin/CreateSameThreadEnforcedStoreTest.kt
@@ -10,43 +10,45 @@ import java.util.concurrent.Executors
 import kotlin.system.measureTimeMillis
 import kotlin.test.*
 
-class CreateSameThreadEnforcedStoreTest : AbstractCreateSameThreadEnforcedStoreTest<Any>(
-    Any(),
-    {
-        createSameThreadEnforcedStore(
-            TodoApp.todoReducer,
-            TodoApp.TodoState(
-                listOf(
-                    TodoApp.Todo(
-                        id = "1",
-                        text = "Hello"
-                    )
-                )
+class CreateSameThreadEnforcedStoreTest :
+    AbstractCreateSameThreadEnforcedStoreTest<Any>(
+        Any(),
+        {
+            createSameThreadEnforcedStore(
+                TodoApp.todoReducer,
+                TodoApp.TodoState(
+                    listOf(
+                        TodoApp.Todo(
+                            id = "1",
+                            text = "Hello",
+                        ),
+                    ),
+                ),
             )
-        )
-    }
-)
+        },
+    )
 
-class CreateSameThreadEnforcedTypedStoreTest : AbstractCreateSameThreadEnforcedStoreTest<TodoApp.TodoAction>(
-    TodoApp.DoNothing,
-    {
-        createTypedSameThreadEnforcedStore(
-            TodoApp.typedTodoReducer,
-            TodoApp.TodoState(
-                listOf(
-                    TodoApp.Todo(
-                        id = "1",
-                        text = "Hello"
-                    )
-                )
+class CreateSameThreadEnforcedTypedStoreTest :
+    AbstractCreateSameThreadEnforcedStoreTest<TodoApp.TodoAction>(
+        TodoApp.DoNothing,
+        {
+            createTypedSameThreadEnforcedStore(
+                TodoApp.typedTodoReducer,
+                TodoApp.TodoState(
+                    listOf(
+                        TodoApp.Todo(
+                            id = "1",
+                            text = "Hello",
+                        ),
+                    ),
+                ),
             )
-        )
-    }
-)
+        },
+    )
 
 abstract class AbstractCreateSameThreadEnforcedStoreTest<A>(
     private val action: A,
-    private val storeProvider: () -> TypedStore<TodoApp.TodoState, A>
+    private val storeProvider: () -> TypedStore<TodoApp.TodoState, A>,
 ) {
     private lateinit var store: TypedStore<TodoApp.TodoState, A>
 
@@ -88,7 +90,7 @@ abstract class AbstractCreateSameThreadEnforcedStoreTest<A>(
                 val store = createSameThreadEnforcedStore(
                     testReducer,
                     TodoApp.TodoState(),
-                    applyMiddleware(middleware.middleware)
+                    applyMiddleware(middleware.middleware),
                 )
 
                 store.dispatch(Any())


### PR DESCRIPTION
> **Stacked PR.** Base is `chore/replace-git-hooks-plugin` (PR #289). After that merges, this PR's base will automatically retarget to `master` and the diff will narrow to PR C's own changes.

## Summary

- Detekt 1.23.8 → **2.0.0-alpha.3** (latest 2.x; 2.0 still in alpha — tracking until GA).
- Plugin id `io.gitlab.arturbosch.detekt` → `dev.detekt`; artifacts under `dev.detekt` group.
- `detekt-formatting` artifact replaced by `dev.detekt:detekt-rules-ktlint-wrapper`.
- Detekt task class moved: `io.gitlab.arturbosch.detekt.Detekt` → `dev.detekt.gradle.Detekt`.
- Reports: `xml` → `checkstyle`, `md` → `markdown`; `txt` removed.
- Config (`gradle/detekt.yml`):
  - `formatting` ruleset → `ktlint`.
  - `CommentOverPrivate{Function,Property}` → `DocumentationOverPrivate{Function,Property}`.
  - `style > UnnecessaryAbstractClass` removed in 2.0; key dropped.

## Why

Detekt 1.23.8 can't parse Kotlin 2.3 metadata ([issue #8865](https://github.com/detekt/detekt/issues/8865)) — false positives across rules with the metadata-version error. 2.0 alpha is built against Kotlin 2.3.21 and resolves the gap.

## Codebase side-effects

Detekt's `--auto-correct` (run by the existing pre-commit hook) applied ktlint 2.x defaults across the codebase. Mechanical only:

- Trailing commas on call/declaration sites.
- Blank line between multiline `when` conditions.
- Super-type-on-newline class signatures.
- One floating `/** … */` block inside a function body in `redux-kotlin/CreateStore.kt` is converted to a `/* … */` comment (ktlint disallows KDoc inside blocks).

No semantic changes.

## Test plan

- [x] `./gradlew detektAll` succeeds (0 issues)
- [x] `./gradlew detektAll --auto-correct` is idempotent (no remaining diff)
- [x] Worktree-safe (depends on #289)
- [ ] CI green on JDK 17 + JDK 21

## Risk

2.0 is alpha. We accept alpha-track maintenance churn (rule renames, API tweaks) until 2.0 GA. Counterweight: 1.23.8 is broken for Kotlin 2.3, which this repo already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)