### PR TITLE
chore(website): Vercel redirects config + GitHub Actions deploy workflow

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,67 @@
+# Deploys the Docusaurus website (website/) to Vercel production.
+#
+# PREREQUISITES — this workflow is inert until you do both:
+#   1. Add three repo secrets (Settings → Secrets and variables → Actions):
+#        VERCEL_TOKEN        a Vercel access token (Account Settings → Tokens)
+#        VERCEL_ORG_ID       from `website/.vercel/project.json` after `vercel link`
+#        VERCEL_PROJECT_ID   from `website/.vercel/project.json` after `vercel link`
+#   2. Turn OFF Vercel's native Git auto-deploy for this project
+#        (Vercel → Project → Settings → Git → "Production Branch" / Ignored Build Step),
+#        otherwise every push to master deploys TWICE — once here, once by Vercel's
+#        own Git integration.
+#
+# Until VERCEL_TOKEN is set, the job short-circuits and stays green.
+name: Deploy Website
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'website/**'
+      - '.github/workflows/deploy-website.yml'
+  workflow_dispatch:
+
+# Avoid overlapping production deploys; cancel superseded runs.
+concurrency:
+  group: deploy-website
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build & deploy to Vercel (production)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - name: Guard — require VERCEL_TOKEN
+        id: guard
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::VERCEL_TOKEN is not configured — skipping deploy. See workflow header for setup."
+          else
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.guard.outputs.has_token == 'true'
+        uses: actions/checkout@v6
+
+      - name: Install Vercel CLI
+        if: steps.guard.outputs.has_token == 'true'
+        run: npm install -g vercel@latest
+
+      - name: Pull Vercel project settings (production)
+        if: steps.guard.outputs.has_token == 'true'
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+
+      - name: Build with production env
+        if: steps.guard.outputs.has_token == 'true'
+        run: vercel build --prod --token="$VERCEL_TOKEN"
+
+      - name: Deploy prebuilt output to production
+        if: steps.guard.outputs.has_token == 'true'
+        run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "redirects": [
+    { "source": "/introduction", "destination": "/introduction/getting-started" },
+    { "source": "/basics", "destination": "/basics/basic-tutorial" },
+    { "source": "/advanced", "destination": "/advanced/advanced-tutorial" },
+    { "source": "/api", "destination": "/api/api-reference" },
+
+    { "source": "/introduction/coreconcepts", "destination": "/introduction/core-concepts" },
+    { "source": "/introduction/learningresources", "destination": "/introduction/learning-resources" },
+    { "source": "/introduction/threeprinciples", "destination": "/introduction/three-principles" },
+    { "source": "/basics/dataflow", "destination": "/basics/data-flow" },
+    { "source": "/advanced/asyncactions", "destination": "/advanced/async-actions" },
+    { "source": "/advanced/asyncflow", "destination": "/advanced/async-flow" },
+    { "source": "/faq/storesetup", "destination": "/faq/store-setup" },
+
+    { "source": "/docs/introduction/CoreConcepts.html", "destination": "/introduction/core-concepts" },
+    { "source": "/docs/introduction/Motivation.html", "destination": "/introduction/motivation" },
+    { "source": "/docs/introduction/Ecosystem.html", "destination": "/introduction/ecosystem" },
+    { "source": "/docs/introduction/ThreePrinciples.html", "destination": "/introduction/three-principles" },
+    { "source": "/docs/introduction/Examples.html", "destination": "/introduction/examples" },
+    { "source": "/docs/basics/Reducers.html", "destination": "/basics/reducers" },
+    { "source": "/docs/basics/Actions.html", "destination": "/basics/actions" },
+    { "source": "/docs/basics/DataFlow.html", "destination": "/basics/data-flow" },
+    { "source": "/docs/basics/Store.html", "destination": "/basics/store" },
+    { "source": "/docs/advanced/AsyncActions.html", "destination": "/advanced/async-actions" },
+    { "source": "/docs/advanced/Middleware.html", "destination": "/advanced/middleware" },
+    { "source": "/docs/advanced/AsyncFlow.html", "destination": "/advanced/async-flow" },
+    { "source": "/docs/faq/General.html", "destination": "/faq/general" },
+    { "source": "/docs/faq/Reducers.html", "destination": "/faq/reducers-faq" },
+    { "source": "/docs/faq/StoreSetup.html", "destination": "/faq/store-setup" },
+    { "source": "/docs/api/createStore.html", "destination": "/api/createstore" },
+    { "source": "/docs/api/applyMiddleware.html", "destination": "/api/applymiddleware" },
+    { "source": "/docs/api/compose.html", "destination": "/api/compose" },
+    { "source": "/docs/api/Store.html", "destination": "/api/store-api" },
+    { "source": "/docs/Glossary.html", "destination": "/glossary" },
+    { "source": "/docs/Troubleshooting.html", "destination": "/troubleshooting" },
+    { "source": "/docs/FAQ.html", "destination": "/faq" }
+  ]
+}


### PR DESCRIPTION
## Summary
Sets up version-controlled deployment config for the Docusaurus site (reduxkotlin.org is hosted on **Vercel**).

### `website/vercel.json` — restored redirects (33)
The live site ignores `website/static/_redirects` (a Netlify/Cloudflare convention; Vercel doesn't read it). This ports the **still-relevant** rules to Vercel's `redirects` format:
- Section landing pages (`/introduction` → `/introduction/getting-started`, etc.)
- camelCase → kebab-case renames for pages that exist
- Legacy Gitbook `/docs/*.html` deep links for pages that exist
- **Fixes two stale targets** from the original copy: `/api/store` → `/api/store-api`, `/faq/reducers` → `/faq/reducers-faq`

Omitted: ~60 rules carried over from the React-Redux docs template that point at pages with no redux-kotlin equivalent (`/recipes/*`, `/basics/usage-with-react`, `react-redux`, …) — porting them would create redirect→404 chains. Happy to add any specific ones back if wanted.

### `.github/workflows/deploy-website.yml` — opt-in CI deploy
Build + `vercel deploy --prebuilt --prod` on push to `master` (paths `website/**`) and via manual dispatch.

**Inert until configured** — the job short-circuits (stays green) unless `VERCEL_TOKEN` is set. To enable:
1. Add repo secrets: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` (the IDs come from `website/.vercel/project.json` after `vercel link`).
2. **Disable Vercel's native Git auto-deploy** for the project, or every master push deploys twice (once here, once by Vercel's Git integration).

> Note: `website/static/_redirects` is left in place (harmless; Vercel ignores it). Remove it in a follow-up if you want.

## Test plan
- [x] `vercel.json` is valid JSON (33 redirects); every destination maps to an existing doc id
- [x] Workflow is valid YAML; all deploy steps gated behind the token guard
- [ ] CI green (Docusaurus build unaffected — `vercel.json` is not read by `docusaurus build`)
- [ ] (manual) After merge + secrets + disabling Vercel Git deploy: confirm a single production deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)