### PR TITLE
build(conventions): drop unnecessary afterEvaluate + eager task realizations

### DIFF
--- a/build-conventions/src/main/kotlin/convention.common.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.common.gradle.kts
@@ -34,6 +34,12 @@ idea {
     }
 }
 
+// The `afterEvaluate` wrapper is load-bearing: KMP registers its own
+// `allTests` task (typed `KotlinTestReport`) later in configuration, so
+// the existence check has to run after all plugins have had a chance to
+// register their tasks. Migrating this off `afterEvaluate` would require
+// reacting to specific plugin application via `pluginManager.withPlugin`
+// for each plugin that may own these names.
 afterEvaluate {
     tasks {
         if (findByName("compile") == null) {

--- a/build-conventions/src/main/kotlin/convention.detekt.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.detekt.gradle.kts
@@ -23,28 +23,28 @@ tasks {
             setSource(files(projectDir))
         }
     }
-    afterEvaluate {
-        withType<Detekt> {
-            parallel = true
-            reports {
-                // observe findings in your browser with structure and code snippets
-                html.required.set(true)
-                // checkstyle-like format mainly for Jenkins-style integrations
-                // (renamed from `xml` in detekt 2.0).
-                checkstyle.required.set(true)
-                // standardized SARIF format (https://sarifweb.azurewebsites.net/) for GitHub Code Scanning.
-                sarif.required.set(true)
-                // markdown report (renamed from `md` in detekt 2.0).
-                markdown.required.set(true)
-            }
-            include("**/*.kt", "**/*.kts")
-            // `.claude/` holds Claude Code harness worktrees / caches; never
-            // scan them. `**/build` is the Gradle output dir.
-            // jvmBenchmark/ holds JMH benchmarks where the @Benchmark
-            // contract dictates the function-naming and KDoc shape; the
-            // benchmarks are not shipped as library API. Skip rather
-            // than burn the rule budget on paraphrasing method names.
-            exclude("**/build", "scripts/", ".claude/", "**/.claude/", "**/jvmBenchmark/**")
+    // `withType().configureEach` is fully lazy; no need to wrap in
+    // `afterEvaluate {}` (which Gradle 10's Provider-API migration discourages).
+    withType<Detekt>().configureEach {
+        parallel = true
+        reports {
+            // observe findings in your browser with structure and code snippets
+            html.required.set(true)
+            // checkstyle-like format mainly for Jenkins-style integrations
+            // (renamed from `xml` in detekt 2.0).
+            checkstyle.required.set(true)
+            // standardized SARIF format (https://sarifweb.azurewebsites.net/) for GitHub Code Scanning.
+            sarif.required.set(true)
+            // markdown report (renamed from `md` in detekt 2.0).
+            markdown.required.set(true)
         }
+        include("**/*.kt", "**/*.kts")
+        // `.claude/` holds Claude Code harness worktrees / caches; never
+        // scan them. `**/build` is the Gradle output dir.
+        // jvmBenchmark/ holds JMH benchmarks where the @Benchmark
+        // contract dictates the function-naming and KDoc shape; the
+        // benchmarks are not shipped as library API. Skip rather
+        // than burn the rule budget on paraphrasing method names.
+        exclude("**/build", "scripts/", ".claude/", "**/.claude/", "**/jvmBenchmark/**")
     }
 }

--- a/build-conventions/src/main/kotlin/convention.publishing.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.publishing.gradle.kts
@@ -74,7 +74,9 @@ publishing {
         val ghOwnerOrganization: String = project.findProperty("gh.owner.organization")!!.toString()
         val ghOwnerOrganizationUrl: String = project.findProperty("gh.owner.organization.url")!!.toString()
         withType<MavenPublication> {
-            artifact(tasks["javadocJar"])
+            // tasks.named() returns a TaskProvider (lazy); `tasks["..."]`
+            // forces eager realization.
+            artifact(tasks.named("javadocJar"))
             pom {
                 name by project.name
                 url by "https://github.com/$ghOwnerId/${rootProject.name}"


### PR DESCRIPTION
> **Stacked PR.** Base is `chore/replace-git-hooks-plugin` (PR #289) for local testability inside worktrees. After #289 merges, this PR's base auto-retargets to `master` and the diff narrows to PR D's own changes.

## Summary

Small audit pass on `build-conventions/` for Gradle 10 Provider API readiness. None of these change behavior — they remove redundant eagerness so the build keeps working when Gradle 10 tightens the screws on Provider API migration.

- `convention.detekt.gradle.kts`: replace `afterEvaluate { withType<Detekt> { ... } }` with `withType<Detekt>().configureEach { ... }`. `configureEach` is fully lazy; wrapping it in `afterEvaluate` is dead weight.
- `convention.publishing.gradle.kts`: replace `tasks["javadocJar"]` with `tasks.named("javadocJar")` inside `MavenPublication` setup. `tasks["..."]` forces eager realization; `tasks.named(...)` returns a `TaskProvider` and stays lazy.
- `convention.common.gradle.kts`: comment-only — explicitly documents why the `afterEvaluate` wrapper around the `compile` / `allTests` aggregator registration is intentionally load-bearing.

## Why the `afterEvaluate` in `convention.common` stays

KMP registers its own `allTests` task (typed `KotlinTestReport`) lazily during configuration. The existence check in `convention.common` has to run **after** all other plugins have had a chance to register their tasks, otherwise this convention plugin would race the KMP plugin and register a plain `DefaultTask` with the same name — which then breaks KMP when it tries to configure `allTests` as `KotlinTestReport`. Verified empirically: removing `afterEvaluate` here produces:

```
> Failed to apply plugin 'convention.mpp-loved'.
   > The task 'allTests' (org.gradle.api.DefaultTask) is not a subclass of the given type
     (org.jetbrains.kotlin.gradle.testing.internal.KotlinTestReport).
```

A cleaner long-term fix would react via `pluginManager.withPlugin(...)` for each plugin that may own these names. Not in scope for this PR — out-of-band follow-up.

## Test plan

- [x] `./gradlew help` succeeds in a worktree (depends on #289)
- [x] `./gradlew :redux-kotlin:publishToLocal --dry-run` resolves the task graph (validates the `tasks.named("javadocJar")` change wires through `MavenPublication`)
- [ ] CI green on JDK 17 + JDK 21
- [ ] Detekt reports still produced (html / xml / sarif / txt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)