### PR TITLE
docs(website): document registry, compose, and multimodel-granular APIs

### DIFF
--- a/website/docs/advanced/Compose.md
+++ b/website/docs/advanced/Compose.md
@@ -1,0 +1,157 @@
+---
+id: compose-integration
+title: Jetpack / Multiplatform Compose
+sidebar_label: Compose Integration
+---
+
+# Compose Integration
+
+`redux-kotlin-compose` bridges a `redux-kotlin` `Store` to
+[Jetpack Compose](https://developer.android.com/jetpack/compose) /
+Compose Multiplatform. It turns a selected slice of store state into a
+Compose [`State<T>`](https://developer.android.com/jetpack/compose/state),
+so a Composable recomposes **only** when the slice it reads actually
+changes.
+
+The bridge is built on top of [Granular Subscriptions](granular-subscriptions):
+each binding is a `subscribeTo` under the hood, so recomposition is
+scoped to the exact field a Composable observes rather than every
+dispatch.
+
+## Installation
+
+```kotlin
+implementation("org.reduxkotlin:redux-kotlin-compose:<version>")
+```
+
+The module depends on `redux-kotlin-granular` and the Compose runtime.
+It targets the platforms that Compose Multiplatform supports.
+
+## Binding a field: `fieldState`
+
+The common case — bind one property of state to a `State<T>` using a
+Kotlin property reference:
+
+```kotlin
+import androidx.compose.runtime.getValue
+import org.reduxkotlin.compose.fieldState
+
+data class AppState(val user: User? = null, val count: Int = 0)
+
+@Composable
+fun Counter(store: Store<AppState>) {
+    val count by store.fieldState(AppState::count)
+    Text("Count: $count")
+}
+```
+
+`Counter` recomposes when `count` changes, but not when an unrelated
+field (e.g. `user`) changes.
+
+## Deriving a value: `selectorState`
+
+When you need to project or compute a value rather than read a property
+directly, use the lambda form:
+
+```kotlin
+import org.reduxkotlin.compose.selectorState
+
+@Composable
+fun OpenTodoBadge(store: Store<AppState>) {
+    val openCount by store.selectorState { it.todos.count { todo -> !todo.completed } }
+    Badge { Text("$openCount") }
+}
+```
+
+The Composable recomposes only when `openCount` itself changes — marking
+a todo complete that doesn't alter the count won't trigger it.
+
+:::note Selector stability
+The lambda passed to `selectorState` is remembered against the store and
+**frozen at first composition**. If the selector closes over other
+Composable state that should refresh the binding, prefer `fieldState`
+with a property reference, or re-key the subscription yourself inside a
+`LaunchedEffect`. The first frame is race-safe: the bridge re-samples
+the current state inside a `DisposableEffect`, so a dispatch landing
+between composition and commit is reflected immediately.
+:::
+
+## Skippability: `StableStore`
+
+Compose's stability inferrer treats interfaces as unstable. Because
+`Store<S>` is an interface, a Composable that takes a `Store<S>`
+parameter directly becomes **non-skippable** — it recomposes
+unconditionally whenever its parent does.
+
+Wrap the store in `StableStore` to restore skippability for downstream
+Composables:
+
+```kotlin
+import org.reduxkotlin.compose.StableStore
+import org.reduxkotlin.compose.rememberStableStore
+import org.reduxkotlin.compose.fieldState
+
+@Composable
+fun App(store: Store<AppState>) {
+    val stable = rememberStableStore(store)
+    Content(stable)
+}
+
+@Composable
+fun Content(store: StableStore<AppState>) {
+    val user by store.value.fieldState(AppState::user)
+    // Content is now skippable: it only recomposes when `user` changes.
+}
+```
+
+`StableStore` is a `@Stable` value class, so the wrapper costs nothing at
+runtime once inlined. `rememberStableStore(store)` is shorthand for
+`remember(store) { StableStore(store) }`.
+
+## Multi-model stores
+
+If you use [`ModelState`](../introduction/ecosystem) from `redux-kotlin-multimodel`,
+add `redux-kotlin-compose-multimodel` for property-reference bindings
+that resolve a field on a specific feature model — the call site never
+names `ModelState`:
+
+```kotlin
+implementation("org.reduxkotlin:redux-kotlin-compose-multimodel:<version>")
+```
+
+```kotlin
+import org.reduxkotlin.compose.multimodel.fieldState
+
+@Composable
+fun ProfileHeader(store: Store<ModelState>) {
+    // M (LoggedInUserModel) is inferred from the property reference's receiver.
+    val displayName by store.fieldState(LoggedInUserModel::displayName)
+    Text("Hello, $displayName")
+}
+```
+
+For callers that hold the model type as a `KClass` rather than a
+compile-time generic (raw JS/TS consumers, or generic helper code), use
+the non-inline `fieldStateOf`:
+
+```kotlin
+import org.reduxkotlin.compose.multimodel.fieldStateOf
+
+val displayName by store.fieldStateOf(LoggedInUserModel::class) { it.displayName }
+```
+
+## Lifecycle and threading
+
+Each binding subscribes inside a `DisposableEffect` and unsubscribes in
+`onDispose`, so subscriptions follow the Composable's lifecycle
+automatically — no manual tear-down. The underlying granular
+subscription inherits the store's threading guarantees; pair the bridge
+with [`createThreadSafeStore`](../api/createthreadsafestore) if you
+dispatch from multiple threads.
+
+## See also
+
+- [Granular Subscriptions](granular-subscriptions) — the field-level
+  subscription layer the Compose bridge is built on.
+- [Ecosystem](../introduction/ecosystem) — the full first-party module
+  list, including `redux-kotlin-multimodel`.

--- a/website/docs/advanced/GranularSubscriptions.md
+++ b/website/docs/advanced/GranularSubscriptions.md
@@ -124,6 +124,67 @@ val sub = store.subscribeFields(
 }
 ```
 
+## Multi-model stores
+
+If your store holds a `ModelState` from `redux-kotlin-multimodel` (a
+type-safe bag of independent feature models), the companion module
+`redux-kotlin-multimodel-granular` adds overloads that subscribe to a
+field of a **specific model** without naming `ModelState` at the call
+site. The model type is inferred from the property reference's receiver.
+
+```kotlin
+implementation("org.reduxkotlin:redux-kotlin-multimodel-granular:<version>")
+```
+
+```kotlin
+import org.reduxkotlin.multimodel.granular.subscribeTo
+
+// M (LoggedInUserModel) is inferred from the property reference.
+val unsubscribe = store.subscribeTo(LoggedInUserModel::displayName) { _, name ->
+    profileHeader.title = name
+}
+```
+
+Internally the selector is `state.get<M>().property` — one extra field
+read versus a plain single-model selector. The change-detection and
+`triggerOnSubscribe` semantics are identical to the core overloads.
+
+Inside a `subscribeFields { … }` block, use the `on(Model::field)`
+overload to mix fields from several feature models behind one underlying
+`store.subscribe`:
+
+```kotlin
+import org.reduxkotlin.multimodel.granular.on
+
+storeSubscription = store.subscribeFields {
+    on(LoggedInUserModel::displayName) { _, name -> userHeader.title = name }
+    on(CartModel::itemCount)           { _, n    -> cartBadge.count = n }
+    on(ThemeModel::palette)            { _, p    -> applyPalette(p) }
+}
+```
+
+### Raw JS / TS and Swift consumers
+
+The property-reference overloads above are `inline` + `reified` (and
+hidden from Swift), so they don't survive to the JS/TS or Objective-C
+boundary. Non-Kotlin consumers use the non-inline `subscribeToModel` /
+`onModel` overloads, which thread the model type through as a `KClass`
+argument and take a plain selector lambda:
+
+```kotlin
+import org.reduxkotlin.multimodel.granular.subscribeToModel
+
+val unsubscribe = store.subscribeToModel(
+    LoggedInUserModel::class,
+    { it.displayName },
+) { _, name ->
+    profileHeader.title = name
+}
+```
+
+`onModel(modelClass, selector) { … }` is the matching DSL form for use
+inside `subscribeFields { … }`.
+
 ## Threading
 
 The granular module does **not** introduce any locks of its own and
@@ -151,13 +212,16 @@ Composes safely with:
   contract (coroutine-serialised, lock-free MPSC queue, read-write
   lock, …).
 
-A subscribe/unsubscribe-during-dispatch-storm test surfaced a
-pre-existing race in `redux-kotlin-threadsafe` (the unsubscribe lambda
-returned by `store.subscribe(...)` mutates the listener list outside
-the lock). The granular layer itself never mutates its entries list
-after activation, so this is a `ThreadSafeStore`-level issue — see the
-`redux-kotlin-threadsafe` notes if you tear down subscriptions
-concurrently with dispatches.
+A subscribe/unsubscribe-during-dispatch-storm test originally surfaced a
+race in `redux-kotlin-threadsafe`: the unsubscribe lambda returned by
+`store.subscribe(...)` mutated the listener list outside the lock, which
+could corrupt the list or throw `ConcurrentModificationException` from
+inside the store's iteration loop. That race has since been **fixed** —
+`ThreadSafeStore` now wraps the returned unsubscribe so it re-acquires
+the same lock as `subscribe` and `dispatch`. The granular layer itself
+never mutates its entries list after activation, so tearing down
+granular subscriptions concurrently with dispatches is safe on
+`createThreadSafeStore`.
 
 ## Performance characteristics
 

--- a/website/docs/advanced/StoreRegistry.md
+++ b/website/docs/advanced/StoreRegistry.md
@@ -1,0 +1,203 @@
+---
+id: store-registry
+title: Store Registry
+sidebar_label: Store Registry
+---
+
+# Store Registry
+
+`redux-kotlin-registry` is an opt-in companion module that manages
+**multiple stores keyed by a unique identifier**, with thread-safe
+`getOrCreate` semantics. Use it whenever your app has scoped state that
+must not bleed between instances:
+
+- a per-thread-view store in a messaging app,
+- a per-call store in a calling app,
+- a per-screen store driven by a route identifier.
+
+The registry is a container only. It does not participate in dispatch or
+reducer execution, and a store's own thread-safety is orthogonal — wrap
+a registered store in [`createThreadSafeStore`](../api/createthreadsafestore)
+if it needs concurrent dispatch.
+
+## Installation
+
+```kotlin
+implementation("org.reduxkotlin:redux-kotlin-registry:<version>")
+```
+
+The module targets every platform the core library supports: JVM,
+Android, JS, wasmJs, iosArm64, iosX64, iosSimulatorArm64, macosArm64,
+macosX64, linuxX64, mingwX64. Its only dependencies are `redux-kotlin`
+and `kotlinx.atomicfu` — no coroutines requirement.
+
+## Tier 1: `StoreRegistry<K, S>`
+
+The headline API. One registry holds many stores of the **same** state
+type `S`, keyed by an identifier of type `K`.
+
+```kotlin
+import org.reduxkotlin.createStore
+import org.reduxkotlin.registry.StoreRegistry
+
+typealias ThreadId = String
+
+val threadStores = StoreRegistry<ThreadId, ThreadState>()
+
+fun openThread(id: ThreadId): Store<ThreadState> =
+    threadStores.getOrCreate(id) {
+        createThreadSafeStore(threadReducer, ThreadState())
+    }
+
+fun closeThread(id: ThreadId) {
+    threadStores.remove(id)
+}
+
+fun onLogout() {
+    threadStores.clear()
+}
+```
+
+### The singleton pattern
+
+`StoreRegistry` is intentionally a class, not a Kotlin `object`, so it
+stays testable (you can create a fresh one per test). If you want a
+process-global registry, hold a top-level `val` — that *is* the
+singleton, with zero ceremony:
+
+```kotlin
+val threadStores = StoreRegistry<ThreadId, ThreadState>()
+```
+
+Or inject one per surface through your DI graph.
+
+### API surface
+
+| Member | Behaviour |
+|---|---|
+| `get(id): Store<S>?` | Lock-free lookup. Returns `null` if absent. Never invokes a creator. |
+| `getOrCreate(id, creator): Store<S>` | Returns the existing store, or creates and inserts one. `creator` runs **at most once per id** across concurrent callers. |
+| `remove(id): Boolean` | Evicts the entry. Returns `true` if anything was removed. |
+| `clear()` | Atomically evicts all entries. |
+| `size` / `isEmpty` | Snapshot counters. |
+| `addListener(listener): RegistrySubscription` | Membership-change callback. Returns an unsubscribe lambda. |
+
+### Listening for membership changes
+
+```kotlin
+import org.reduxkotlin.registry.RegistryEvent
+
+val off = threadStores.addListener { event ->
+    when (event) {
+        is RegistryEvent.Added   -> telemetry.log("thread_store_opened", event.id)
+        is RegistryEvent.Removed -> telemetry.log("thread_store_closed", event.id)
+    }
+}
+
+// later, on tear-down:
+off()
+```
+
+`clear()` fires one `Removed` event per evicted entry (not a single
+coarse "cleared" event), so a listener that maintains a per-id index can
+use the same code path it uses for `remove(id)`.
+
+## Tier 2: `TypedStoreRegistry`
+
+Opt-in, for the rarer case where one logical bag must hold stores of
+**different** state types. Keys carry a `KClass<S>` type witness via
+[`storeKey`][storekey], so the registry stays type-safe at the lookup
+boundary.
+
+```kotlin
+import org.reduxkotlin.registry.TypedStoreRegistry
+import org.reduxkotlin.registry.storeKey
+
+val global = TypedStoreRegistry()
+
+val callStore: Store<CallState> =
+    global.getOrCreate(storeKey<CallState>(callId)) {
+        createStore(callReducer, CallState())
+    }
+
+val threadStore: Store<ThreadState> =
+    global.getOrCreate(storeKey<ThreadState>(threadId)) {
+        createStore(threadReducer, ThreadState())
+    }
+```
+
+[storekey]: #storekey
+
+### `storeKey`
+
+`storeKey<S>(id)` builds a `StoreKey<K, S>` that pairs your identifier
+with a state-type witness. Two keys are equal **only** when both the
+`id` and the state type match:
+
+```kotlin
+storeKey<CallState>("x") == storeKey<CallState>("x")   // true
+storeKey<CallState>("x") == storeKey<ThreadState>("x") // false — different state types
+```
+
+That discrimination is the safety property: two callers using the same
+`id` but different state types address **distinct** entries and can
+never silently alias each other's store. Internally there is a single
+unchecked cast on retrieval, which is provably safe because the only
+insertion path is the typed `getOrCreate`.
+
+### Choosing a tier
+
+Prefer **Tier 1**. Reach for Tier 2 only when one registry genuinely
+must mix state types; the `storeKey<S>(...)` ceremony at every call site
+is deliberate friction that steers you back to Tier 1 when it would do.
+
+## Concurrency
+
+Concurrency is a first-class concern of this module.
+
+- **Reads are lock-free.** `get(id)` and the fast path of
+  `getOrCreate` perform a single atomic load of an immutable map
+  snapshot followed by a `HashMap` lookup — no lock, no contention.
+- **`getOrCreate` runs `creator` at most once per id.** Under
+  contention, only one thread executes the creator; the others observe
+  the inserted store and return it. This matters when the creator has
+  side effects (opening a connection, allocating resources).
+- **Writes take a brief lock.** `getOrCreate` (on a miss), `remove`,
+  and `clear` acquire a `kotlinx.atomicfu` `SynchronizedObject` for the
+  duration of the map swap. Writes copy the map snapshot (`O(n)`), which
+  is microseconds for the dozens-to-thousands of entries typical of
+  scoped registries.
+- **Listeners fire under the lock.** Events are dispatched synchronously
+  on the mutating thread, while the lock is held, so the global order of
+  `Added`/`Removed` events matches the global order of mutations. The
+  practical consequences:
+  - Keep listener work short — a slow listener stalls all writers.
+  - **Do not call back into a mutating method** (`getOrCreate`,
+    `remove`, `clear`) from inside a listener — it will deadlock.
+  - Reads (`get`, `size`) from inside a listener are safe, because
+    reads never take the lock.
+
+If a listener throws, the exception propagates to the caller of the
+mutating operation and the remaining listeners are skipped. The mutation
+itself has already completed and is observable. Listeners should not
+throw.
+
+## Lifecycle
+
+Lifecycle is **manual**. The registry never auto-evicts — there is no
+TTL, reference counting, or weak-reference reaping. Tie eviction to
+whatever scope makes sense in your app (a ViewModel `onCleared`, a
+screen disposal, a logout flow).
+
+Removing a store from the registry does **not** dispatch a teardown
+action to it, does **not** unsubscribe its listeners, and does **not**
+invalidate references that callers already hold. The registry simply
+forgets it; any further cleanup of the store is the caller's
+responsibility.
+
+## See also
+
+- [createThreadSafeStore](../api/createthreadsafestore) — wrap a
+  registered store when multiple threads dispatch to it.
+- [Granular Subscriptions](granular-subscriptions) — bind UI to a
+  specific field of any store, including ones held in a registry.

--- a/website/docs/introduction/Ecosystem.md
+++ b/website/docs/introduction/Ecosystem.md
@@ -11,10 +11,27 @@ tools and extensions, and the community has created a wide variety of helpful ad
 tools. You don't need to use any of these addons to use Redux, but they can help make it easier to
 implement features and solve problems in your application.
 
-ReduxKotlin ecosystem is currently very small.  This list will be updated as needed.  
-
 For inspiration or examples, the JS ecosystem is quite rich and [can be explored
 here](https://redux.js.org/introduction/ecosystem).
+
+## First-party modules
+
+The core `redux-kotlin` library is intentionally minimal. Optional
+companion modules build on its contracts; add only the ones you need.
+All share the core's group id `org.reduxkotlin` and version.
+
+| Module | Purpose |
+|---|---|
+| `redux-kotlin` | The core store, reducer, and middleware contracts. |
+| `redux-kotlin-threadsafe` | [`createThreadSafeStore`](../api/createthreadsafestore) — a store wrapper that serialises access so any thread can dispatch, read, and subscribe safely. |
+| `redux-kotlin-granular` | [Granular Subscriptions](../advanced/granular-subscriptions) — subscribe to a single field or selector with an `(old, new)` callback that fires only when that value changes. |
+| `redux-kotlin-registry` | [Store Registry](../advanced/store-registry) — manage many stores keyed by a unique identifier, with thread-safe `getOrCreate` and manual lifecycle. |
+| `redux-kotlin-multimodel` | `ModelState` — a type-safe bag of independent feature models keyed by class, plus `combineModelReducers` to drive them from one store. |
+| `redux-kotlin-multimodel-granular` | [Granular subscriptions for `ModelState`](../advanced/granular-subscriptions#multi-model-stores) — `subscribeTo(Model::field)` / `subscribeToModel(...)`. |
+| `redux-kotlin-compose` | [Compose integration](../advanced/compose-integration) — bind store fields to Compose `State<T>` with `fieldState` / `selectorState`. |
+| `redux-kotlin-compose-multimodel` | Compose `fieldState(Model::field)` bindings for `ModelState` stores. |
+
+## Community
 
 **[Presenter-middleware](https://github.com/reduxkotlin/presenter-middleware)**  
 A middleware for writing concise UI binding code and no-fuss lifecycle/subscription management.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -49,6 +49,8 @@ const sidebars: SidebarsConfig = {
         'advanced/async-flow',
         'advanced/middleware',
         'advanced/granular-subscriptions',
+        'advanced/store-registry',
+        'advanced/compose-integration',
       ],
     },
     {


### PR DESCRIPTION
## Summary
Follow-up docs for the `redux-kotlin-registry` work merged in #295, plus coverage gaps for existing companion modules.

- **New** `advanced/store-registry` page — Tier 1 `StoreRegistry<K, S>`, Tier 2 `TypedStoreRegistry` / `storeKey`, concurrency model, manual lifecycle.
- **New** `advanced/compose-integration` page — `fieldState` / `selectorState`, `StableStore` / `rememberStableStore`, and the `compose-multimodel` `fieldState(Model::field)` bindings.
- **Granular page**: documented `redux-kotlin-multimodel-granular` (`subscribeTo(Model::field)`, `subscribeToModel`, `on`/`onModel`); refreshed the ThreadSafeStore unsubscribe-race note now that the race is fixed (commit on master).
- **Ecosystem page**: now lists all first-party modules with links.
- Wired the two new pages into `sidebars.ts`.

## Test plan
- [x] `npm run build` (Docusaurus) passes, EXIT=0, zero broken-link errors
- [x] No broken anchors introduced by the new/edited pages (pre-existing anchor warnings in `/api`, `/faq/*`, `/glossary` are untouched)
- [ ] CI "Website (Docusaurus build)" green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)