### PR TITLE
feat(multimodel-granular): add typed subscribeTo(Model::field) overload (PR η of v2, reopened)

### DIFF
--- a/redux-kotlin-multimodel-granular/build.gradle.kts
+++ b/redux-kotlin-multimodel-granular/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    id("convention.library-mpp-loved")
+    id("convention.publishing-mpp")
+}
+
+val hasAndroidSdk: Boolean = run {
+    val localProps = rootProject.file("local.properties")
+    val hasSdkInLocalProperties = localProps.exists() && localProps.readText().lineSequence().any {
+        it.trim().startsWith("sdk.dir=") && it.substringAfter("sdk.dir=").isNotBlank()
+    }
+    val hasSdkInEnv =
+        !System.getenv("ANDROID_HOME").isNullOrBlank() ||
+            !System.getenv("ANDROID_SDK_ROOT").isNullOrBlank()
+    hasSdkInLocalProperties || hasSdkInEnv
+}
+
+kotlin {
+    if (hasAndroidSdk) {
+        android {
+            namespace = "org.reduxkotlin.multimodel.granular"
+        }
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":redux-kotlin-granular"))
+                api(project(":redux-kotlin-multimodel"))
+            }
+        }
+    }
+}

--- a/redux-kotlin-multimodel-granular/src/commonMain/kotlin/org/reduxkotlin/multimodel/granular/SubscribeToModel.kt
+++ b/redux-kotlin-multimodel-granular/src/commonMain/kotlin/org/reduxkotlin/multimodel/granular/SubscribeToModel.kt
@@ -1,0 +1,59 @@
+package org.reduxkotlin.multimodel.granular
+
+import org.reduxkotlin.Store
+import org.reduxkotlin.StoreSubscription
+import org.reduxkotlin.granular.FieldSubscriptionScope
+import org.reduxkotlin.granular.subscribeTo
+import org.reduxkotlin.multimodel.ModelState
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
+import kotlin.reflect.KProperty1
+
+/**
+ * Property-reference convenience for [ModelState]-shaped stores:
+ * subscribe to a single field of model type [M], identified by a Kotlin
+ * property reference like `LoggedInUserModel::displayName`.
+ *
+ * The model type [M] is inferred from the property reference's receiver
+ * — the call site does not need to name [ModelState] at all. Internally
+ * the selector is `state.get<M>().property`: two field reads instead of
+ * one.
+ *
+ * Hidden from Swift via [HiddenFromObjC] (KProperty1 is not
+ * constructible from Swift) and not `@JsExport`ed (inline + reified
+ * cannot be exported). Raw JS/TS / Swift consumers should use
+ * [subscribeToModel].
+ */
+@OptIn(ExperimentalObjCRefinement::class)
+@HiddenFromObjC
+public inline fun <reified M : Any, F> Store<ModelState>.subscribeTo(
+    property: KProperty1<M, F>,
+    triggerOnSubscribe: Boolean = true,
+    noinline listener: (oldValue: F, newValue: F) -> Unit,
+): StoreSubscription = subscribeTo(
+    selector = { state -> property.get(state.get<M>()) },
+    triggerOnSubscribe = triggerOnSubscribe,
+    listener = listener,
+)
+
+/**
+ * DSL counterpart of [subscribeTo] above, for use inside a
+ * `subscribeFields { … }` block on a `Store<ModelState>`. Lets a single
+ * batch of subscriptions mix fields from multiple feature models while
+ * still backed by one underlying `store.subscribe`.
+ *
+ * Same Swift / JS visibility rules as the standalone overload.
+ */
+@OptIn(ExperimentalObjCRefinement::class)
+@HiddenFromObjC
+public inline fun <reified M : Any, F> FieldSubscriptionScope<ModelState>.on(
+    property: KProperty1<M, F>,
+    triggerOnSubscribe: Boolean = true,
+    noinline listener: (oldValue: F, newValue: F) -> Unit,
+) {
+    on(
+        selector = { state -> property.get(state.get<M>()) },
+        triggerOnSubscribe = triggerOnSubscribe,
+        listener = listener,
+    )
+}

--- a/redux-kotlin-multimodel-granular/src/commonMain/kotlin/org/reduxkotlin/multimodel/granular/SubscribeToModelByClass.kt
+++ b/redux-kotlin-multimodel-granular/src/commonMain/kotlin/org/reduxkotlin/multimodel/granular/SubscribeToModelByClass.kt
@@ -1,0 +1,57 @@
+package org.reduxkotlin.multimodel.granular
+
+import org.reduxkotlin.Store
+import org.reduxkotlin.StoreSubscription
+import org.reduxkotlin.granular.FieldSubscriptionScope
+import org.reduxkotlin.granular.subscribeTo
+import org.reduxkotlin.multimodel.ModelState
+import kotlin.reflect.KClass
+
+/**
+ * Non-inline alternative to the reified [subscribeTo] overload, for
+ * callers that hold the model type as a [KClass] rather than as a
+ * compile-time generic — i.e. raw JS/TS consumers (`inline reified` is
+ * Kotlin-only and is erased from the generated `.d.ts`), Swift
+ * consumers, and generic helper code that re-dispatches across
+ * dynamically chosen models.
+ *
+ * Functionally equivalent to:
+ * ```
+ * store.subscribeTo<M>(M::someProperty) { old, new -> … }
+ * ```
+ * but with the model class threaded through as a runtime argument:
+ * ```
+ * store.subscribeToModel(M::class, { it.someProperty }) { old, new -> … }
+ * ```
+ *
+ * This is the resolution to adversarial-review item I11 — the inline
+ * reified overload doesn't survive to the JS boundary, so a non-inline
+ * pathway must exist for non-Kotlin consumers.
+ */
+public fun <M : Any, F> Store<ModelState>.subscribeToModel(
+    modelClass: KClass<M>,
+    selector: (M) -> F,
+    triggerOnSubscribe: Boolean = true,
+    listener: (oldValue: F, newValue: F) -> Unit,
+): StoreSubscription = subscribeTo(
+    selector = { state -> selector(state.get(modelClass)) },
+    triggerOnSubscribe = triggerOnSubscribe,
+    listener = listener,
+)
+
+/**
+ * DSL counterpart of [subscribeToModel] for use inside a
+ * `subscribeFields { … }` block on a `Store<ModelState>`.
+ */
+public fun <M : Any, F> FieldSubscriptionScope<ModelState>.onModel(
+    modelClass: KClass<M>,
+    selector: (M) -> F,
+    triggerOnSubscribe: Boolean = true,
+    listener: (oldValue: F, newValue: F) -> Unit,
+) {
+    on(
+        selector = { state -> selector(state.get(modelClass)) },
+        triggerOnSubscribe = triggerOnSubscribe,
+        listener = listener,
+    )
+}

--- a/redux-kotlin-multimodel-granular/src/commonTest/kotlin/org/reduxkotlin/multimodel/granular/SubscribeToModelTest.kt
+++ b/redux-kotlin-multimodel-granular/src/commonTest/kotlin/org/reduxkotlin/multimodel/granular/SubscribeToModelTest.kt
@@ -1,0 +1,151 @@
+package org.reduxkotlin.multimodel.granular
+
+import org.reduxkotlin.createStore
+import org.reduxkotlin.granular.subscribeFields
+import org.reduxkotlin.multimodel.ModelState
+import org.reduxkotlin.multimodel.combineModelReducers
+import org.reduxkotlin.multimodel.modelReducer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private data class UserModel(val displayName: String = "")
+private data class FeedModel(val items: List<String> = emptyList())
+private data class UnregisteredModel(val value: Int = 0)
+
+private data class SetDisplayName(val name: String)
+private data class AppendFeedItem(val item: String)
+private object UnrelatedAction
+
+class SubscribeToModelTest {
+
+    private fun newStore() = createStore(
+        reducer = combineModelReducers(
+            modelReducer<UserModel> { user, action ->
+                if (action is SetDisplayName) user.copy(displayName = action.name) else user
+            },
+            modelReducer<FeedModel> { feed, action ->
+                if (action is AppendFeedItem) feed.copy(items = feed.items + action.item) else feed
+            },
+        ),
+        preloadedState = ModelState.of(UserModel("Ada"), FeedModel(listOf("a"))),
+    )
+
+    @Test
+    fun reified_subscribeTo_fires_only_for_matching_model_field() {
+        val store = newStore()
+        val updates = mutableListOf<String>()
+        // Drop the initial trigger fire so we're only measuring change-only events.
+        val unsubscribe = store.subscribeTo(UserModel::displayName, triggerOnSubscribe = false) { _, new ->
+            updates += new
+        }
+
+        store.dispatch(AppendFeedItem("b")) // unrelated model — must not fire
+        store.dispatch(SetDisplayName("Babbage"))
+        store.dispatch(SetDisplayName("Babbage")) // same value — must not fire (=== short-circuit)
+        store.dispatch(SetDisplayName("Lovelace"))
+
+        unsubscribe()
+        assertEquals(listOf("Babbage", "Lovelace"), updates)
+    }
+
+    @Test
+    fun reified_subscribeTo_fires_initial_value_when_trigger_default() {
+        val store = newStore()
+        val updates = mutableListOf<String>()
+        store.subscribeTo(UserModel::displayName) { _, new -> updates += new }
+        // First entry is the trigger-on-subscribe fire with the current value.
+        assertEquals(listOf("Ada"), updates)
+    }
+
+    @Test
+    fun dsl_on_mixes_fields_from_multiple_models() {
+        val store = newStore()
+        val nameUpdates = mutableListOf<String>()
+        val feedUpdates = mutableListOf<List<String>>()
+
+        store.subscribeFields {
+            on(UserModel::displayName, triggerOnSubscribe = false) { _, new -> nameUpdates += new }
+            on(FeedModel::items, triggerOnSubscribe = false) { _, new -> feedUpdates += new }
+        }
+
+        store.dispatch(SetDisplayName("Babbage"))
+        store.dispatch(AppendFeedItem("b"))
+        store.dispatch(UnrelatedAction) // === fast-path: no model changes, no listener fires
+
+        assertEquals(listOf("Babbage"), nameUpdates)
+        assertEquals(listOf(listOf("a", "b")), feedUpdates)
+    }
+
+    @Test
+    fun unrelated_action_does_not_fire_any_listener() {
+        val store = newStore()
+        var fired = 0
+        store.subscribeTo(UserModel::displayName, triggerOnSubscribe = false) { _, _ -> fired++ }
+        store.subscribeTo(FeedModel::items, triggerOnSubscribe = false) { _, _ -> fired++ }
+
+        store.dispatch(UnrelatedAction)
+        assertEquals(0, fired)
+    }
+
+    @Test
+    fun subscribeToModel_kclass_shim_routes_to_correct_model() {
+        val store = newStore()
+        val updates = mutableListOf<String>()
+        val unsubscribe = store.subscribeToModel(
+            modelClass = UserModel::class,
+            selector = { it.displayName },
+            triggerOnSubscribe = false,
+            listener = { _, new -> updates += new },
+        )
+
+        store.dispatch(AppendFeedItem("b"))
+        store.dispatch(SetDisplayName("Babbage"))
+        unsubscribe()
+
+        assertEquals(listOf("Babbage"), updates)
+    }
+
+    @Test
+    fun onModel_kclass_dsl_shim_works_inside_subscribeFields() {
+        val store = newStore()
+        val updates = mutableListOf<String>()
+        store.subscribeFields {
+            onModel(UserModel::class, { it.displayName }, triggerOnSubscribe = false) { _, new ->
+                updates += new
+            }
+        }
+        store.dispatch(SetDisplayName("Babbage"))
+        assertEquals(listOf("Babbage"), updates)
+    }
+
+    @Test
+    fun unsubscribe_stops_further_notifications() {
+        val store = newStore()
+        val updates = mutableListOf<String>()
+        val unsubscribe = store.subscribeTo(
+            UserModel::displayName,
+            triggerOnSubscribe = false,
+        ) { _, new -> updates += new }
+
+        store.dispatch(SetDisplayName("Babbage"))
+        unsubscribe()
+        store.dispatch(SetDisplayName("Lovelace"))
+
+        assertEquals(listOf("Babbage"), updates)
+    }
+
+    @Test
+    fun selector_throws_when_model_class_not_registered() {
+        // Build a ModelState that DOES NOT have UnregisteredModel registered.
+        val store = newStore()
+        var captured: Throwable? = null
+
+        store.subscribeFields(onSelectorError = { captured = it }) { scope ->
+            scope.on(UnregisteredModel::value, triggerOnSubscribe = false) { _, _ -> }
+        }
+
+        assertTrue(captured is IllegalStateException, "expected IllegalStateException for unregistered model")
+        assertEquals(true, captured!!.message!!.contains("UnregisteredModel"))
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ include(
     ":redux-kotlin-granular",
     ":redux-kotlin-multimodel",
     ":redux-kotlin-compose",
+    ":redux-kotlin-multimodel-granular",
     ":examples:counter:common",
     ":examples:counter:android",
     ":examples:todos:common",


### PR DESCRIPTION
Reopens / supersedes #281, which auto-closed when its old base branch was deleted during the merge-prep rebase. Branch content rebased onto current master — single integration commit, no cherry-picked multimodel commit (now redundant since #290/ζ landed).

## Summary

Tiny integration module bridging `redux-kotlin-granular` and `redux-kotlin-multimodel`. Reified inline `Store<ModelState>.subscribeTo(KProperty1<M, F>)` plus the `FieldSubscriptionScope.on(KProperty1<M, F>)` DSL form (both `@HiddenFromObjC`), plus non-inline `subscribeToModel(KClass, …)` / `onModel(KClass, …)` shims for raw JS/TS (review I11).

## Files

- `redux-kotlin-multimodel-granular/build.gradle.kts`
- `redux-kotlin-multimodel-granular/src/commonMain/.../SubscribeToModel.kt` (reified overloads)
- `redux-kotlin-multimodel-granular/src/commonMain/.../SubscribeToModelByClass.kt` (KClass shims)
- `redux-kotlin-multimodel-granular/src/commonTest/.../SubscribeToModelTest.kt` (8 cases)
- `settings.gradle.kts` (+1 line)

## Test plan

- [x] `:redux-kotlin-multimodel-granular:build` passes (all KMP targets compile)
- [x] `:jvmTest`, `:jsNodeTest`, `:wasmJsNodeTest` green
- [x] Detekt + `explicitApi` clean
- [ ] CI matrix on this fresh PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)