### PR TITLE
fix(build): always compile jvm/js/android targets regardless of host

### DIFF
--- a/build-conventions/src/main/kotlin/convention.control.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.control.gradle.kts
@@ -62,9 +62,10 @@ fun control(targets: NamedDomainObjectCollection<KotlinTarget>) {
         printlnCI("[${it.name}] ${!CI} || $SANDBOX || ${HostManager.hostIsMingw} = $enabled")
         enabled
     }
-    mainHostTargets.onlyBuildIf {
-        val enabled = mainEnabled || SANDBOX
-        printlnCI("[${it.name}] ${!CI} || $SANDBOX || $isMainHost = $enabled")
-        mainEnabled
-    }
+    // JVM/JS/Wasm/Android targets are host-independent and are consumed across the build
+    // (e.g. the Android sample apps depend on the example `:common` modules' compiled
+    // output). Host-gating their compilation — correct for native targets — starves those
+    // consumers on non-main hosts: the Android examples then fail to resolve their deps on a
+    // clean build. So always compile them; only native targets remain host-gated above.
+    mainHostTargets.onlyBuildIf { true }
 }


### PR DESCRIPTION
## Summary
The Android sample apps (`examples/*/android`) fail to compile on a clean build whenever the CI runner's OS differs from `project.mainOS` — `:examples:*:android:compileDebugKotlin` reports `Unresolved reference 'StoreSubscription' / 'examples' / 'createThreadSafeStore'`.

**Root cause:** `convention.control` gated `mainHostTargets` (jvm/js/wasm/android) compilation by `!CI || isMainHost`, the same rule used for native targets. Those targets are host-independent and are consumed across the build (the Android apps depend on the example `:common` modules' compiled output). On a non-main host their compile task is skipped, so on a clean checkout the consumers can't resolve them. Only native targets need host gating.

This is a pre-existing latent bug (it already breaks the `Check on windows-latest` job on master, where `isMainHost=false`). It became blocking because PR #298 sets `project.mainOS=macos`, which makes the ubuntu Sample-apps job a non-main host.

## Fix
`mainHostTargets.onlyBuildIf { true }` — always compile jvm/js/wasm/android; native targets stay host-gated.

## Test plan
- [x] Clean-room build (fresh `GRADLE_USER_HOME`, `isMainHost=false`): jvm compiles now run instead of being skipped; `:examples:{counter,todos}:android:assembleDebug` green
- [x] detekt passes (pre-commit hook)
- [ ] CI green on this PR (note: ubuntu + `mainOS=linux` ⇒ `isMainHost=true`, so this PR doesn't reproduce the original failure; definitive verification is PR #298 — `mainOS=macos` ⇒ ubuntu is non-main — going green after rebasing on this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)