### PR TITLE
feat(routing): redux-kotlin-routing module — routed (model,action) dispatch (Phase 1)

### DIFF
--- a/docs/superpowers/plans/2026-05-28-redux-kotlin-routing-phase1.md
+++ b/docs/superpowers/plans/2026-05-28-redux-kotlin-routing-phase1.md
@@ -1,0 +1,1670 @@
+# redux-kotlin-routing (Phase 1, Mechanism A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a new opt-in companion module `redux-kotlin-routing` that provides a runtime DSL for `(model, action)` routed dispatch over `ModelState`, replacing the `when(action){}` cascade with exact-leaf-class routing.
+
+**Architecture:** A `createModelStore { … }` builder collects per-model initial instances and handlers into a routing table keyed by the *exact* action `KClass`. It emits a plain `Reducer<ModelState>` that drops into the existing `createStore`. Dispatch looks up only the handlers registered for `action::class`, folds them over a transient working view (later handlers see earlier writes), and commits with at most one `ModelState` map copy — preserving `===` identity of untouched models so the granular layer's fast-path is unaffected.
+
+**Tech Stack:** Kotlin Multiplatform (all targets per `convention.library-mpp-loved`); `kotlin-test`; builds on `redux-kotlin` + `redux-kotlin-multimodel`; detekt 2.0.0-alpha.3 with `explicitApi()` + KDoc gate; binary-compatibility-validator (`apiDump`/`apiCheck`).
+
+**Spec:** `docs/superpowers/specs/2026-05-28-reducer-middleware-routing-design.md` (Phase 1 only; KSP codegen, compiler plugin, and the `-effects` module are out of scope).
+
+**Public API shape (target):**
+
+```kotlin
+val store: Store<ModelState> = createModelStore(
+    devChecks = false,            // opt-in immutability assertion
+    onWrite = null,               // opt-in !==-gated write observer
+) {
+    model(UserModel()) {                                   // structural init: instance supplied here
+        on<LoggedIn>  { s, a -> s.copy(user = a.user) }    // single-model, pure (M,A)->M
+        on<LoggedOut> { s, _ -> s.copy(user = null) }
+    }
+    model(CartModel()) {
+        on<AddItem> { s, a -> s.copy(items = s.items + a.item) }
+    }
+    onAction<Checkout> { reads, a ->                       // multi-model, returns a write-set
+        val cart = reads.get<CartModel>()
+        writeSet {
+            set(cart.copy(closed = true))
+            set(reads.get<UserModel>().copy(lastOrder = cart.id))
+        }
+    }
+    onBroadcast<Logout> { model, _ ->                      // runs for every installed model
+        if (model is Clearable) model.cleared() else model
+    }
+    install(SomeFeatureModule)                             // modular composition; order fixed here
+}
+```
+
+---
+
+## File Structure
+
+**New module `redux-kotlin-routing/`:**
+- `build.gradle.kts` — module config (mirror `redux-kotlin-registry`); deps `api(project(":redux-kotlin"))` + `api(project(":redux-kotlin-multimodel"))`.
+- `src/commonMain/kotlin/org/reduxkotlin/routing/WriteSet.kt` — `Reads` read-view, `WriteSet`, `WriteSetBuilder`, `writeSet { }`.
+- `src/commonMain/kotlin/org/reduxkotlin/routing/RoutingDsl.kt` — `RoutingBuilder`, `ModelHandlerScope<M>`, `ReduxModule`, `install`, registration functions (`model`/`on`/`onAction`/`onBroadcast`).
+- `src/commonMain/kotlin/org/reduxkotlin/routing/RoutedReducer.kt` — internal `WorkingState`, `Cell`, broadcast materialization, the `Reducer<ModelState>` fold.
+- `src/commonMain/kotlin/org/reduxkotlin/routing/CreateModelStore.kt` — `OnWrite` typealias, `createModelStore { }` entry point.
+- `src/commonTest/kotlin/org/reduxkotlin/routing/*.kt` — correctness tests + shared test fixtures.
+- `src/jvmTest/kotlin/org/reduxkotlin/routing/concurrency/*.kt` — threadsafe routed-dispatch stress.
+- `api/redux-kotlin-routing.klib.api` + `api/jvm/redux-kotlin-routing.api` — generated baselines.
+- `README.md`.
+
+**Modified existing module `redux-kotlin-multimodel/`:**
+- `src/commonMain/kotlin/org/reduxkotlin/multimodel/ModelState.kt` — add public `withAll(changes)` (single batch copy).
+- `src/commonTest/kotlin/org/reduxkotlin/multimodel/ModelStateTest.kt` — add/extend tests for `withAll`.
+- `api/*.api` — regenerated.
+
+**Modified root:**
+- `settings.gradle.kts` — add `:redux-kotlin-routing` to `include(...)`.
+
+---
+
+## Conventions (apply to every task)
+
+- **Package:** `org.reduxkotlin.routing`.
+- **`explicitApi()` is on:** every `public` declaration needs an explicit `public` modifier **and** a KDoc comment, including nested classes and their public properties. The code blocks below include the required KDoc — keep it.
+- **Detekt auto-correct:** the pre-commit hook runs `detektAll --auto-correct`; formatting (trailing commas, wrapping, brace style) is fixed in place. If a commit rewrites files, re-stage and commit again. Never use `--no-verify`.
+- **Commit style:** Conventional Commits (`feat`/`test`/`build`/`docs`), `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` footer is added automatically by the harness convention; here, plain messages are fine.
+- **Run a single module's common tests:** `./gradlew :redux-kotlin-routing:jvmTest` (fast inner loop; `allTests` runs every host target).
+
+---
+
+### Task 0: Scaffold the module
+
+**Files:**
+- Modify: `settings.gradle.kts:16-24`
+- Create: `redux-kotlin-routing/build.gradle.kts`
+- Create: `redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/.gitkeep`
+- Create: `redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/.gitkeep`
+
+- [ ] **Step 1: Register the module in settings**
+
+Modify `settings.gradle.kts`, adding the module to the `include(...)` list right after `:redux-kotlin-multimodel`:
+
+```kotlin
+include(
+    ":redux-kotlin",
+    ":redux-kotlin-threadsafe",
+    ":redux-kotlin-registry",
+    ":redux-kotlin-granular",
+    ":redux-kotlin-multimodel",
+    ":redux-kotlin-routing",
+    ":redux-kotlin-compose",
+    ":redux-kotlin-multimodel-granular",
+    ":redux-kotlin-compose-multimodel",
+    ":examples:counter:common",
+    ":examples:counter:android",
+    ":examples:todos:common",
+    ":examples:todos:android",
+)
+```
+
+- [ ] **Step 2: Create the build file**
+
+Create `redux-kotlin-routing/build.gradle.kts` (mirrors `redux-kotlin-registry`, but depends on multimodel and needs no atomicfu — the routed reducer is pure):
+
+```kotlin
+plugins {
+    id("convention.library-mpp-loved")
+    id("convention.publishing-mpp")
+}
+
+val hasAndroidSdk: Boolean = run {
+    val localProps = rootProject.file("local.properties")
+    val hasSdkInLocalProperties = localProps.exists() && localProps.readText().lineSequence().any {
+        it.trim().startsWith("sdk.dir=") && it.substringAfter("sdk.dir=").isNotBlank()
+    }
+    val hasSdkInEnv =
+        !System.getenv("ANDROID_HOME").isNullOrBlank() ||
+            !System.getenv("ANDROID_SDK_ROOT").isNullOrBlank()
+    hasSdkInLocalProperties || hasSdkInEnv
+}
+
+kotlin {
+    if (hasAndroidSdk) {
+        android {
+            namespace = "org.reduxkotlin.routing"
+        }
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":redux-kotlin"))
+                api(project(":redux-kotlin-multimodel"))
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Create source directories with placeholders**
+
+Create empty `redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/.gitkeep` and `redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/.gitkeep` so the source sets exist.
+
+- [ ] **Step 4: Verify the module configures and compiles (empty)**
+
+Run: `./gradlew :redux-kotlin-routing:compileKotlinJvm`
+Expected: `BUILD SUCCESSFUL` (nothing to compile yet, but the project must resolve).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add settings.gradle.kts redux-kotlin-routing/build.gradle.kts redux-kotlin-routing/src
+git commit -m "build(routing): scaffold redux-kotlin-routing module"
+```
+
+---
+
+### Task 1: Add `ModelState.withAll` to multimodel (batch single-copy write)
+
+The routing module cannot see `ModelState.models` (it is `internal`), and the dispatch fold must apply N model writes with **one** map copy. Add a public batch-write that mirrors `with`'s key-set check.
+
+**Files:**
+- Modify: `redux-kotlin-multimodel/src/commonMain/kotlin/org/reduxkotlin/multimodel/ModelState.kt`
+- Test: `redux-kotlin-multimodel/src/commonTest/kotlin/org/reduxkotlin/multimodel/ModelStateTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ModelStateTest.kt` (create the file with this content if it does not exist; if it exists, add these functions inside the existing test class — check the file first). If creating fresh:
+
+```kotlin
+package org.reduxkotlin.multimodel
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+
+private data class A(val n: Int)
+private data class B(val s: String)
+private data class Unregistered(val x: Int)
+
+class ModelStateWithAllTest {
+
+    @Test
+    fun withAll_replaces_multiple_models_in_one_call() {
+        val state = ModelState.of(A(1), B("x"))
+        val next = state.withAll(mapOf(A::class to A(2), B::class to B("y")))
+        assertEquals(A(2), next.get<A>())
+        assertEquals(B("y"), next.get<B>())
+    }
+
+    @Test
+    fun withAll_with_empty_map_returns_same_instance() {
+        val state = ModelState.of(A(1))
+        assertSame(state, state.withAll(emptyMap()))
+    }
+
+    @Test
+    fun withAll_rejects_unregistered_model_class() {
+        val state = ModelState.of(A(1))
+        assertFailsWith<IllegalStateException> {
+            state.withAll(mapOf(Unregistered::class to Unregistered(0)))
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-multimodel:jvmTest --tests "org.reduxkotlin.multimodel.ModelStateWithAllTest"`
+Expected: FAIL — `withAll` unresolved reference.
+
+- [ ] **Step 3: Implement `withAll`**
+
+In `ModelState.kt`, add this method inside the `ModelState` class, immediately after the non-reified `with(modelClass, model)` method:
+
+```kotlin
+    /**
+     * Returns a new [ModelState] with every slot named in [changes]
+     * replaced, in a single map copy. Other models are shared with the
+     * receiver. Returns the receiver unchanged when [changes] is empty.
+     *
+     * This is the batch form of [with]; it exists so a routed reducer
+     * can apply several model writes from one dispatch with exactly one
+     * allocation, preserving the `===` identity of untouched slots.
+     *
+     * @throws IllegalStateException if any key in [changes] was not
+     *   declared at construction; the key set is fixed by
+     *   [Companion.of].
+     */
+    public fun withAll(changes: Map<KClass<*>, Any>): ModelState {
+        if (changes.isEmpty()) return this
+        for (klass in changes.keys) {
+            check(klass in models) {
+                "Cannot replace model ${klass.simpleName ?: klass} that wasn't declared at construction. " +
+                    "ModelState's key set is fixed by ModelState.of(...)."
+            }
+        }
+        return ModelState(models + changes)
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-multimodel:jvmTest --tests "org.reduxkotlin.multimodel.ModelStateWithAllTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Regenerate the multimodel API dump**
+
+Run: `./gradlew :redux-kotlin-multimodel:apiDump`
+Expected: `BUILD SUCCESSFUL`; `redux-kotlin-multimodel/api/*.api` now lists `withAll`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add redux-kotlin-multimodel/src redux-kotlin-multimodel/api
+git commit -m "feat(multimodel): add ModelState.withAll for single-copy batch writes"
+```
+
+---
+
+### Task 2: `Reads` + `WriteSet` + `writeSet { }`
+
+**Files:**
+- Create: `redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/WriteSet.kt`
+- Test: `redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/WriteSetTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `WriteSetTest.kt`:
+
+```kotlin
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private data class Foo(val n: Int)
+private data class Bar(val s: String)
+
+class WriteSetTest {
+
+    @Test
+    fun writeSet_collects_models_keyed_by_class() {
+        val ws = writeSet {
+            set(Foo(1))
+            set(Bar("x"))
+        }
+        assertEquals(2, ws.changes.size)
+        assertEquals(Foo(1), ws.changes[Foo::class])
+        assertEquals(Bar("x"), ws.changes[Bar::class])
+    }
+
+    @Test
+    fun writeSet_last_set_for_a_class_wins() {
+        val ws = writeSet {
+            set(Foo(1))
+            set(Foo(2))
+        }
+        assertEquals(1, ws.changes.size)
+        assertEquals(Foo(2), ws.changes[Foo::class])
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-routing:jvmTest --tests "org.reduxkotlin.routing.WriteSetTest"`
+Expected: FAIL — unresolved references `writeSet`, `set`, `changes`.
+
+- [ ] **Step 3: Implement `WriteSet.kt`**
+
+```kotlin
+package org.reduxkotlin.routing
+
+import kotlin.reflect.KClass
+
+/**
+ * A read-only view of model state passed to multi-model handlers
+ * during a dispatch. Reads reflect writes already produced by earlier
+ * handlers in the same dispatch (fold semantics), so a later handler
+ * observes prior handlers' results.
+ */
+public interface Reads {
+    /**
+     * Returns the current working instance of [modelClass] for this
+     * dispatch.
+     *
+     * @throws IllegalStateException if [modelClass] was not registered
+     *   in the [createModelStore] block.
+     */
+    public fun <M : Any> get(modelClass: KClass<M>): M
+}
+
+/**
+ * Reified convenience for [Reads.get].
+ */
+public inline fun <reified M : Any> Reads.get(): M = get(M::class)
+
+/**
+ * The set of model replacements returned by a multi-model handler
+ * ([onAction]). Each entry replaces one model slot; a model not named
+ * here is left untouched. Build instances with [writeSet].
+ */
+public class WriteSet @PublishedApi internal constructor(
+    /** The replacements, keyed by concrete model class. */
+    @PublishedApi internal val changes: Map<KClass<*>, Any>,
+)
+
+/**
+ * Builder for [WriteSet]; the receiver of the [writeSet] lambda.
+ */
+public class WriteSetBuilder @PublishedApi internal constructor() {
+
+    @PublishedApi
+    internal val changes: MutableMap<KClass<*>, Any> = LinkedHashMap()
+
+    /**
+     * Stages [model] as the new instance for model type [M]. A later
+     * [set] for the same type overrides an earlier one.
+     */
+    public inline fun <reified M : Any> set(model: M): Unit = set(M::class, model)
+
+    /**
+     * Non-reified overload of [set] for callers holding a [KClass].
+     */
+    public fun <M : Any> set(modelClass: KClass<M>, model: M) {
+        changes[modelClass] = model
+    }
+}
+
+/**
+ * Builds a [WriteSet] from a sequence of [WriteSetBuilder.set] calls.
+ */
+public fun writeSet(block: WriteSetBuilder.() -> Unit): WriteSet {
+    val builder = WriteSetBuilder()
+    builder.block()
+    return WriteSet(builder.changes.toMap())
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-routing:jvmTest --tests "org.reduxkotlin.routing.WriteSetTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-routing/src
+git commit -m "feat(routing): add Reads view and WriteSet builder"
+```
+
+---
+
+### Task 3: Internal routing runtime — `WorkingState`, `Cell`, routed reducer
+
+This task adds the internal engine the DSL will populate. It has no public surface yet; it is exercised through `CreateModelStore`/`RoutingDsl` in Task 4. To keep TDD honest, write the engine and a white-box test that constructs cells directly.
+
+**Files:**
+- Create: `redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/RoutedReducer.kt`
+- Test: `redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/RoutedReducerTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `RoutedReducerTest.kt`:
+
+```kotlin
+package org.reduxkotlin.routing
+
+import org.reduxkotlin.multimodel.ModelState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+private data class Counter(val n: Int)
+private data class Flag(val on: Boolean)
+private object Inc
+private object Toggle
+private object Unhandled
+
+class RoutedReducerTest {
+
+    private fun table(): Map<Any, List<Cell>> = mapOf(
+        Inc::class to listOf(
+            Cell("counter") { working, _ ->
+                val c = working.get(Counter::class)
+                mapOf(Counter::class to c.copy(n = c.n + 1))
+            },
+        ),
+    )
+
+    @Test
+    fun dispatch_runs_only_the_matching_cell() {
+        val reducer = routedReducer(table(), broadcasts = emptyList(), devChecks = false, onWrite = null)
+        val s0 = ModelState.of(Counter(0), Flag(false))
+        val s1 = reducer(s0, Inc)
+        assertEquals(1, s1.get<Counter>().n)
+        assertEquals(false, s1.get<Flag>().on)
+    }
+
+    @Test
+    fun unhandled_action_returns_same_instance() {
+        val reducer = routedReducer(table(), broadcasts = emptyList(), devChecks = false, onWrite = null)
+        val s0 = ModelState.of(Counter(0), Flag(false))
+        assertSame(s0, reducer(s0, Unhandled))
+    }
+
+    @Test
+    fun handled_action_with_no_change_returns_same_instance() {
+        val noop = mapOf<Any, List<Cell>>(
+            Toggle::class to listOf(Cell("flag") { _, _ -> emptyMap() }),
+        )
+        val reducer = routedReducer(noop, broadcasts = emptyList(), devChecks = false, onWrite = null)
+        val s0 = ModelState.of(Flag(false))
+        assertSame(s0, reducer(s0, Toggle))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-routing:jvmTest --tests "org.reduxkotlin.routing.RoutedReducerTest"`
+Expected: FAIL — unresolved `Cell`, `routedReducer`, `WorkingState.get`.
+
+- [ ] **Step 3: Implement `RoutedReducer.kt`**
+
+```kotlin
+package org.reduxkotlin.routing
+
+import org.reduxkotlin.Reducer
+import org.reduxkotlin.multimodel.ModelState
+import kotlin.reflect.KClass
+
+/**
+ * A single registered handler keyed under one action class. Given the
+ * working state and the dispatched action, it returns the model
+ * replacements it wants to make (possibly empty). The change gate and
+ * the [OnWrite] notification are applied centrally by [routedReducer].
+ */
+internal class Cell(
+    val source: String,
+    val handler: (working: WorkingState, action: Any) -> Map<KClass<*>, Any>,
+)
+
+/**
+ * A broadcast handler that runs once per installed model for its action
+ * class. Materialized into per-model [Cell]s at reducer-build time so
+ * it covers every model regardless of declaration order.
+ */
+internal class Broadcast(
+    val actionClass: KClass<*>,
+    val perModel: (model: Any, action: Any) -> Any,
+)
+
+/**
+ * Transient per-dispatch working view over a base [ModelState]. Reads
+ * return staged writes first (so later handlers see earlier writes),
+ * falling back to the committed base. The staging map is allocated
+ * lazily on the first write, so a dispatch that changes nothing makes
+ * no map copy.
+ */
+internal class WorkingState(private val base: ModelState) : Reads {
+
+    var staged: MutableMap<KClass<*>, Any>? = null
+        private set
+
+    override fun <M : Any> get(modelClass: KClass<M>): M {
+        @Suppress("UNCHECKED_CAST")
+        return peek(modelClass) as M
+    }
+
+    fun peek(modelClass: KClass<*>): Any {
+        staged?.get(modelClass)?.let { return it }
+        return base.get(modelClass)
+    }
+
+    fun stage(modelClass: KClass<*>, model: Any) {
+        val current = staged ?: LinkedHashMap<KClass<*>, Any>().also { staged = it }
+        current[modelClass] = model
+    }
+}
+
+/**
+ * Builds the routed [Reducer] over [ModelState] from a finished routing
+ * table plus broadcast registrations.
+ */
+internal fun routedReducer(
+    table: Map<Any, List<Cell>>,
+    broadcasts: List<Broadcast>,
+    devChecks: Boolean,
+    onWrite: OnWrite?,
+    modelClasses: List<KClass<*>> = emptyList(),
+): Reducer<ModelState> {
+    // Materialize broadcasts into the table as per-model cells.
+    val full: Map<Any, List<Cell>> = if (broadcasts.isEmpty()) {
+        table
+    } else {
+        val merged = LinkedHashMap<Any, MutableList<Cell>>()
+        for ((key, cells) in table) merged[key] = cells.toMutableList()
+        for (broadcast in broadcasts) {
+            val cells = merged.getOrPut(broadcast.actionClass) { mutableListOf() }
+            for (modelClass in modelClasses) {
+                cells += Cell("broadcast:${modelClass.simpleName}") { working, action ->
+                    val current = working.peek(modelClass)
+                    val next = broadcast.perModel(current, action)
+                    if (next !== current) mapOf(modelClass to next) else emptyMap()
+                }
+            }
+        }
+        merged
+    }
+
+    return reducer@{ state, action ->
+        val cells = full[action::class] ?: return@reducer state
+        val working = WorkingState(state)
+        for (cell in cells) {
+            val writes = cell.handler(working, action)
+            for ((modelClass, next) in writes) {
+                val prev = working.peek(modelClass)
+                if (next !== prev) {
+                    check(!(devChecks && next == prev)) {
+                        "Handler '${cell.source}' returned a new but structurally-equal instance for " +
+                            "${modelClass.simpleName ?: modelClass}. This allocates without changing state and " +
+                            "would fire subscribers spuriously. Return the same instance when nothing changed."
+                    }
+                    onWrite?.invoke(action, modelClass, prev, next, cell.source)
+                    working.stage(modelClass, next)
+                }
+            }
+        }
+        val staged = working.staged ?: return@reducer state
+        state.withAll(staged)
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-routing:jvmTest --tests "org.reduxkotlin.routing.RoutedReducerTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-routing/src
+git commit -m "feat(routing): add internal routed-reducer engine"
+```
+
+---
+
+### Task 4: The DSL — `RoutingBuilder`, `model`/`on`, and `createModelStore`
+
+Wires the public builder to the engine and gives the first end-to-end single-model dispatch.
+
+**Files:**
+- Create: `redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/RoutingDsl.kt`
+- Create: `redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/CreateModelStore.kt`
+- Test: `redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/CreateModelStoreTest.kt`
+- Test fixtures: `redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/Fixtures.kt`
+
+- [ ] **Step 1: Write shared test fixtures**
+
+Create `Fixtures.kt` (shared sealed/data action + model types used across tests):
+
+```kotlin
+package org.reduxkotlin.routing
+
+/** A user model for tests. */
+internal data class UserModel(val user: String? = null, val lastOrder: Int = -1)
+
+/** A cart model for tests. */
+internal data class CartModel(val items: List<String> = emptyList(), val id: Int = 0, val closed: Boolean = false)
+
+/** Actions used across routing tests. */
+internal data class LoggedIn(val user: String)
+internal object LoggedOut
+internal data class AddItem(val item: String)
+internal object Checkout
+internal object ResetAll
+internal object NeverHandled
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `CreateModelStoreTest.kt`:
+
+```kotlin
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class CreateModelStoreTest {
+
+    private fun store() = createModelStore {
+        model(UserModel()) {
+            on<LoggedIn> { s, a -> s.copy(user = a.user) }
+            on<LoggedOut> { s, _ -> s.copy(user = null) }
+        }
+        model(CartModel()) {
+            on<AddItem> { s, a -> s.copy(items = s.items + a.item) }
+        }
+    }
+
+    @Test
+    fun single_model_handler_updates_its_model() {
+        val s = store()
+        s.dispatch(LoggedIn("ann"))
+        assertEquals("ann", s.state.get<UserModel>().user)
+    }
+
+    @Test
+    fun action_routes_only_to_its_model() {
+        val s = store()
+        val before = s.state.get<CartModel>()
+        s.dispatch(LoggedIn("ann"))
+        // Cart untouched -> same instance preserved (=== identity).
+        assertSame(before, s.state.get<CartModel>())
+    }
+
+    @Test
+    fun unhandled_action_leaves_state_identity_unchanged() {
+        val s = store()
+        val before = s.state
+        s.dispatch(NeverHandled)
+        assertSame(before, s.state)
+    }
+
+    @Test
+    fun logged_out_clears_user() {
+        val s = store()
+        s.dispatch(LoggedIn("ann"))
+        s.dispatch(LoggedOut)
+        assertNull(s.state.get<UserModel>().user)
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-routing:jvmTest --tests "org.reduxkotlin.routing.CreateModelStoreTest"`
+Expected: FAIL — unresolved `createModelStore`, `model`, `on`.
+
+- [ ] **Step 4: Implement `RoutingDsl.kt`**
+
+```kotlin
+package org.reduxkotlin.routing
+
+import org.reduxkotlin.Reducer
+import org.reduxkotlin.multimodel.ModelState
+import kotlin.reflect.KClass
+
+/**
+ * Collects model initial instances and action handlers, then produces
+ * the initial [ModelState] and the routed [Reducer]. This is the
+ * receiver of the [createModelStore] lambda and of [ReduxModule]
+ * contributions. Registration order across the whole block (including
+ * [install]ed modules) fixes the dispatch order for any action handled
+ * by more than one handler.
+ */
+public class RoutingBuilder @PublishedApi internal constructor() {
+
+    @PublishedApi
+    internal val initials: MutableList<Any> = mutableListOf()
+
+    @PublishedApi
+    internal val modelClasses: MutableList<KClass<*>> = mutableListOf()
+
+    @PublishedApi
+    internal val table: MutableMap<Any, MutableList<Cell>> = LinkedHashMap()
+
+    @PublishedApi
+    internal val broadcasts: MutableList<Broadcast> = mutableListOf()
+
+    /**
+     * Registers a model of type [M] with its [initial] instance and its
+     * single-model handlers. The initial instance is the sole source of
+     * that model's starting value — there is no INIT action fan-out.
+     *
+     * @throws IllegalArgumentException if [M] is registered more than
+     *   once.
+     */
+    public inline fun <reified M : Any> model(initial: M, block: ModelHandlerScope<M>.() -> Unit) {
+        registerModel(M::class, initial)
+        ModelHandlerScope(M::class, this).block()
+    }
+
+    /**
+     * Registers a multi-model handler for action [A]. The handler reads
+     * any models via [Reads] and returns a [WriteSet] of replacements.
+     */
+    public inline fun <reified A : Any> onAction(noinline handler: (reads: Reads, action: A) -> WriteSet) {
+        addCell(A::class, "onAction:${A::class.simpleName}") { working, action ->
+            @Suppress("UNCHECKED_CAST")
+            handler(working, action as A).changes
+        }
+    }
+
+    /**
+     * Registers a broadcast handler for action [A] that runs once per
+     * installed model. [transform] receives each model instance and
+     * returns its (possibly unchanged) replacement. Use for
+     * cross-cutting actions such as reset/logout that every model must
+     * observe.
+     */
+    public inline fun <reified A : Any> onBroadcast(noinline transform: (model: Any, action: A) -> Any) {
+        @Suppress("UNCHECKED_CAST")
+        registerBroadcast(A::class) { model, action -> transform(model, action as A) }
+    }
+
+    @PublishedApi
+    internal fun registerModel(modelClass: KClass<*>, initial: Any) {
+        require(modelClasses.none { it == modelClass }) {
+            "Model ${modelClass.simpleName ?: modelClass} registered more than once in createModelStore { }."
+        }
+        modelClasses += modelClass
+        initials += initial
+    }
+
+    @PublishedApi
+    internal fun addCell(actionClass: KClass<*>, source: String, handler: (WorkingState, Any) -> Map<KClass<*>, Any>) {
+        table.getOrPut(actionClass) { mutableListOf() } += Cell(source, handler)
+    }
+
+    @PublishedApi
+    internal fun registerBroadcast(actionClass: KClass<*>, perModel: (Any, Any) -> Any) {
+        broadcasts += Broadcast(actionClass, perModel)
+    }
+
+    internal fun buildInitialState(): ModelState = ModelState.of(*initials.toTypedArray())
+
+    internal fun buildReducer(devChecks: Boolean, onWrite: OnWrite?): Reducer<ModelState> =
+        routedReducer(table, broadcasts, devChecks, onWrite, modelClasses.toList())
+}
+
+/**
+ * The receiver of a [RoutingBuilder.model] block; registers
+ * single-model handlers for model type [M].
+ */
+public class ModelHandlerScope<M : Any> @PublishedApi internal constructor(
+    @PublishedApi internal val modelClass: KClass<M>,
+    @PublishedApi internal val builder: RoutingBuilder,
+) {
+    /**
+     * Registers a pure single-model handler for action [A]: given the
+     * current model and the action, return the next model instance
+     * (return the same instance to signal "no change"). Matching is by
+     * exact leaf class — a handler on [A] does not catch subtypes of
+     * [A].
+     */
+    public inline fun <reified A : Any> on(noinline reducer: (model: M, action: A) -> M) {
+        builder.addCell(A::class, "model:${modelClass.simpleName}") { working, action ->
+            val model = working.get(modelClass)
+            @Suppress("UNCHECKED_CAST")
+            val next = reducer(model, action as A)
+            if (next !== model) mapOf<KClass<*>, Any>(modelClass to next) else emptyMap()
+        }
+    }
+}
+
+/**
+ * A reusable bundle of model and handler registrations that can be
+ * [install]ed into a [RoutingBuilder]. Lets feature modules package
+ * their slice of the store; the app fixes ordering by the sequence of
+ * [install] calls.
+ */
+public fun interface ReduxModule {
+    /** Contributes this module's models and handlers to the builder. */
+    public fun RoutingBuilder.contribute()
+}
+
+/**
+ * Applies a [ReduxModule]'s registrations to this builder, in call
+ * order.
+ */
+public fun RoutingBuilder.install(module: ReduxModule) {
+    with(module) { contribute() }
+}
+```
+
+- [ ] **Step 5: Implement `CreateModelStore.kt`**
+
+```kotlin
+package org.reduxkotlin.routing
+
+import org.reduxkotlin.Store
+import org.reduxkotlin.StoreEnhancer
+import org.reduxkotlin.createStore
+import org.reduxkotlin.multimodel.ModelState
+import kotlin.reflect.KClass
+
+/**
+ * Observer invoked for every effective model write during a dispatch,
+ * i.e. only when the new instance is referentially different
+ * (`next !== prev`). Fired synchronously during the fold, before the
+ * dispatch commits, so under last-write-wins it can observe
+ * intermediate (clobbered) values. It MUST be a pure observer: it must
+ * not call `dispatch` or read the store.
+ */
+public typealias OnWrite = (action: Any, modelClass: KClass<*>, prev: Any, next: Any, source: String) -> Unit
+
+/**
+ * Builds a [Store] of [ModelState] from a routing [block]. Each model's
+ * starting value comes from its [RoutingBuilder.model] declaration;
+ * there is no INIT-action fan-out. Dispatch routes by the exact leaf
+ * class of the action.
+ *
+ * @param enhancer optional store enhancer (e.g. `applyMiddleware`),
+ *   passed straight to [createStore].
+ * @param devChecks when true, throws if a handler returns a new but
+ *   structurally-equal model instance (a wasteful no-op write that
+ *   would fire subscribers spuriously).
+ * @param onWrite optional [OnWrite] observer for tracing/conflict
+ *   detection.
+ */
+public fun createModelStore(
+    enhancer: StoreEnhancer<ModelState>? = null,
+    devChecks: Boolean = false,
+    onWrite: OnWrite? = null,
+    block: RoutingBuilder.() -> Unit,
+): Store<ModelState> {
+    val builder = RoutingBuilder()
+    builder.block()
+    val initialState = builder.buildInitialState()
+    val reducer = builder.buildReducer(devChecks, onWrite)
+    return createStore(reducer, initialState, enhancer)
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-routing:jvmTest --tests "org.reduxkotlin.routing.CreateModelStoreTest"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add redux-kotlin-routing/src
+git commit -m "feat(routing): add createModelStore DSL with single-model handlers"
+```
+
+---
+
+### Task 5: Exact-leaf matching guard
+
+Lock the documented narrowing: a handler registered on a type does **not** catch its subtypes.
+
+**Files:**
+- Test: `redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/ExactLeafMatchingTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ExactLeafMatchingTest.kt`:
+
+```kotlin
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+private sealed interface Nav
+private data class Open(val screen: String) : Nav
+private data class Close(val screen: String) : Nav
+
+private data class NavModel(val current: String = "home", val opens: Int = 0)
+
+class ExactLeafMatchingTest {
+
+    private fun store() = createModelStore {
+        model(NavModel()) {
+            on<Open> { s, a -> s.copy(current = a.screen, opens = s.opens + 1) }
+        }
+    }
+
+    @Test
+    fun handler_matches_its_exact_leaf_class() {
+        val s = store()
+        s.dispatch(Open("profile"))
+        assertEquals("profile", s.state.get<NavModel>().current)
+        assertEquals(1, s.state.get<NavModel>().opens)
+    }
+
+    @Test
+    fun handler_does_not_match_a_sibling_subtype() {
+        val s = store()
+        val before = s.state
+        s.dispatch(Close("profile")) // no handler registered for Close
+        assertSame(before, s.state)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes (already-correct behavior)**
+
+Run: `./gradlew :redux-kotlin-routing:jvmTest --tests "org.reduxkotlin.routing.ExactLeafMatchingTest"`
+Expected: PASS — the engine keys by `action::class`, so `Close` finds no cell. This test documents and locks the behavior.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add redux-kotlin-routing/src
+git commit -m "test(routing): lock exact-leaf-class matching semantics"
+```
+
+---
+
+### Task 6: Multi-model handlers — `onAction`, fold ordering, last-write-wins
+
+**Files:**
+- Test: `redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/MultiModelTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `MultiModelTest.kt`:
+
+```kotlin
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class MultiModelTest {
+
+    private fun store() = createModelStore {
+        model(UserModel()) {
+            on<LoggedIn> { s, a -> s.copy(user = a.user) }
+        }
+        model(CartModel(id = 7)) {
+            on<AddItem> { s, a -> s.copy(items = s.items + a.item) }
+        }
+        onAction<Checkout> { reads, _ ->
+            val cart = reads.get<CartModel>()
+            writeSet {
+                set(cart.copy(closed = true))
+                set(reads.get<UserModel>().copy(lastOrder = cart.id))
+            }
+        }
+    }
+
+    @Test
+    fun multi_model_handler_writes_several_models() {
+        val s = store()
+        s.dispatch(LoggedIn("ann"))
+        s.dispatch(AddItem("book"))
+        s.dispatch(Checkout)
+        assertTrue(s.state.get<CartModel>().closed)
+        assertEquals(7, s.state.get<UserModel>().lastOrder)
+    }
+
+    @Test
+    fun later_handler_in_same_action_sees_earlier_write() {
+        // Two handlers for one action: a single-model cart writer runs
+        // first, then a multi-model handler reads the updated cart.
+        val s = createModelStore {
+            model(CartModel(id = 1)) {
+                on<Checkout> { c, _ -> c.copy(items = c.items + "auto") }
+            }
+            model(UserModel()) {}
+            onAction<Checkout> { reads, _ ->
+                val cart = reads.get<CartModel>() // must see the "auto" item
+                writeSet { set(reads.get<UserModel>().copy(user = cart.items.joinToString())) }
+            }
+        }
+        s.dispatch(Checkout)
+        assertEquals("auto", s.state.get<UserModel>().user)
+    }
+
+    @Test
+    fun unchanged_models_keep_identity_after_multi_write() {
+        val s = store()
+        s.dispatch(LoggedIn("ann"))
+        val userBefore = s.state.get<UserModel>()
+        s.dispatch(AddItem("book")) // touches only cart
+        assertSame(userBefore, s.state.get<UserModel>())
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-routing:jvmTest --tests "org.reduxkotlin.routing.MultiModelTest"`
+Expected: PASS — `onAction` and the fold are already implemented in Tasks 3–4; this exercises the multi-model path and fold ordering.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add redux-kotlin-routing/src
+git commit -m "test(routing): cover multi-model handlers and fold ordering"
+```
+
+---
+
+### Task 7: Broadcast handlers — `onBroadcast` runs for every installed model
+
+**Files:**
+- Test: `redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/BroadcastTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `BroadcastTest.kt`:
+
+```kotlin
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class BroadcastTest {
+
+    @Test
+    fun broadcast_runs_for_every_installed_model() {
+        val s = createModelStore {
+            model(UserModel(user = "ann")) {}
+            model(CartModel(items = listOf("book"))) {}
+            // Reset every model to a cleared instance.
+            onBroadcast<ResetAll> { model, _ ->
+                when (model) {
+                    is UserModel -> UserModel()
+                    is CartModel -> CartModel()
+                    else -> model
+                }
+            }
+        }
+        s.dispatch(ResetAll)
+        assertNull(s.state.get<UserModel>().user)
+        assertEquals(emptyList(), s.state.get<CartModel>().items)
+    }
+
+    @Test
+    fun broadcast_covers_models_declared_after_it() {
+        // onBroadcast registered before the second model; must still
+        // cover it because broadcasts materialize at build time.
+        val s = createModelStore {
+            model(UserModel(user = "ann")) {}
+            onBroadcast<ResetAll> { model, _ -> if (model is UserModel) UserModel() else model }
+            model(CartModel(items = listOf("book"))) {}
+        }
+        s.dispatch(ResetAll)
+        assertNull(s.state.get<UserModel>().user)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-routing:jvmTest --tests "org.reduxkotlin.routing.BroadcastTest"`
+Expected: PASS — `onBroadcast` + build-time materialization implemented in Tasks 3–4.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add redux-kotlin-routing/src
+git commit -m "test(routing): cover onBroadcast fan-out across installed models"
+```
+
+---
+
+### Task 8: Modular composition — `install(ReduxModule)` and order-at-creation
+
+**Files:**
+- Test: `redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/ModuleInstallTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ModuleInstallTest.kt`:
+
+```kotlin
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private data class Audit(val log: List<String> = emptyList())
+
+class ModuleInstallTest {
+
+    private val userModule = ReduxModule {
+        model(UserModel()) {
+            on<LoggedIn> { s, a -> s.copy(user = a.user) }
+        }
+    }
+
+    @Test
+    fun installed_module_contributes_models_and_handlers() {
+        val s = createModelStore {
+            install(userModule)
+        }
+        s.dispatch(LoggedIn("ann"))
+        assertEquals("ann", s.state.get<UserModel>().user)
+    }
+
+    @Test
+    fun handler_order_follows_install_order() {
+        // Two handlers for the same action append to the audit log in
+        // registration order; install order is the composition point.
+        val first = ReduxModule {
+            model(Audit()) {
+                on<Checkout> { a, _ -> a.copy(log = a.log + "first") }
+            }
+        }
+        val second = ReduxModule {
+            onAction<Checkout> { reads, _ ->
+                val a = reads.get<Audit>()
+                writeSet { set(a.copy(log = a.log + "second")) }
+            }
+        }
+        val s = createModelStore {
+            install(first)
+            install(second)
+        }
+        s.dispatch(Checkout)
+        assertEquals(listOf("first", "second"), s.state.get<Audit>().log)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-routing:jvmTest --tests "org.reduxkotlin.routing.ModuleInstallTest"`
+Expected: PASS — `install` and ordered table append implemented in Task 4.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add redux-kotlin-routing/src
+git commit -m "test(routing): cover ReduxModule install and creation-time ordering"
+```
+
+---
+
+### Task 9: `onWrite` hook — `!==`-gated, intermediate values, source label
+
+**Files:**
+- Test: `redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/OnWriteHookTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `OnWriteHookTest.kt`:
+
+```kotlin
+package org.reduxkotlin.routing
+
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private data class Write(val modelClass: KClass<*>, val prev: Any, val next: Any, val source: String)
+
+class OnWriteHookTest {
+
+    @Test
+    fun hook_fires_once_per_effective_write_with_source() {
+        val writes = mutableListOf<Write>()
+        val s = createModelStore(
+            onWrite = { _, modelClass, prev, next, source -> writes += Write(modelClass, prev, next, source) },
+        ) {
+            model(UserModel()) {
+                on<LoggedIn> { u, a -> u.copy(user = a.user) }
+            }
+        }
+        s.dispatch(LoggedIn("ann"))
+        assertEquals(1, writes.size)
+        assertEquals(UserModel::class, writes[0].modelClass)
+        assertEquals(UserModel(), writes[0].prev)
+        assertEquals(UserModel(user = "ann"), writes[0].next)
+        assertTrue(writes[0].source.contains("UserModel"))
+    }
+
+    @Test
+    fun hook_does_not_fire_for_no_op_handler() {
+        val writes = mutableListOf<Write>()
+        val s = createModelStore(
+            onWrite = { _, modelClass, prev, next, source -> writes += Write(modelClass, prev, next, source) },
+        ) {
+            model(UserModel()) {
+                on<LoggedOut> { u, _ -> u } // returns same instance -> no write
+            }
+        }
+        s.dispatch(LoggedOut)
+        assertTrue(writes.isEmpty())
+    }
+
+    @Test
+    fun hook_observes_intermediate_values_under_last_write_wins() {
+        val nexts = mutableListOf<Any>()
+        // Two handlers for the same action both write UserModel.
+        val s = createModelStore(
+            onWrite = { _, _, _, next, _ -> nexts += next },
+        ) {
+            model(UserModel()) {
+                on<Checkout> { u, _ -> u.copy(user = "a") }
+            }
+            onAction<Checkout> { reads, _ ->
+                writeSet { set(reads.get<UserModel>().copy(user = "b")) }
+            }
+        }
+        s.dispatch(Checkout)
+        assertEquals(listOf(UserModel(user = "a"), UserModel(user = "b")), nexts)
+        assertEquals("b", s.state.get<UserModel>().user) // committed = last write
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-routing:jvmTest --tests "org.reduxkotlin.routing.OnWriteHookTest"`
+Expected: PASS — `onWrite` plumbed in Tasks 3–4.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add redux-kotlin-routing/src
+git commit -m "test(routing): cover the !==-gated onWrite hook"
+```
+
+---
+
+### Task 10: `devChecks` immutability assertion
+
+**Files:**
+- Test: `redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/DevChecksTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `DevChecksTest.kt`:
+
+```kotlin
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class DevChecksTest {
+
+    @Test
+    fun devChecks_throws_on_structurally_equal_new_instance() {
+        val s = createModelStore(devChecks = true) {
+            model(UserModel()) {
+                // Returns a brand-new instance that is structurally equal: a wasteful no-op write.
+                on<LoggedIn> { u, _ -> u.copy() }
+            }
+        }
+        assertFailsWith<IllegalStateException> {
+            s.dispatch(LoggedIn("ann"))
+        }
+    }
+
+    @Test
+    fun devChecks_allows_real_change() {
+        val s = createModelStore(devChecks = true) {
+            model(UserModel()) {
+                on<LoggedIn> { u, a -> u.copy(user = a.user) }
+            }
+        }
+        s.dispatch(LoggedIn("ann")) // does not throw
+    }
+
+    @Test
+    fun without_devChecks_no_op_copy_is_silently_committed() {
+        val s = createModelStore(devChecks = false) {
+            model(UserModel()) {
+                on<LoggedIn> { u, _ -> u.copy() }
+            }
+        }
+        s.dispatch(LoggedIn("ann")) // no throw; just a wasteful write
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-routing:jvmTest --tests "org.reduxkotlin.routing.DevChecksTest"`
+Expected: PASS — the `check(!(devChecks && next == prev))` guard is implemented in Task 3.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add redux-kotlin-routing/src
+git commit -m "test(routing): cover devChecks immutability assertion"
+```
+
+---
+
+### Task 11: All-or-nothing error semantics
+
+**Files:**
+- Test: `redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/ErrorSemanticsTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ErrorSemanticsTest.kt`:
+
+```kotlin
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+private class Boom : RuntimeException("boom")
+
+class ErrorSemanticsTest {
+
+    @Test
+    fun throwing_handler_aborts_dispatch_without_partial_commit() {
+        val s = createModelStore {
+            model(UserModel()) {
+                on<Checkout> { u, _ -> u.copy(user = "ann") } // staged first
+            }
+            onAction<Checkout> { _, _ -> throw Boom() } // throws before commit
+        }
+        val before = s.state
+        assertFailsWith<Boom> { s.dispatch(Checkout) }
+        // No partial commit: the earlier staged write must not survive.
+        assertSame(before, s.state)
+        assertTrue(s.state.get<UserModel>().user == null)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-routing:jvmTest --tests "org.reduxkotlin.routing.ErrorSemanticsTest"`
+Expected: PASS — staging is local to `WorkingState`; a throw propagates before `withAll`, so `createStore` never reassigns `currentState`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add redux-kotlin-routing/src
+git commit -m "test(routing): lock all-or-nothing dispatch error semantics"
+```
+
+---
+
+### Task 12: Granular integration — precise `===` firing
+
+Confirms the routed store composes with `redux-kotlin-granular` (which is not a routing dependency, so the test lives where granular is available — add a test-only dependency).
+
+**Files:**
+- Modify: `redux-kotlin-routing/build.gradle.kts` (add `commonTest` dependency on granular + multimodel-granular)
+- Test: `redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/GranularIntegrationTest.kt`
+
+- [ ] **Step 1: Add the test dependency**
+
+In `redux-kotlin-routing/build.gradle.kts`, add a `commonTest` source-set block inside `sourceSets { … }` (after the `commonMain { … }` block):
+
+```kotlin
+        commonTest {
+            dependencies {
+                implementation(project(":redux-kotlin-granular"))
+            }
+        }
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `GranularIntegrationTest.kt`:
+
+```kotlin
+package org.reduxkotlin.routing
+
+import org.reduxkotlin.granular.subscribeTo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GranularIntegrationTest {
+
+    @Test
+    fun subscriber_fires_only_when_its_model_changes() {
+        val s = createModelStore {
+            model(UserModel()) {
+                on<LoggedIn> { u, a -> u.copy(user = a.user) }
+            }
+            model(CartModel()) {
+                on<AddItem> { c, a -> c.copy(items = c.items + a.item) }
+            }
+        }
+        var userFires = 0
+        s.subscribeTo(selector = { it.get<UserModel>() }, triggerOnSubscribe = false) { _, _ -> userFires++ }
+
+        s.dispatch(AddItem("book")) // cart only -> user selector unchanged
+        assertEquals(0, userFires)
+
+        s.dispatch(LoggedIn("ann")) // user changes
+        assertEquals(1, userFires)
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails, then passes**
+
+Run: `./gradlew :redux-kotlin-routing:jvmTest --tests "org.reduxkotlin.routing.GranularIntegrationTest"`
+Expected: PASS once the dependency resolves. (If `subscribeTo`'s parameter names differ, open `redux-kotlin-granular/src/commonMain/kotlin/org/reduxkotlin/granular/SubscribeFields.kt` and match the actual signature — verified at plan time as `subscribeTo(selector, triggerOnSubscribe, listener)`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add redux-kotlin-routing/build.gradle.kts redux-kotlin-routing/src
+git commit -m "test(routing): verify precise granular subscription firing"
+```
+
+---
+
+### Task 13: JVM concurrency stress under the thread-safe wrapper
+
+**Files:**
+- Modify: `redux-kotlin-routing/build.gradle.kts` (add `commonTest`/`jvmTest` dependency on threadsafe)
+- Test: `redux-kotlin-routing/src/jvmTest/kotlin/org/reduxkotlin/routing/concurrency/RoutedThreadSafeStressTest.kt`
+
+- [ ] **Step 1: Add the threadsafe test dependency**
+
+In `redux-kotlin-routing/build.gradle.kts`, add to the `commonTest` dependencies block created in Task 12:
+
+```kotlin
+                implementation(project(":redux-kotlin-threadsafe"))
+```
+
+- [ ] **Step 2: Write the failing test**
+
+The routed reducer is internal, so a test cannot re-wrap it with `createThreadSafeStore` directly; production code wraps the whole `Store` returned by `createModelStore`. This test instead serializes dispatch with an explicit lock — the same single-lock contract `redux-kotlin-threadsafe` provides — to validate that the routed fold + `withAll` commit is internally consistent under concurrent drive. Create `RoutedThreadSafeStressTest.kt`:
+
+```kotlin
+package org.reduxkotlin.routing.concurrency
+
+import org.reduxkotlin.routing.AddItem
+import org.reduxkotlin.routing.CartModel
+import org.reduxkotlin.routing.createModelStore
+import org.reduxkotlin.routing.get
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RoutedThreadSafeStressTest {
+
+    @Test
+    fun externally_synchronized_concurrent_dispatch_does_not_lose_writes() {
+        val store = createModelStore {
+            model(CartModel()) {
+                on<AddItem> { c, a -> c.copy(items = c.items + a.item) }
+            }
+        }
+        val lock = Any()
+        val threads = 8
+        val perThread = 1000
+        val pool = Executors.newFixedThreadPool(threads)
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(threads)
+        repeat(threads) {
+            pool.submit {
+                start.await()
+                repeat(perThread) { synchronized(lock) { store.dispatch(AddItem("x")) } }
+                done.countDown()
+            }
+        }
+        start.countDown()
+        done.await()
+        pool.shutdown()
+        assertEquals(threads * perThread, store.state.get<CartModel>().items.size)
+    }
+}
+```
+
+This validates that the routed fold + `withAll` commit is internally consistent under serialized concurrent dispatch (the contract the `redux-kotlin-threadsafe` wrapper provides via one lock). The `threadsafe` test dependency added in Step 1 documents the intended production wrapping even though this test synchronizes directly.
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-routing:jvmTest --tests "org.reduxkotlin.routing.concurrency.RoutedThreadSafeStressTest"`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add redux-kotlin-routing/build.gradle.kts redux-kotlin-routing/src
+git commit -m "test(routing): add JVM concurrency stress for routed dispatch"
+```
+
+---
+
+### Task 14: README, API dump, full-tree gate
+
+**Files:**
+- Create: `redux-kotlin-routing/README.md`
+- Create (generated): `redux-kotlin-routing/api/redux-kotlin-routing.klib.api`, `redux-kotlin-routing/api/jvm/redux-kotlin-routing.api`
+
+- [ ] **Step 1: Write the README**
+
+Create `redux-kotlin-routing/README.md`:
+
+```markdown
+# redux-kotlin-routing
+
+Routed `(model, action)` dispatch over `ModelState`. Replaces the
+`when(action) {}` cascade with exact-leaf-class routing: an action only
+visits the handlers registered for its concrete class, and only the
+models a handler changes are rebuilt (preserving `===` identity of the
+rest, so the granular subscription layer stays precise).
+
+## Quick start
+
+```kotlin
+val store = createModelStore {
+    model(UserModel()) {
+        on<LoggedIn>  { s, a -> s.copy(user = a.user) }
+        on<LoggedOut> { s, _ -> s.copy(user = null) }
+    }
+    model(CartModel()) {
+        on<AddItem> { s, a -> s.copy(items = s.items + a.item) }
+    }
+    onAction<Checkout> { reads, _ ->
+        val cart = reads.get<CartModel>()
+        writeSet { set(cart.copy(closed = true)) }
+    }
+    onBroadcast<Logout> { model, _ -> /* reset each model */ model }
+    install(SomeFeatureModule)
+}
+```
+
+## Semantics
+
+- **Exact-leaf matching.** `on<Open>` matches `Open`, not subtypes of a
+  shared sealed parent. Register each leaf, or use `onBroadcast` for
+  cross-cutting actions.
+- **Structural init.** A model's starting value is its `model(initial)`
+  declaration. There is no INIT-action fan-out.
+- **Order fixed at creation.** Handlers for the same action run in
+  registration order; `install(module)` order is the composition point.
+- **Last-write-wins** on same-model writes within one dispatch.
+- **Immutability is required.** Return a new instance to signal a
+  change, the same instance for "no change". Enable `devChecks = true`
+  to fail fast on wasteful structurally-equal copies.
+- **All-or-nothing.** A handler that throws aborts the whole dispatch;
+  no partial commit.
+
+Built on `redux-kotlin` + `redux-kotlin-multimodel`. Wrap with
+`createThreadSafeStore` for cross-thread access; composes with
+`redux-kotlin-granular` and the Compose bindings unchanged.
+```
+
+- [ ] **Step 2: Generate the API baseline**
+
+Run: `./gradlew :redux-kotlin-routing:apiDump`
+Expected: `BUILD SUCCESSFUL`; `redux-kotlin-routing/api/` now contains the `.klib.api` and `jvm/*.api` baselines listing the public surface (`createModelStore`, `RoutingBuilder`, `ModelHandlerScope`, `ReduxModule`, `install`, `Reads`, `WriteSet`, `WriteSetBuilder`, `writeSet`, `OnWrite`).
+
+- [ ] **Step 3: Run the full module gate**
+
+Run: `./gradlew :redux-kotlin-routing:build`
+Expected: `BUILD SUCCESSFUL` — compiles, runs tests, passes `apiCheck`, passes detekt (`explicitApi` + KDoc). If detekt reports a missing KDoc on a public symbol, add it (do not hand-fix formatting — the pre-commit auto-correct handles that).
+
+- [ ] **Step 4: Run detekt across the tree**
+
+Run: `./gradlew detektAll`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-routing/README.md redux-kotlin-routing/api
+git commit -m "docs(routing): add README and public API baseline"
+```
+
+---
+
+### Task 15: Cross-target verification & plan self-check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the host's full target tests for the new module**
+
+Run: `./gradlew :redux-kotlin-routing:allTests`
+Expected: `BUILD SUCCESSFUL` across the targets this host can run (JVM, JS, wasmJs, native for the host OS). If `iosSimulatorArm64Test` fails with an Xcode SDK error, that is environmental — trust CI (per CLAUDE.md).
+
+- [ ] **Step 2: Run the multimodel module build (regression for `withAll`)**
+
+Run: `./gradlew :redux-kotlin-multimodel:build`
+Expected: `BUILD SUCCESSFUL` (includes `apiCheck` against the dump regenerated in Task 1).
+
+- [ ] **Step 3: Confirm no unintended public-API drift across the repo**
+
+Run: `./gradlew apiCheck`
+Expected: `BUILD SUCCESSFUL`. Only `redux-kotlin-routing` (new) and `redux-kotlin-multimodel` (`withAll`) dumps should have changed in this branch.
+
+- [ ] **Step 4: Final smoke build**
+
+Run: `./gradlew build`
+Expected: `BUILD SUCCESSFUL`.
+
+---
+
+## Self-Review (run before handoff)
+
+**Spec coverage (Phase 1 obligations → tasks):**
+- Exact-leaf matching → Tasks 3 (engine keys by `action::class`), 5 (locked).
+- Return-a-write-set single idiom → Tasks 2 (`WriteSet`/`writeSet`), 4 (`on` returns `M`), 6 (`onAction` returns `WriteSet`).
+- Structural init, no INIT fan-out → Task 4 (`model(initial)`, `buildInitialState`); README + KDoc state it.
+- `onBroadcast` for cross-cutting actions → Task 7.
+- Copy-on-first-write / zero-alloc no-op / `===` preservation → Tasks 1 (`withAll` single copy), 3 (lazy `staged`, unhandled returns same instance), 4 & 6 (identity tests).
+- All-or-nothing error semantics → Task 11.
+- Immutability hard contract + dev assertion → Task 10.
+- `!==`-gated `onWrite` hook (with `source`, intermediate values) → Task 9.
+- All KMP targets → Task 15 (`allTests`).
+- detekt `explicitApi` + KDoc → KDoc in every public code block; Task 14 Steps 3–4.
+- `apiDump` → Tasks 1 (multimodel), 14 (routing).
+- Module conventions (`library-mpp-loved` + `publishing-mpp`, package, registry template) → Task 0.
+
+**Out of scope (correctly absent):** KSP codegen (B), compiler plugin (C), `-effects`/coroutines module, devtools strippable-module wiring, serialization, dynamic post-creation registration / Play Feature Delivery splits — all deferred per the spec.
+
+**Type-name consistency check:** `createModelStore`, `RoutingBuilder`, `ModelHandlerScope<M>.on`, `RoutingBuilder.onAction`/`onBroadcast`/`model`, `ReduxModule.contribute`, `install`, `Reads.get`, `WriteSet.changes`, `WriteSetBuilder.set`, `writeSet`, `OnWrite`, internal `Cell`/`Broadcast`/`WorkingState`/`routedReducer`, `ModelState.withAll` — names are used identically across Tasks 1–14.
+
+**Known wiring note:** Task 13 uses an externally-synchronized test because the routed reducer is `internal` and cannot be re-wrapped by `createThreadSafeStore` directly in a test; production code wraps the whole `Store` returned by `createModelStore`. The `threadsafe` test dependency is added to document that intended production wrapping.
+
+---
+
+## Execution Handoff
+
+Plan complete. Choose execution mode (offered after save).

--- a/docs/superpowers/specs/2026-05-28-reducer-middleware-routing-design.md
+++ b/docs/superpowers/specs/2026-05-28-reducer-middleware-routing-design.md
@@ -1,0 +1,322 @@
+# RFC: Routed reducer/middleware API for redux-kotlin
+
+- **Status:** Draft (comparative RFC, pre-implementation)
+- **Date:** 2026-05-28
+- **Scope:** Design exploration + recommended path. No code committed yet.
+- **Constraints (locked with requester):** opt-in/additive primary (document breaking-2.0 upside separately); must work on **all** current KMP targets without runtime-reflection-only solutions; forward-looking (no hard perf numbers yet — flag where measurement is mandatory); the three goals (ergonomics, routing-perf, lazy-load/memory) were initially co-equal but are **re-weighted below** after expert review.
+
+This RFC was stress-tested by five expert review lenses (correctness, performance, gaps/completeness, Android, Kotlin Multiplatform), all grounded in the repository. Their findings are folded into the design decisions and traced in [§11](#11-review-findings--resolutions).
+
+---
+
+## 1. Context & goals
+
+### Current machinery (verified against the repo)
+
+- `Reducer<State> = (State, action: Any) -> State`. The action type is `Any` (`Definitions.kt:6,12`).
+- `combineReducers(vararg)` is a left fold: **every child reducer runs on every action** (`CombineReducers.kt:6-8`).
+- `combineModelReducers` (multimodel) iterates **every model reducer for every action**, using `===` referential change-detection to rebuild `ModelState` only with changed models; returns the *same* `ModelState` instance when nothing changed (`CombineModelReducers.kt:54-82`).
+- `typedReducer` filters internally via `when(action){ is X -> … else -> state }` — i.e. **subtype** matching (`Definitions.kt:144-151`).
+- `createStore.dispatch` runs `currentState = currentReducer(state, action)` then notifies **all** subscribers synchronously; dispatches `ActionTypes.INIT` at creation and `ActionTypes.REPLACE` on `replaceReducer` (`CreateStore.kt:175-205,224,237`). The `isDispatching` re-entry guard inside `dispatch` is **commented out** (`CreateStore.kt:182-191`).
+- `ModelState = Map<KClass<*>, Any>` with a **key set fixed at construction**; `get()` throws on a missing model (`ModelState.kt:33-61`).
+- Granular `subscribeTo { selector }` memoizes by `===` then `==` (`SubscribeFields.kt:127`).
+- `threadsafe` wraps `dispatch`/`getState`/`subscribe` in `synchronized` (`ThreadSafeStore.kt`).
+- Eager classload: assembling the root reducer references every feature reducer lambda, so all are loaded at store assembly.
+
+### The two problems this RFC addresses
+
+1. **Broadcast dispatch.** Actions visit every reducer/middleware; relevance is decided by per-handler instance checks (`when`/`is`). Two nested broadcasts in the multimodel case (every model × every action).
+2. **Ergonomics.** `when(action){}` / cascading `if` is the only routing idiom.
+
+### Goals, re-weighted after review
+
+| Goal | Original | Revised weight | Why |
+|---|---|---|---|
+| **Ergonomics** | co-equal | **Primary** | The most defensible, all-target, all-phase win. |
+| **Routing precision** | co-equal | **Primary, reframed** | Reframed from "faster dispatch" to "scaling headroom + precise subscriptions." At realistic model counts a hash lookup likely ties/loses to the current `is`-sweep; the real win is not running irrelevant handlers and feeding the granular `===` fast-path. |
+| **Lazy-load / memory** | co-equal | **Secondary, scoped** | Achievable only in Mechanism B, only on JVM/Android (Native/wasm are AOT — no runtime classloading), and it is *code-init deferral*, **not** resident-memory reduction (see [§6.2](#62-the-lazy-load-reality)). |
+
+---
+
+## 2. Organizing principle
+
+Routing is a **2-D sparse matrix**: `(ModelType, ActionType) → handler`. Most reducers touch exactly one model → one cell. A model is the natural unit of a **code module** and (where it exists) the unit of **lazy code-loading**. Flat single-state is the **one-model degenerate case** — structurally true, with one behavioral caveat (it loses "every reducer sees every action"; see broadcast actions, [§5.3](#53-broadcast--cross-cutting-actions)).
+
+The new API targets `Store<ModelState>`, built on `redux-kotlin-multimodel`. It produces a plain `Reducer<ModelState>` and therefore drops into the existing `createStore` / `createThreadSafeStore` and composes with `granular` / `compose` unchanged.
+
+---
+
+## 3. Handler taxonomy (one write-discipline)
+
+Decision: a single **return-a-write-set** discipline (no imperative `scope.set`). This avoids the fragmentation footgun where a handler that grows from one model to two must be rewritten into a different paradigm, and the "forgotten `scope.set` silently no-ops" trap.
+
+### Single-model handler — the 90% case
+
+A pure function `(M, A) -> M`:
+
+```kotlin
+model<UserModel> {
+    on<LoggedIn>  { s, a -> s.copy(user = a.user) }
+    on<LoggedOut> { s, _ -> s.copy(user = null) }
+}
+```
+
+### Multi-model handler — the 10% case
+
+Reads any number of slices (snapshot of the working state), **returns** a typed write-set. It never mutates in place.
+
+```kotlin
+onAction<Checkout> { reads, a ->
+    val cart = reads.get<CartModel>()
+    writeSet {
+        set(cart.copy(closed = true))
+        set(reads.get<UserModel>().copy(lastOrder = cart.id))
+    }
+}
+```
+
+A single-model handler is exactly the one-entry-write-set specialization: same return-based discipline, same `===` change semantics.
+
+### Action matching rule (locked): exact leaf class only
+
+`table[action::class]` matches the **concrete leaf class** of the action. Registering a handler on a sealed parent / interface is **not** supported (a compile-time error in the codegen path). This is a deliberate narrowing versus today's `typedReducer` `is`-matching; it is documented, codegen-friendly, and avoids a per-dispatch superclass walk (which is reflection-heavier on Native/JS).
+
+- Sealed-hierarchy users who relied on parent fan-in register each leaf, or use a broadcast registration ([§5.3](#53-broadcast--cross-cutting-actions)).
+- A test must assert that dispatching a subtype against a parent-registered handler does **not** match, documenting the behavior.
+
+### Immutability is a hard contract
+
+Models must be immutable (`data class` + `copy()`); a handler that intends to change a model must return a **`!==`** instance. A dev-mode assertion flags a handler that claims a change but returns the same instance (it would be silently dropped by the `===` gate). In-place mutation returning the same instance is an error.
+
+---
+
+## 4. Dispatch algorithm (sequence-preserving, zero-alloc on no-op)
+
+```text
+dispatch(action):
+  handlers = table[action::class]          // exact-leaf lookup; usually 0 or 1 entry
+  if handlers is empty:                     // unhandled action
+      return currentModelState              // SAME instance — no rebuild, no alloc
+  var working = currentModelState           // immutable snapshot
+  var changed = null                        // copy-on-first-write accumulator
+  for h in handlers (in store-creation order):
+      writeSet = h.apply(reads = working, action)   // reads see prior handlers' writes
+      for (modelKey, newModel) in writeSet:
+          if newModel !== working[modelKey]:        // === gate (matches combineModelReducers)
+              changed = changed ?: copyOf(working.models)
+              changed[modelKey] = newModel
+              working = ModelState(changed)         // view for subsequent reads
+              onWrite?.fire(action, modelKey, prevForKey, newModel, h.source)  // only when !==
+  return if (changed == null) currentModelState else working   // ≤1 effective rebuild
+```
+
+Key invariants (all required, all testable):
+
+- **Fold semantics preserved.** A later handler reads earlier handlers' writes (the `reads` view reflects accumulated changes). Only *relevant* cells run.
+- **Zero allocation on no-op dispatch** — mirror `combineModelReducers`' `changedModels == null` fast path (`CombineModelReducers.kt:65,80`). An unhandled action returns the *same* `ModelState` instance.
+- **`===` identity of untouched models preserved through commit.** This is load-bearing for the granular `===` fast-path and for Compose recomposition skipping. Test: an unchanged model's slot is `===` across dispatch and its granular subscribers fire zero times.
+- **Subscriber contract unchanged.** Raw `store.subscribe` listeners still fire on every dispatch (the Redux contract); only the *granular* layer is "precise." This must be stated plainly — the precision claim is a granular-layer property, not a raw-subscribe property.
+
+### Order, conflicts, hook
+
+- **Order is fixed at store creation** via the `install()` sequence (single composition point; deterministic across independently-compiled modules):
+
+  ```kotlin
+  val store = createModelStore(initialModels) {
+      install(UserModule)        // ← order here defines cross-module handler sequence
+      install(CartModule)
+      install(CheckoutModule)
+  }
+  ```
+
+  Within a module, declaration order.
+- **Last-write-wins** on same-model writes within one dispatch (sequential, like the current fold). `source` identifies the writing handler.
+- **`onWrite` hook** fires **only when `next !== prev`** (skips no-op writes, matching the `===` gate). It is a **pure observer**: no `dispatch`, no `getState`, no store access; it runs synchronously during the fold, before commit, so `prev`/`next` reflect transient working state. For conflict tracing it intentionally sees intermediate (clobbered) values. A separate **per-dispatch** hook is the right shape for devtools/time-travel (which must group by action, not by write); see [§7](#7-effects-middleware--devtools) for why the hook must not be a plain runtime store field.
+
+### Error semantics (locked)
+
+Handlers run against an **immutable working snapshot**. A throw in handler *k* aborts the whole dispatch **before commit** — the store observes the same all-or-nothing guarantee the core already provides (`CreateStore.kt` never reassigns `currentState` if the reducer throws). No partial commit. Because changes are *returned* (not mutated via a scope), there is no half-mutated working bag to leak.
+
+---
+
+## 5. The unavoidable edges (must be specified, not glossed)
+
+### 5.1 INIT / REPLACE
+
+There is **no INIT fan-out**. Initial model instances come from `install()` / `ModelState.of(...)` at store creation — initialization is **structural**, not action-driven. `ActionTypes.INIT` and `ActionTypes.REPLACE` have no registered cell and are therefore no-ops over the routing table; models keep their current instances. This is documented as intentional and is the migration sharp-edge for code that relied on `(undefined, INIT) -> defaultState`.
+
+### 5.2 Reentrancy
+
+`onWrite` and handlers may not call `dispatch`/`getState`. Routed effects ([§7](#7-effects-middleware--devtools)) dispatch **after** the reducer returns, via the dispatch funnel, never inside a handler. The RFC notes the core's commented-out `isDispatching` guard (`CreateStore.kt:182-191`) as a pre-existing hazard the routed layer must not depend on.
+
+### 5.3 Broadcast / cross-cutting actions
+
+Because matching is exact-leaf, a global `RESET` / `LOGOUT` / `REHYDRATE` that every model must handle is **not** implicitly broadcast (unlike `combineReducers`' fold). A first-class registration handles this:
+
+```kotlin
+onBroadcast<Reset> { /* per-model reset, run for every installed model */ }
+```
+
+Cost is `O(handlers registered for the broadcast)` — this is the routing model's worst case and a realistic one; it must be benchmarked (the LOGOUT-clears-all scenario).
+
+### 5.4 Dynamic registration
+
+v1 fixes the table at store creation. Post-creation registration (the `replaceReducer` code-splitting use case, and Android dynamic-feature splits) is supported only via an explicit `registry.installInto(store)` + `replaceReducer` path — see [§6.4](#64-android-classloader-topology). The tension between "fixed install order" and "add features later" is called out, not hidden.
+
+---
+
+## 6. Three mechanisms
+
+### 6.1 Mechanism A — runtime DSL (Phase 1, the product)
+
+`createModelStore { model<X>{ on<Y>{…} }; onAction<Z>{…}; onBroadcast<R>{…} }` → a plain `Reducer<ModelState>`.
+
+- ✅ Ergonomics (kills the `when` cascade), routing precision, granular synergy.
+- ✅ **Unconditionally portable**: zero new expect/actual, no runtime reflection, builds on proven multimodel + KClass-key machinery already in CI on every target.
+- ❌ **No lazy-load.** Building the DSL instantiates every handler lambda at config time (each lambda is a synthetic class). On Android this verifies those classes on the **main thread at `createStore`** — the same eager-classload it claims to fix. A is for ergonomics + routing precision, and has today's classload profile. Do not market lazy-load for A.
+
+### 6.2 The lazy-load reality
+
+- Real laziness requires Mechanism B (function-reference / stable-key registration that defers a handler's containing facade classload until first matching dispatch).
+- It is **JVM/Android-only** — Kotlin/Native and wasmJs are AOT-linked with dead-code elimination; "lazy classloading" has no runtime meaning there.
+- It is **code-init deferral, not memory reduction.** `ModelState`'s fixed key set means every model *instance* exists for the store's lifetime; only *code* can be deferred, and only until a feature is first used. True lazy model *data* would require relaxing the fixed-key-set invariant — a **2.0 item** ([§10](#10-breaking-20-appendix)).
+- Measure with Android time-to-interactive / class-init counts and a JVM `-verbose:class` probe; do not claim resident-heap savings without a heap-dump diff, and quantify against typical screen memory to show it is small.
+
+### 6.3 Mechanism B — KSP codegen (Phase 2, gated)
+
+`@Reduce`-annotated top-level functions grouped by their model parameter type; KSP generates a per-feature **registrar object**.
+
+- **Cross-module contract is explicit `install(FeatureModule)`** — *not* automatic discovery. KSP's `Resolver` cannot enumerate annotated symbols sitting in binary **klib** dependencies on Native/wasm, and there is no ServiceLoader / classpath scan off-JVM. The app references each feature's generated registrar by name at the single `install()` point (the app→feature dependency already exists; sibling deps are not needed).
+- **No Int-ID array dispatch.** Independent per-module KSP passes have no shared counter → ID collisions → silent wrong-handler corruption and unstable serialization keys. Keep KClass-keyed (or per-module-namespaced **string**-key) `HashMap` routing — already O(1), collision-free, and the string keys are serialization-stable. Array dispatch is a closed-world property and belongs only to Mechanism C.
+- **Build-system fallback:** the same explicit `installInto(registry)` is the contract for Buck / non-Gradle (KSP is Gradle-wired).
+- **Testing/gate:** generated source location, detekt/`apiCheck` treatment (generated public API must satisfy `explicitApi()` + KDoc or be excluded), per-`@Reduce` unit-testing, and a runtime "dump the resolved routing table" affordance for debuggability — all must be specified before B ships. **Phase 2 is gated on a KSP2 spike** validating `getClassDeclarationByName`/`getDeclarationsFromPackage` against `iosArm64` + `wasmJs` klib dependencies. If the spike fails, B degrades to "codegen the DSL boilerplate behind explicit `install()`" — still useful, but a smaller win than advertised.
+
+### 6.4 Android classloader topology
+
+KClass identity is per-classloader. Standard Gradle `:feature` library modules share one classloader → routing is correct and O(1) (KClass `hashCode`/`equals` are stable per-classloader on ART). **Play Feature Delivery on-demand / dynamic-feature splits** load through a separate classloader → KClass equality silently fails. Documented support: standard library modules only; runtime splits must call `registry.installInto(store)` after `SplitInstallManager` confirms install (backed by `replaceReducer`), or opt into string-key codegen (B) which sidesteps classloader identity.
+
+### 6.5 Mechanism C — compiler plugin (documented, recommend-against)
+
+FIR + IR plugin: synthesize the `ModelState` bag, a dense 2-D jump table, compile-time exhaustiveness.
+
+- Recommend-against, and the rationale is *stronger* than first stated: **perpetual per-Kotlin-version, per-target IR maintenance** against explicitly unstable FIR/IR APIs, for a small OSS library, with the same (worse) Gradle-wiring problem as KSP. Its one unique upside — the array jump-table — needs measured hot-path pressure that does not exist. Documented as the ceiling and as a 2.0 input.
+
+### Mechanism scorecard
+
+| | A (DSL) | B (KSP) | C (compiler plugin) |
+|---|---|---|---|
+| Ergonomics | ✅ kills `when` | ✅ + less boilerplate | ✅✅ zero-boilerplate |
+| Routing precision | ✅ | ✅ | ✅ |
+| Lazy-load | ❌ none | ⚠️ JVM/Android only, gated | ⚠️ closed-world |
+| All KMP targets | ✅ proven | ⚠️ cross-module spike needed | ⚠️ per-target IR |
+| Runtime reflection | none | none | none |
+| Build systems | any | Gradle (+ `installInto` fallback) | Gradle, fragile |
+| Cost / risk | low | moderate, gated | high, perpetual |
+
+---
+
+## 7. Effects, middleware & devtools
+
+### Effects — a separate `redux-kotlin-routing-effects` module (locked)
+
+Core routing stays pure reducers with **no `kotlinx.coroutines` dependency** (true to the minimal ethos). A companion `redux-kotlin-routing-effects` module owns the coroutine effect API, isolating the dependency for opt-in users:
+
+```kotlin
+onEffect<LoggedIn> { reads, a ->         // suspend; store-lifetime CoroutineScope
+    val profile = api.fetchProfile(a.userId)
+    dispatch(ProfileLoaded(profile))      // dispatch AFTER reducer commit, via the funnel
+}
+```
+
+Contract: effects run **after** the routed reducer commits; they dispatch follow-up actions through the normal dispatch funnel (re-entering the routing table cleanly, never inside a handler); cancellation is scoped to a store-lifetime `CoroutineScope`. A worked `LoggedIn → fetchUser → LoggedInSuccess` loop is part of the module's docs.
+
+### Middleware pipeline (must be drawn, not asserted)
+
+The routed reducer is the **single** `Dispatcher` that `applyMiddleware` and `ThreadSafeStore` wrap. The full pipeline:
+
+```text
+action → linear middleware chain (compose(chain)) → routed reducer (fold over cells) → commit → effects → subscriber notify
+```
+
+Cross-cutting middleware (logging, crash reporting) stays the existing linear chain and sees the action before the reducer. Because the routed reducer is one synchronous `Reducer<ModelState>` inside `dispatch`, `ThreadSafeStore`'s single lock covers the whole fold + commit — thread-safety is preserved by construction. Effects sit after commit and dispatch new actions (which re-enter the funnel and are themselves wrapped).
+
+### Devtools / serialization
+
+- The `onWrite` hook is **not** a plain runtime store field (R8 cannot prove it null → cannot strip it; a time-travel buffer behind it is unbounded memory + a PII surface in release). Devtools is wired via a **separate enhancer/module** that release builds simply do not depend on — structurally absent and R8-strippable.
+- Persistence requires a **stable string model-key registry** (not KClass, which is process-local; not Int, which collides across modules) + per-model `kotlinx.serialization` + a documented restore that reconstructs the fixed `ModelState` key set. Time-travel replay is **reducer-only** (effects suppressed) to avoid re-firing network calls. Designed in the persistence module, out of scope for Phase 1 beyond reserving the `onDispatch` hook shape.
+
+---
+
+## 8. Integration with existing modules
+
+| Module | Adaptation |
+|---|---|
+| `createStore` / `createSameThreadEnforcedStore` | unchanged — routed reducer is a plain `Reducer<ModelState>` |
+| `threadsafe` | unchanged — single lock wraps the whole fold + commit |
+| `granular` | unchanged — `subscribeTo { it.get<UserModel>() }` fires precisely **because** commit preserves `===` of untouched models |
+| `compose` / `compose-multimodel` | unchanged — `selectorState`/`fieldState` ride the granular `===` path; `StableStore` reference stays `@Stable` |
+| `registry` | the multi-store container; incremental adoption (one routed store alongside flat stores) is supported via separate stores |
+| `multimodel` | the substrate; `combineModelReducers` coexists and is **not** deprecated in v1 |
+
+An **interop matrix** + an **incremental-adoption** statement (one routed feature beside flat state) are required doc deliverables.
+
+---
+
+## 9. Recommendation & phased roadmap
+
+1. **Phase 1 — ship Mechanism A** as `redux-kotlin-routing` (opt-in companion module). Delivers ergonomics + routing precision + granular synergy on **all** targets, no tooling, no new runtime dependency. This is the product.
+2. **Phase 1.5 — ship `redux-kotlin-routing-effects`** (opt-in, owns the coroutine effect API).
+3. **Phase 2 — Mechanism B (KSP)**, *gated* on the cross-module KSP2 spike ([§6.3](#63-mechanism-b--ksp-codegen-phase-2-gated)). Codegen emits exactly what A's DSL produces by hand, so **A remains the escape hatch and the test oracle** (generated output must match hand-written). Adds lazy registration (JVM/Android) + string-key serialization stability.
+4. **Phase 3 — document Mechanism C**, recommend-against; capture it as a 2.0 input.
+
+New modules: `redux-kotlin-routing`, `redux-kotlin-routing-effects`, later `redux-kotlin-routing-codegen`. Each follows the repo's module conventions (`convention.library-mpp-loved` + `convention.publishing-mpp`, package `org.reduxkotlin.routing`, mirror `redux-kotlin-registry` as template).
+
+---
+
+## 10. Breaking-2.0 appendix
+
+What an additive design cannot reach, captured for a future major:
+
+- **Typed action union at the core contract** (replace `action: Any`), enabling compile-time exhaustiveness and removing the `isPlainObject` runtime check.
+- **Relaxed `ModelState` key set** to allow true lazy model *data* (not just code) — the only path to actual resident-memory reduction.
+- **Routed dispatch as the core default**, retiring the broadcast fold.
+- **Mechanism C** compiler plugin enabling dense array dispatch + zero-boilerplate handlers + compile-time conflict detection.
+
+---
+
+## 11. Review findings → resolutions
+
+| # | Finding (severity) | Resolution |
+|---|---|---|
+| 1 | INIT/REPLACE reach an empty table; models never init (blocker) | [§5.1](#51-init--replace): init is structural via `install()`; no INIT fan-out, documented |
+| 2 | `action::class` narrows vs `is`-matching (blocker) | [§3](#3-handler-taxonomy-one-write-discipline): **exact-leaf only**, sealed-parent registration disallowed, documented + tested |
+| 3 | Effects/async undesigned (blocker) | [§7](#7-effects-middleware--devtools): separate `-effects` module, coroutine contract specified |
+| 4 | Mid-fold error: partial commit? (blocker) | [§4](#4-dispatch-algorithm-sequence-preserving-zero-alloc-on-no-op): all-or-nothing, return-based (no half-mutated bag) |
+| 5 | Routed vs linear middleware composition (blocker) | [§7](#7-effects-middleware--devtools): pipeline drawn; routed reducer is the single wrapped `Dispatcher` |
+| 6 | Lazy-load overclaimed (major ×4) | [§1](#1-context--goals)/[§6.2](#62-the-lazy-load-reality): demoted, scoped JVM/Android-only, code-deferral not memory |
+| 7 | Routing perf likely a wash at small N; alloc regression (major) | [§1](#1-context--goals)/[§4](#4-dispatch-algorithm-sequence-preserving-zero-alloc-on-no-op): reframed; copy-on-first-write, zero-alloc no-op; benchmark mandatory |
+| 8 | Int-ID array dispatch collides cross-module (major ×3) | [§6.3](#63-mechanism-b--ksp-codegen-phase-2-gated): dropped from B; string keys; array → C only |
+| 9 | KSP cross-module auto-discovery fails on klibs (major) | [§6.3](#63-mechanism-b--ksp-codegen-phase-2-gated): explicit `install()` is the contract; Phase 2 gated on spike |
+| 10 | KClass breaks across classloaders (Android) (major) | [§6.4](#64-android-classloader-topology): supported topology documented; `installInto` for splits |
+| 11 | `onWrite` leak / not strippable (major) | [§4](#4-dispatch-algorithm-sequence-preserving-zero-alloc-on-no-op)/[§7](#7-effects-middleware--devtools): devtools via separate strippable module; hook is pure, `!==`-gated |
+| 12 | Single vs multi idiom fragments mental model (major) | [§3](#3-handler-taxonomy-one-write-discipline): **return-a-write-set** single discipline |
+| 13 | No migration path (major) | [§12](#12-migration): migration section with the no-cell-vs-fold semantic diff |
+| 14 | Commit must preserve `===` / immutability contract (major+) | [§3](#3-handler-taxonomy-one-write-discipline)/[§4](#4-dispatch-algorithm-sequence-preserving-zero-alloc-on-no-op): hard contract + dev assertion + tests |
+| — | KClass-as-key correct on all targets; zero expect/actual; new MM safe (confirmations) | [§6.1](#61-mechanism-a--runtime-dsl-phase-1-the-product)/[§8](#8-integration-with-existing-modules): kept as stated strengths |
+
+---
+
+## 12. Migration
+
+Concrete before/after for each current entry point (`combineReducers`, `combineModelReducers`, `typedReducer`), and the load-bearing semantic difference: **a routed table with no cell for an action does nothing**, whereas a `combineReducers` fold runs every child — including any `else -> state` catch-all logic that observed all actions. `combineModelReducers` is the natural migration source and **coexists** (not deprecated) in v1. Global broadcast actions (`RESET`/`LOGOUT`) migrate to `onBroadcast` ([§5.3](#53-broadcast--cross-cutting-actions)).
+
+---
+
+## 13. Open items / where measurement is mandatory
+
+- **Dispatch micro-benchmark** across `M ∈ {1,4,8,16,32,64}` and across jvm/js/wasmJs/native: publish the crossover N where KClass-routing beats the `is`-sweep. If crossover > ~16, reframe routing-perf as large-app headroom only. (Reuse the `redux-kotlin-granular` JMH harness.)
+- **Allocation test:** zero B/op on no-op dispatch; ≤1 map copy per changed dispatch (`-prof gc`).
+- **Broadcast worst case:** benchmark LOGOUT-clears-all.
+- **Lazy-load:** Android time-to-interactive + class-init counts; JVM `-verbose:class` first-dispatch probe. No resident-heap claim without a heap-dump diff.
+- **KSP2 cross-module spike** on `iosArm64` + `wasmJs` klibs before committing Phase 2 array/IDs (already a Phase-2 gate).
+- **All-target tests from day one:** `wasmJsTest` + an iOS `commonTest` asserting distinct-slot routing and re-dispatch stability; a `jvmTest` routed-dispatch-under-threadsafe concurrency stress.

--- a/redux-kotlin-multimodel/api/jvm/redux-kotlin-multimodel.api
+++ b/redux-kotlin-multimodel/api/jvm/redux-kotlin-multimodel.api
@@ -18,6 +18,7 @@ public final class org/reduxkotlin/multimodel/ModelState {
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public final fun with (Lkotlin/reflect/KClass;Ljava/lang/Object;)Lorg/reduxkotlin/multimodel/ModelState;
+	public final fun withAll (Ljava/util/Map;)Lorg/reduxkotlin/multimodel/ModelState;
 }
 
 public final class org/reduxkotlin/multimodel/ModelState$Companion {

--- a/redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api
+++ b/redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api
@@ -26,6 +26,7 @@ final class org.reduxkotlin.multimodel/ModelState { // org.reduxkotlin.multimode
     final fun equals(kotlin/Any?): kotlin/Boolean // org.reduxkotlin.multimodel/ModelState.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // org.reduxkotlin.multimodel/ModelState.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // org.reduxkotlin.multimodel/ModelState.toString|toString(){}[0]
+    final fun withAll(kotlin.collections/Map<kotlin.reflect/KClass<*>, kotlin/Any>): org.reduxkotlin.multimodel/ModelState // org.reduxkotlin.multimodel/ModelState.withAll|withAll(kotlin.collections.Map<kotlin.reflect.KClass<*>,kotlin.Any>){}[0]
     final inline fun <#A1: reified kotlin/Any> get(): #A1 // org.reduxkotlin.multimodel/ModelState.get|get(){0§<kotlin.Any>}[0]
     final inline fun <#A1: reified kotlin/Any> with(#A1): org.reduxkotlin.multimodel/ModelState // org.reduxkotlin.multimodel/ModelState.with|with(0:0){0§<kotlin.Any>}[0]
 

--- a/redux-kotlin-multimodel/src/commonMain/kotlin/org/reduxkotlin/multimodel/ModelState.kt
+++ b/redux-kotlin-multimodel/src/commonMain/kotlin/org/reduxkotlin/multimodel/ModelState.kt
@@ -84,6 +84,30 @@ public class ModelState @PublishedApi internal constructor(@PublishedApi interna
         return ModelState(models + (modelClass to model))
     }
 
+    /**
+     * Returns a new [ModelState] with every slot named in [changes]
+     * replaced, in a single map copy. Other models are shared with the
+     * receiver. Returns the receiver unchanged when [changes] is empty.
+     *
+     * This is the batch form of [with]; it exists so a routed reducer
+     * can apply several model writes from one dispatch with exactly one
+     * allocation, preserving the `===` identity of untouched slots.
+     *
+     * @throws IllegalStateException if any key in [changes] was not
+     *   declared at construction; the key set is fixed by
+     *   [Companion.of].
+     */
+    public fun withAll(changes: Map<KClass<*>, Any>): ModelState {
+        if (changes.isEmpty()) return this
+        for (klass in changes.keys) {
+            check(klass in models) {
+                "Cannot replace model ${klass.simpleName ?: klass} that wasn't declared at construction. " +
+                    "ModelState's key set is fixed by ModelState.of(...)."
+            }
+        }
+        return ModelState(models + changes)
+    }
+
     override fun equals(other: Any?): Boolean = other is ModelState && other.models == models
 
     override fun hashCode(): Int = models.hashCode()

--- a/redux-kotlin-multimodel/src/commonTest/kotlin/org/reduxkotlin/multimodel/ModelStateWithAllTest.kt
+++ b/redux-kotlin-multimodel/src/commonTest/kotlin/org/reduxkotlin/multimodel/ModelStateWithAllTest.kt
@@ -1,0 +1,35 @@
+package org.reduxkotlin.multimodel
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+
+private data class A(val n: Int)
+private data class B(val s: String)
+private data class Unregistered(val x: Int)
+
+class ModelStateWithAllTest {
+
+    @Test
+    fun withAll_replaces_multiple_models_in_one_call() {
+        val state = ModelState.of(A(1), B("x"))
+        val next = state.withAll(mapOf(A::class to A(2), B::class to B("y")))
+        assertEquals(A(2), next.get<A>())
+        assertEquals(B("y"), next.get<B>())
+    }
+
+    @Test
+    fun withAll_with_empty_map_returns_same_instance() {
+        val state = ModelState.of(A(1))
+        assertSame(state, state.withAll(emptyMap()))
+    }
+
+    @Test
+    fun withAll_rejects_unregistered_model_class() {
+        val state = ModelState.of(A(1))
+        assertFailsWith<IllegalStateException> {
+            state.withAll(mapOf(Unregistered::class to Unregistered(0)))
+        }
+    }
+}

--- a/redux-kotlin-routing/README.md
+++ b/redux-kotlin-routing/README.md
@@ -1,0 +1,47 @@
+# redux-kotlin-routing
+
+Routed `(model, action)` dispatch over `ModelState`. Replaces the
+`when(action) {}` cascade with exact-leaf-class routing: an action only
+visits the handlers registered for its concrete class, and only the
+models a handler changes are rebuilt (preserving `===` identity of the
+rest, so the granular subscription layer stays precise).
+
+## Quick start
+
+```kotlin
+val store = createModelStore {
+    model(UserModel()) {
+        on<LoggedIn>  { s, a -> s.copy(user = a.user) }
+        on<LoggedOut> { s, _ -> s.copy(user = null) }
+    }
+    model(CartModel()) {
+        on<AddItem> { s, a -> s.copy(items = s.items + a.item) }
+    }
+    onAction<Checkout> { reads, _ ->
+        val cart = reads.get<CartModel>()
+        writeSet { set(cart.copy(closed = true)) }
+    }
+    onBroadcast<Logout> { model, _ -> /* reset each model */ model }
+    install(SomeFeatureModule)
+}
+```
+
+## Semantics
+
+- **Exact-leaf matching.** `on<Open>` matches `Open`, not subtypes of a
+  shared sealed parent. Register each leaf, or use `onBroadcast` for
+  cross-cutting actions.
+- **Structural init.** A model's starting value is its `model(initial)`
+  declaration. There is no INIT-action fan-out.
+- **Order fixed at creation.** Handlers for the same action run in
+  registration order; `install(module)` order is the composition point.
+- **Last-write-wins** on same-model writes within one dispatch.
+- **Immutability is required.** Return a new instance to signal a
+  change, the same instance for "no change". Enable `devChecks = true`
+  to fail fast on wasteful structurally-equal copies.
+- **All-or-nothing.** A handler that throws aborts the whole dispatch;
+  no partial commit.
+
+Built on `redux-kotlin` + `redux-kotlin-multimodel`. Wrap with
+`createThreadSafeStore` for cross-thread access; composes with
+`redux-kotlin-granular` and the Compose bindings unchanged.

--- a/redux-kotlin-routing/README.md
+++ b/redux-kotlin-routing/README.md
@@ -39,6 +39,10 @@ val store = createModelStore {
 - **Immutability is required.** Return a new instance to signal a
   change, the same instance for "no change". Enable `devChecks = true`
   to fail fast on wasteful structurally-equal copies.
+- **Handlers must be pure.** `on` / `onAction` / `onBroadcast` handlers
+  compute the next model(s) from their inputs only — never call
+  `dispatch` or read the store from inside a handler (side effects
+  belong in middleware). The same applies to the `onWrite` observer.
 - **All-or-nothing.** A handler that throws aborts the whole dispatch;
   no partial commit.
 

--- a/redux-kotlin-routing/api/jvm/redux-kotlin-routing.api
+++ b/redux-kotlin-routing/api/jvm/redux-kotlin-routing.api
@@ -1,0 +1,49 @@
+public final class org/reduxkotlin/routing/CreateModelStoreKt {
+	public static final fun createModelStore (Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function5;Lkotlin/jvm/functions/Function1;)Lorg/reduxkotlin/TypedStore;
+	public static synthetic fun createModelStore$default (Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function5;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/reduxkotlin/TypedStore;
+}
+
+public final class org/reduxkotlin/routing/ModelHandlerScope {
+	public fun <init> (Lkotlin/reflect/KClass;Lorg/reduxkotlin/routing/RoutingBuilder;)V
+	public final fun getBuilder ()Lorg/reduxkotlin/routing/RoutingBuilder;
+	public final fun getModelClass ()Lkotlin/reflect/KClass;
+}
+
+public abstract interface class org/reduxkotlin/routing/Reads {
+	public abstract fun get (Lkotlin/reflect/KClass;)Ljava/lang/Object;
+}
+
+public abstract interface class org/reduxkotlin/routing/ReduxModule {
+	public abstract fun contribute (Lorg/reduxkotlin/routing/RoutingBuilder;)V
+}
+
+public final class org/reduxkotlin/routing/RoutingBuilder {
+	public fun <init> ()V
+	public final fun addCell (Lkotlin/reflect/KClass;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public final fun getBroadcasts ()Ljava/util/List;
+	public final fun getInitials ()Ljava/util/List;
+	public final fun getModelClasses ()Ljava/util/List;
+	public final fun getTable ()Ljava/util/Map;
+	public final fun registerBroadcast (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;)V
+	public final fun registerModel (Lkotlin/reflect/KClass;Ljava/lang/Object;)V
+}
+
+public final class org/reduxkotlin/routing/RoutingDslKt {
+	public static final fun install (Lorg/reduxkotlin/routing/RoutingBuilder;Lorg/reduxkotlin/routing/ReduxModule;)V
+}
+
+public final class org/reduxkotlin/routing/WriteSet {
+	public fun <init> (Ljava/util/Map;)V
+	public final fun getChanges ()Ljava/util/Map;
+}
+
+public final class org/reduxkotlin/routing/WriteSetBuilder {
+	public fun <init> ()V
+	public final fun getChanges ()Ljava/util/Map;
+	public final fun set (Lkotlin/reflect/KClass;Ljava/lang/Object;)V
+}
+
+public final class org/reduxkotlin/routing/WriteSetKt {
+	public static final fun writeSet (Lkotlin/jvm/functions/Function1;)Lorg/reduxkotlin/routing/WriteSet;
+}
+

--- a/redux-kotlin-routing/api/redux-kotlin-routing.klib.api
+++ b/redux-kotlin-routing/api/redux-kotlin-routing.klib.api
@@ -1,0 +1,68 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxX64, macosArm64, macosX64, mingwX64, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <org.reduxkotlin:redux-kotlin-routing>
+abstract fun interface org.reduxkotlin.routing/ReduxModule { // org.reduxkotlin.routing/ReduxModule|null[0]
+    abstract fun (org.reduxkotlin.routing/RoutingBuilder).contribute() // org.reduxkotlin.routing/ReduxModule.contribute|contribute@org.reduxkotlin.routing.RoutingBuilder(){}[0]
+}
+
+abstract interface org.reduxkotlin.routing/Reads { // org.reduxkotlin.routing/Reads|null[0]
+    abstract fun <#A1: kotlin/Any> get(kotlin.reflect/KClass<#A1>): #A1 // org.reduxkotlin.routing/Reads.get|get(kotlin.reflect.KClass<0:0>){0§<kotlin.Any>}[0]
+}
+
+final class <#A: kotlin/Any> org.reduxkotlin.routing/ModelHandlerScope { // org.reduxkotlin.routing/ModelHandlerScope|null[0]
+    constructor <init>(kotlin.reflect/KClass<#A>, org.reduxkotlin.routing/RoutingBuilder) // org.reduxkotlin.routing/ModelHandlerScope.<init>|<init>(kotlin.reflect.KClass<1:0>;org.reduxkotlin.routing.RoutingBuilder){}[0]
+
+    final val builder // org.reduxkotlin.routing/ModelHandlerScope.builder|{}builder[0]
+        final fun <get-builder>(): org.reduxkotlin.routing/RoutingBuilder // org.reduxkotlin.routing/ModelHandlerScope.builder.<get-builder>|<get-builder>(){}[0]
+    final val modelClass // org.reduxkotlin.routing/ModelHandlerScope.modelClass|{}modelClass[0]
+        final fun <get-modelClass>(): kotlin.reflect/KClass<#A> // org.reduxkotlin.routing/ModelHandlerScope.modelClass.<get-modelClass>|<get-modelClass>(){}[0]
+
+    final inline fun <#A1: reified kotlin/Any> on(noinline kotlin/Function2<#A, #A1, #A>) // org.reduxkotlin.routing/ModelHandlerScope.on|on(kotlin.Function2<1:0,0:0,1:0>){0§<kotlin.Any>}[0]
+}
+
+final class org.reduxkotlin.routing/RoutingBuilder { // org.reduxkotlin.routing/RoutingBuilder|null[0]
+    constructor <init>() // org.reduxkotlin.routing/RoutingBuilder.<init>|<init>(){}[0]
+
+    final val broadcasts // org.reduxkotlin.routing/RoutingBuilder.broadcasts|{}broadcasts[0]
+        final fun <get-broadcasts>(): kotlin.collections/MutableList<org.reduxkotlin.routing/Broadcast> // org.reduxkotlin.routing/RoutingBuilder.broadcasts.<get-broadcasts>|<get-broadcasts>(){}[0]
+    final val initials // org.reduxkotlin.routing/RoutingBuilder.initials|{}initials[0]
+        final fun <get-initials>(): kotlin.collections/MutableList<kotlin/Any> // org.reduxkotlin.routing/RoutingBuilder.initials.<get-initials>|<get-initials>(){}[0]
+    final val modelClasses // org.reduxkotlin.routing/RoutingBuilder.modelClasses|{}modelClasses[0]
+        final fun <get-modelClasses>(): kotlin.collections/MutableList<kotlin.reflect/KClass<*>> // org.reduxkotlin.routing/RoutingBuilder.modelClasses.<get-modelClasses>|<get-modelClasses>(){}[0]
+    final val table // org.reduxkotlin.routing/RoutingBuilder.table|{}table[0]
+        final fun <get-table>(): kotlin.collections/MutableMap<kotlin/Any, kotlin.collections/MutableList<org.reduxkotlin.routing/Cell>> // org.reduxkotlin.routing/RoutingBuilder.table.<get-table>|<get-table>(){}[0]
+
+    final fun addCell(kotlin.reflect/KClass<*>, kotlin/String, kotlin/Function2<org.reduxkotlin.routing/Reads, kotlin/Any, kotlin.collections/Map<kotlin.reflect/KClass<*>, kotlin/Any>>) // org.reduxkotlin.routing/RoutingBuilder.addCell|addCell(kotlin.reflect.KClass<*>;kotlin.String;kotlin.Function2<org.reduxkotlin.routing.Reads,kotlin.Any,kotlin.collections.Map<kotlin.reflect.KClass<*>,kotlin.Any>>){}[0]
+    final fun registerBroadcast(kotlin.reflect/KClass<*>, kotlin/Function2<kotlin/Any, kotlin/Any, kotlin/Any>) // org.reduxkotlin.routing/RoutingBuilder.registerBroadcast|registerBroadcast(kotlin.reflect.KClass<*>;kotlin.Function2<kotlin.Any,kotlin.Any,kotlin.Any>){}[0]
+    final fun registerModel(kotlin.reflect/KClass<*>, kotlin/Any) // org.reduxkotlin.routing/RoutingBuilder.registerModel|registerModel(kotlin.reflect.KClass<*>;kotlin.Any){}[0]
+    final inline fun <#A1: reified kotlin/Any> model(#A1, kotlin/Function1<org.reduxkotlin.routing/ModelHandlerScope<#A1>, kotlin/Unit>) // org.reduxkotlin.routing/RoutingBuilder.model|model(0:0;kotlin.Function1<org.reduxkotlin.routing.ModelHandlerScope<0:0>,kotlin.Unit>){0§<kotlin.Any>}[0]
+    final inline fun <#A1: reified kotlin/Any> onAction(noinline kotlin/Function2<org.reduxkotlin.routing/Reads, #A1, org.reduxkotlin.routing/WriteSet>) // org.reduxkotlin.routing/RoutingBuilder.onAction|onAction(kotlin.Function2<org.reduxkotlin.routing.Reads,0:0,org.reduxkotlin.routing.WriteSet>){0§<kotlin.Any>}[0]
+    final inline fun <#A1: reified kotlin/Any> onBroadcast(noinline kotlin/Function2<kotlin/Any, #A1, kotlin/Any>) // org.reduxkotlin.routing/RoutingBuilder.onBroadcast|onBroadcast(kotlin.Function2<kotlin.Any,0:0,kotlin.Any>){0§<kotlin.Any>}[0]
+}
+
+final class org.reduxkotlin.routing/WriteSet { // org.reduxkotlin.routing/WriteSet|null[0]
+    constructor <init>(kotlin.collections/Map<kotlin.reflect/KClass<*>, kotlin/Any>) // org.reduxkotlin.routing/WriteSet.<init>|<init>(kotlin.collections.Map<kotlin.reflect.KClass<*>,kotlin.Any>){}[0]
+
+    final val changes // org.reduxkotlin.routing/WriteSet.changes|{}changes[0]
+        final fun <get-changes>(): kotlin.collections/Map<kotlin.reflect/KClass<*>, kotlin/Any> // org.reduxkotlin.routing/WriteSet.changes.<get-changes>|<get-changes>(){}[0]
+}
+
+final class org.reduxkotlin.routing/WriteSetBuilder { // org.reduxkotlin.routing/WriteSetBuilder|null[0]
+    constructor <init>() // org.reduxkotlin.routing/WriteSetBuilder.<init>|<init>(){}[0]
+
+    final val changes // org.reduxkotlin.routing/WriteSetBuilder.changes|{}changes[0]
+        final fun <get-changes>(): kotlin.collections/MutableMap<kotlin.reflect/KClass<*>, kotlin/Any> // org.reduxkotlin.routing/WriteSetBuilder.changes.<get-changes>|<get-changes>(){}[0]
+
+    final fun <#A1: kotlin/Any> set(kotlin.reflect/KClass<#A1>, #A1) // org.reduxkotlin.routing/WriteSetBuilder.set|set(kotlin.reflect.KClass<0:0>;0:0){0§<kotlin.Any>}[0]
+    final inline fun <#A1: reified kotlin/Any> set(#A1) // org.reduxkotlin.routing/WriteSetBuilder.set|set(0:0){0§<kotlin.Any>}[0]
+}
+
+final fun (org.reduxkotlin.routing/RoutingBuilder).org.reduxkotlin.routing/install(org.reduxkotlin.routing/ReduxModule) // org.reduxkotlin.routing/install|install@org.reduxkotlin.routing.RoutingBuilder(org.reduxkotlin.routing.ReduxModule){}[0]
+final fun org.reduxkotlin.routing/createModelStore(kotlin/Function1<kotlin/Function3<kotlin/Function2<org.reduxkotlin.multimodel/ModelState, kotlin/Any, org.reduxkotlin.multimodel/ModelState>, org.reduxkotlin.multimodel/ModelState, kotlin/Any?, org.reduxkotlin/TypedStore<org.reduxkotlin.multimodel/ModelState, kotlin/Any>>, kotlin/Function3<kotlin/Function2<org.reduxkotlin.multimodel/ModelState, kotlin/Any, org.reduxkotlin.multimodel/ModelState>, org.reduxkotlin.multimodel/ModelState, kotlin/Any?, org.reduxkotlin/TypedStore<org.reduxkotlin.multimodel/ModelState, kotlin/Any>>>? = ..., kotlin/Boolean = ..., kotlin/Function5<kotlin/Any, kotlin.reflect/KClass<*>, kotlin/Any, kotlin/Any, kotlin/String, kotlin/Unit>? = ..., kotlin/Function1<org.reduxkotlin.routing/RoutingBuilder, kotlin/Unit>): org.reduxkotlin/TypedStore<org.reduxkotlin.multimodel/ModelState, kotlin/Any> // org.reduxkotlin.routing/createModelStore|createModelStore(kotlin.Function1<kotlin.Function3<kotlin.Function2<org.reduxkotlin.multimodel.ModelState,kotlin.Any,org.reduxkotlin.multimodel.ModelState>,org.reduxkotlin.multimodel.ModelState,kotlin.Any?,org.reduxkotlin.TypedStore<org.reduxkotlin.multimodel.ModelState,kotlin.Any>>,kotlin.Function3<kotlin.Function2<org.reduxkotlin.multimodel.ModelState,kotlin.Any,org.reduxkotlin.multimodel.ModelState>,org.reduxkotlin.multimodel.ModelState,kotlin.Any?,org.reduxkotlin.TypedStore<org.reduxkotlin.multimodel.ModelState,kotlin.Any>>>?;kotlin.Boolean;kotlin.Function5<kotlin.Any,kotlin.reflect.KClass<*>,kotlin.Any,kotlin.Any,kotlin.String,kotlin.Unit>?;kotlin.Function1<org.reduxkotlin.routing.RoutingBuilder,kotlin.Unit>){}[0]
+final fun org.reduxkotlin.routing/writeSet(kotlin/Function1<org.reduxkotlin.routing/WriteSetBuilder, kotlin/Unit>): org.reduxkotlin.routing/WriteSet // org.reduxkotlin.routing/writeSet|writeSet(kotlin.Function1<org.reduxkotlin.routing.WriteSetBuilder,kotlin.Unit>){}[0]
+final inline fun <#A: reified kotlin/Any> (org.reduxkotlin.routing/Reads).org.reduxkotlin.routing/get(): #A // org.reduxkotlin.routing/get|get@org.reduxkotlin.routing.Reads(){0§<kotlin.Any>}[0]

--- a/redux-kotlin-routing/build.gradle.kts
+++ b/redux-kotlin-routing/build.gradle.kts
@@ -28,5 +28,10 @@ kotlin {
                 api(project(":redux-kotlin-multimodel"))
             }
         }
+        commonTest {
+            dependencies {
+                implementation(project(":redux-kotlin-granular"))
+            }
+        }
     }
 }

--- a/redux-kotlin-routing/build.gradle.kts
+++ b/redux-kotlin-routing/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(project(":redux-kotlin-granular"))
+                implementation(project(":redux-kotlin-threadsafe"))
             }
         }
     }

--- a/redux-kotlin-routing/build.gradle.kts
+++ b/redux-kotlin-routing/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    id("convention.library-mpp-loved")
+    id("convention.publishing-mpp")
+}
+
+val hasAndroidSdk: Boolean = run {
+    val localProps = rootProject.file("local.properties")
+    val hasSdkInLocalProperties = localProps.exists() && localProps.readText().lineSequence().any {
+        it.trim().startsWith("sdk.dir=") && it.substringAfter("sdk.dir=").isNotBlank()
+    }
+    val hasSdkInEnv =
+        !System.getenv("ANDROID_HOME").isNullOrBlank() ||
+            !System.getenv("ANDROID_SDK_ROOT").isNullOrBlank()
+    hasSdkInLocalProperties || hasSdkInEnv
+}
+
+kotlin {
+    if (hasAndroidSdk) {
+        android {
+            namespace = "org.reduxkotlin.routing"
+        }
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":redux-kotlin"))
+                api(project(":redux-kotlin-multimodel"))
+            }
+        }
+    }
+}

--- a/redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/CreateModelStore.kt
+++ b/redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/CreateModelStore.kt
@@ -1,0 +1,46 @@
+package org.reduxkotlin.routing
+
+import org.reduxkotlin.Store
+import org.reduxkotlin.StoreEnhancer
+import org.reduxkotlin.createStore
+import org.reduxkotlin.multimodel.ModelState
+import kotlin.reflect.KClass
+
+/**
+ * Observer invoked for every effective model write during a dispatch,
+ * i.e. only when the new instance is referentially different
+ * (`next !== prev`). Fired synchronously during the fold, before the
+ * dispatch commits, so under last-write-wins it can observe
+ * intermediate (clobbered) values. It MUST be a pure observer: it must
+ * not call `dispatch` or read the store.
+ */
+public typealias OnWrite = (action: Any, modelClass: KClass<*>, prev: Any, next: Any, source: String) -> Unit
+
+/**
+ * Builds a [Store] of [ModelState] from a routing [block]. Each model's
+ * starting value comes from its [RoutingBuilder.model] declaration;
+ * there is no INIT-action fan-out. Dispatch routes by the exact leaf
+ * class of the action.
+ *
+ * @param enhancer optional store enhancer (e.g. `applyMiddleware`),
+ *   passed straight to [createStore].
+ * @param devChecks when true, throws if a handler returns a new but
+ *   structurally-equal model instance (a wasteful no-op write that
+ *   would fire subscribers spuriously).
+ * @param onWrite optional [OnWrite] observer for tracing/conflict
+ *   detection.
+ * @param block the routing configuration: model and handler
+ *   registrations applied to a [RoutingBuilder].
+ */
+public fun createModelStore(
+    enhancer: StoreEnhancer<ModelState>? = null,
+    devChecks: Boolean = false,
+    onWrite: OnWrite? = null,
+    block: RoutingBuilder.() -> Unit,
+): Store<ModelState> {
+    val builder = RoutingBuilder()
+    builder.block()
+    val initialState = builder.buildInitialState()
+    val reducer = builder.buildReducer(devChecks, onWrite)
+    return createStore(reducer, initialState, enhancer)
+}

--- a/redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/RoutedReducer.kt
+++ b/redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/RoutedReducer.kt
@@ -1,0 +1,107 @@
+package org.reduxkotlin.routing
+
+import org.reduxkotlin.Reducer
+import org.reduxkotlin.multimodel.ModelState
+import kotlin.reflect.KClass
+
+/**
+ * A single registered handler keyed under one action class. Given the
+ * working state and the dispatched action, it returns the model
+ * replacements it wants to make (possibly empty). The change gate and
+ * the onWrite notification are applied centrally by [routedReducer].
+ */
+internal class Cell(
+    val source: String,
+    val handler: (working: WorkingState, action: Any) -> Map<KClass<*>, Any>,
+)
+
+/**
+ * A broadcast handler that runs once per installed model for its action
+ * class. Materialized into per-model [Cell]s at reducer-build time so
+ * it covers every model regardless of declaration order.
+ */
+internal class Broadcast(
+    val actionClass: KClass<*>,
+    val perModel: (model: Any, action: Any) -> Any,
+)
+
+/**
+ * Transient per-dispatch working view over a base [ModelState]. Reads
+ * return staged writes first (so later handlers see earlier writes),
+ * falling back to the committed base. The staging map is allocated
+ * lazily on the first write, so a dispatch that changes nothing makes
+ * no map copy.
+ */
+internal class WorkingState(private val base: ModelState) : Reads {
+
+    var staged: MutableMap<KClass<*>, Any>? = null
+        private set
+
+    override fun <M : Any> get(modelClass: KClass<M>): M {
+        @Suppress("UNCHECKED_CAST")
+        return peek(modelClass) as M
+    }
+
+    fun peek(modelClass: KClass<*>): Any {
+        staged?.get(modelClass)?.let { return it }
+        return base.get(modelClass)
+    }
+
+    fun stage(modelClass: KClass<*>, model: Any) {
+        val current = staged ?: LinkedHashMap<KClass<*>, Any>().also { staged = it }
+        current[modelClass] = model
+    }
+}
+
+/**
+ * Builds the routed [Reducer] over [ModelState] from a finished routing
+ * table plus broadcast registrations.
+ */
+internal fun routedReducer(
+    table: Map<Any, List<Cell>>,
+    broadcasts: List<Broadcast>,
+    devChecks: Boolean,
+    onWrite: ((action: Any, modelClass: KClass<*>, prev: Any, next: Any, source: String) -> Unit)?,
+    modelClasses: List<KClass<*>> = emptyList(),
+): Reducer<ModelState> {
+    // Materialize broadcasts into the table as per-model cells.
+    val full: Map<Any, List<Cell>> = if (broadcasts.isEmpty()) {
+        table
+    } else {
+        val merged = LinkedHashMap<Any, MutableList<Cell>>()
+        for ((key, cells) in table) merged[key] = cells.toMutableList()
+        for (broadcast in broadcasts) {
+            val cells = merged.getOrPut(broadcast.actionClass) { mutableListOf() }
+            for (modelClass in modelClasses) {
+                cells += Cell("broadcast:${modelClass.simpleName}") { working, action ->
+                    val current = working.peek(modelClass)
+                    val next = broadcast.perModel(current, action)
+                    if (next !== current) mapOf(modelClass to next) else emptyMap()
+                }
+            }
+        }
+        merged
+    }
+
+    return reducer@{ state, action ->
+        val cells = full[action::class] ?: return@reducer state
+        val working = WorkingState(state)
+        for (cell in cells) {
+            val writes = cell.handler(working, action)
+            for ((modelClass, next) in writes) {
+                val prev = working.peek(modelClass)
+                if (next !== prev) {
+                    check(!(devChecks && next == prev)) {
+                        "Handler '${cell.source}' returned a new but structurally-equal instance for " +
+                            "${modelClass.simpleName ?: modelClass}. This allocates without changing state and " +
+                            "would fire subscribers spuriously. Return the same instance when nothing changed."
+                    }
+                    onWrite?.invoke(action, modelClass, prev, next, cell.source)
+                    working.stage(modelClass, next)
+                }
+            }
+        }
+        val staged = working.staged ?: return@reducer state
+        state.withAll(staged)
+    }
+}

--- a/redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/RoutedReducer.kt
+++ b/redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/RoutedReducer.kt
@@ -10,20 +10,14 @@ import kotlin.reflect.KClass
  * replacements it wants to make (possibly empty). The change gate and
  * the onWrite notification are applied centrally by [routedReducer].
  */
-internal class Cell(
-    val source: String,
-    val handler: (working: WorkingState, action: Any) -> Map<KClass<*>, Any>,
-)
+internal class Cell(val source: String, val handler: (working: WorkingState, action: Any) -> Map<KClass<*>, Any>)
 
 /**
  * A broadcast handler that runs once per installed model for its action
  * class. Materialized into per-model [Cell]s at reducer-build time so
  * it covers every model regardless of declaration order.
  */
-internal class Broadcast(
-    val actionClass: KClass<*>,
-    val perModel: (model: Any, action: Any) -> Any,
-)
+internal class Broadcast(val actionClass: KClass<*>, val perModel: (model: Any, action: Any) -> Any)
 
 /**
  * Transient per-dispatch working view over a base [ModelState]. Reads

--- a/redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/RoutingDsl.kt
+++ b/redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/RoutingDsl.kt
@@ -1,0 +1,133 @@
+package org.reduxkotlin.routing
+
+import org.reduxkotlin.Reducer
+import org.reduxkotlin.multimodel.ModelState
+import kotlin.reflect.KClass
+
+/**
+ * Collects model initial instances and action handlers, then produces
+ * the initial [ModelState] and the routed [Reducer]. This is the
+ * receiver of the [createModelStore] lambda and of [ReduxModule]
+ * contributions. Registration order across the whole block (including
+ * [install]ed modules) fixes the dispatch order for any action handled
+ * by more than one handler.
+ */
+public class RoutingBuilder @PublishedApi internal constructor() {
+
+    @PublishedApi
+    internal val initials: MutableList<Any> = mutableListOf()
+
+    @PublishedApi
+    internal val modelClasses: MutableList<KClass<*>> = mutableListOf()
+
+    @PublishedApi
+    internal val table: MutableMap<Any, MutableList<Cell>> = LinkedHashMap()
+
+    @PublishedApi
+    internal val broadcasts: MutableList<Broadcast> = mutableListOf()
+
+    /**
+     * Registers a model of type [M] with its [initial] instance and its
+     * single-model handlers. The initial instance is the sole source of
+     * that model's starting value — there is no INIT action fan-out.
+     *
+     * @throws IllegalArgumentException if [M] is registered more than
+     *   once.
+     */
+    public inline fun <reified M : Any> model(initial: M, block: ModelHandlerScope<M>.() -> Unit) {
+        registerModel(M::class, initial)
+        ModelHandlerScope(M::class, this).block()
+    }
+
+    /**
+     * Registers a multi-model handler for action [A]. The handler reads
+     * any models via [Reads] and returns a [WriteSet] of replacements.
+     */
+    public inline fun <reified A : Any> onAction(noinline handler: (reads: Reads, action: A) -> WriteSet) {
+        addCell(A::class, "onAction:${A::class.simpleName}") { working, action ->
+            @Suppress("UNCHECKED_CAST")
+            handler(working, action as A).changes
+        }
+    }
+
+    /**
+     * Registers a broadcast handler for action [A] that runs once per
+     * installed model. [transform] receives each model instance and
+     * returns its (possibly unchanged) replacement. Use for
+     * cross-cutting actions such as reset/logout that every model must
+     * observe.
+     */
+    public inline fun <reified A : Any> onBroadcast(noinline transform: (model: Any, action: A) -> Any) {
+        @Suppress("UNCHECKED_CAST")
+        registerBroadcast(A::class) { model, action -> transform(model, action as A) }
+    }
+
+    @PublishedApi
+    internal fun registerModel(modelClass: KClass<*>, initial: Any) {
+        require(modelClasses.none { it == modelClass }) {
+            "Model ${modelClass.simpleName ?: modelClass} registered more than once in createModelStore { }."
+        }
+        modelClasses += modelClass
+        initials += initial
+    }
+
+    @PublishedApi
+    internal fun addCell(actionClass: KClass<*>, source: String, handler: (Reads, Any) -> Map<KClass<*>, Any>) {
+        table.getOrPut(actionClass) { mutableListOf() } += Cell(source) { working, action -> handler(working, action) }
+    }
+
+    @PublishedApi
+    internal fun registerBroadcast(actionClass: KClass<*>, perModel: (Any, Any) -> Any) {
+        broadcasts += Broadcast(actionClass, perModel)
+    }
+
+    internal fun buildInitialState(): ModelState = ModelState.of(*initials.toTypedArray())
+
+    internal fun buildReducer(devChecks: Boolean, onWrite: OnWrite?): Reducer<ModelState> =
+        routedReducer(table, broadcasts, devChecks, onWrite, modelClasses.toList())
+}
+
+/**
+ * The receiver of a [RoutingBuilder.model] block; registers
+ * single-model handlers for model type [M].
+ */
+public class ModelHandlerScope<M : Any> @PublishedApi internal constructor(
+    @PublishedApi internal val modelClass: KClass<M>,
+    @PublishedApi internal val builder: RoutingBuilder,
+) {
+    /**
+     * Registers a pure single-model handler for action [A]: given the
+     * current model and the action, return the next model instance
+     * (return the same instance to signal "no change"). Matching is by
+     * exact leaf class — a handler on [A] does not catch subtypes of
+     * [A].
+     */
+    public inline fun <reified A : Any> on(noinline reducer: (model: M, action: A) -> M) {
+        builder.addCell(A::class, "model:${modelClass.simpleName}") { working, action ->
+            val model = working.get(modelClass)
+
+            @Suppress("UNCHECKED_CAST")
+            val next = reducer(model, action as A)
+            if (next !== model) mapOf<KClass<*>, Any>(modelClass to next) else emptyMap()
+        }
+    }
+}
+
+/**
+ * A reusable bundle of model and handler registrations that can be
+ * [install]ed into a [RoutingBuilder]. Lets feature modules package
+ * their slice of the store; the app fixes ordering by the sequence of
+ * [install] calls.
+ */
+public fun interface ReduxModule {
+    /** Contributes this module's models and handlers to the builder. */
+    public fun RoutingBuilder.contribute()
+}
+
+/**
+ * Applies a [ReduxModule]'s registrations to this builder, in call
+ * order.
+ */
+public fun RoutingBuilder.install(module: ReduxModule) {
+    with(module) { contribute() }
+}

--- a/redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/RoutingDsl.kt
+++ b/redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/RoutingDsl.kt
@@ -42,6 +42,8 @@ public class RoutingBuilder @PublishedApi internal constructor() {
     /**
      * Registers a multi-model handler for action [A]. The handler reads
      * any models via [Reads] and returns a [WriteSet] of replacements.
+     * The handler must be pure: it must not call `dispatch` or read the
+     * store, only compute the next models from its inputs.
      */
     public inline fun <reified A : Any> onAction(noinline handler: (reads: Reads, action: A) -> WriteSet) {
         addCell(A::class, "onAction:${A::class.simpleName}") { working, action ->
@@ -55,7 +57,8 @@ public class RoutingBuilder @PublishedApi internal constructor() {
      * installed model. [transform] receives each model instance and
      * returns its (possibly unchanged) replacement. Use for
      * cross-cutting actions such as reset/logout that every model must
-     * observe.
+     * observe. The transform must be pure: it must not call `dispatch`
+     * or read the store, only compute the next model from its inputs.
      */
     public inline fun <reified A : Any> onBroadcast(noinline transform: (model: Any, action: A) -> Any) {
         @Suppress("UNCHECKED_CAST")
@@ -100,7 +103,8 @@ public class ModelHandlerScope<M : Any> @PublishedApi internal constructor(
      * current model and the action, return the next model instance
      * (return the same instance to signal "no change"). Matching is by
      * exact leaf class — a handler on [A] does not catch subtypes of
-     * [A].
+     * [A]. The reducer must be pure: it must not call `dispatch` or read
+     * the store, only compute the next model from its inputs.
      */
     public inline fun <reified A : Any> on(noinline reducer: (model: M, action: A) -> M) {
         builder.addCell(A::class, "model:${modelClass.simpleName}") { working, action ->

--- a/redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/WriteSet.kt
+++ b/redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/WriteSet.kt
@@ -1,0 +1,66 @@
+package org.reduxkotlin.routing
+
+import kotlin.reflect.KClass
+
+/**
+ * A read-only view of model state passed to multi-model handlers
+ * during a dispatch. Reads reflect writes already produced by earlier
+ * handlers in the same dispatch (fold semantics), so a later handler
+ * observes prior handlers' results.
+ */
+public interface Reads {
+    /**
+     * Returns the current working instance of [modelClass] for this
+     * dispatch.
+     *
+     * @throws IllegalStateException if [modelClass] was not registered
+     *   in the createModelStore block.
+     */
+    public fun <M : Any> get(modelClass: KClass<M>): M
+}
+
+/**
+ * Reified convenience for [Reads.get].
+ */
+public inline fun <reified M : Any> Reads.get(): M = get(M::class)
+
+/**
+ * The set of model replacements returned by a multi-model handler
+ * (onAction). Each entry replaces one model slot; a model not named
+ * here is left untouched. Build instances with [writeSet].
+ */
+public class WriteSet @PublishedApi internal constructor(
+    /** The replacements, keyed by concrete model class. */
+    @PublishedApi internal val changes: Map<KClass<*>, Any>,
+)
+
+/**
+ * Builder for [WriteSet]; the receiver of the [writeSet] lambda.
+ */
+public class WriteSetBuilder @PublishedApi internal constructor() {
+
+    @PublishedApi
+    internal val changes: MutableMap<KClass<*>, Any> = LinkedHashMap()
+
+    /**
+     * Stages [model] as the new instance for model type [M]. A later
+     * [set] for the same type overrides an earlier one.
+     */
+    public inline fun <reified M : Any> set(model: M): Unit = set(M::class, model)
+
+    /**
+     * Non-reified overload of [set] for callers holding a [KClass].
+     */
+    public fun <M : Any> set(modelClass: KClass<M>, model: M) {
+        changes[modelClass] = model
+    }
+}
+
+/**
+ * Builds a [WriteSet] from a sequence of [WriteSetBuilder.set] calls.
+ */
+public fun writeSet(block: WriteSetBuilder.() -> Unit): WriteSet {
+    val builder = WriteSetBuilder()
+    builder.block()
+    return WriteSet(builder.changes.toMap())
+}

--- a/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/BroadcastTest.kt
+++ b/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/BroadcastTest.kt
@@ -1,0 +1,37 @@
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class BroadcastTest {
+
+    @Test
+    fun broadcast_runs_for_every_installed_model() {
+        val s = createModelStore {
+            model(UserModel(user = "ann")) {}
+            model(CartModel(items = listOf("book"))) {}
+            onBroadcast<ResetAll> { model, _ ->
+                when (model) {
+                    is UserModel -> UserModel()
+                    is CartModel -> CartModel()
+                    else -> model
+                }
+            }
+        }
+        s.dispatch(ResetAll)
+        assertNull(s.state.get<UserModel>().user)
+        assertEquals(emptyList(), s.state.get<CartModel>().items)
+    }
+
+    @Test
+    fun broadcast_covers_models_declared_after_it() {
+        val s = createModelStore {
+            model(UserModel(user = "ann")) {}
+            onBroadcast<ResetAll> { model, _ -> if (model is UserModel) UserModel() else model }
+            model(CartModel(items = listOf("book"))) {}
+        }
+        s.dispatch(ResetAll)
+        assertNull(s.state.get<UserModel>().user)
+    }
+}

--- a/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/CreateModelStoreTest.kt
+++ b/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/CreateModelStoreTest.kt
@@ -1,0 +1,50 @@
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class CreateModelStoreTest {
+
+    private fun store() = createModelStore {
+        model(UserModel()) {
+            on<LoggedIn> { s, a -> s.copy(user = a.user) }
+            on<LoggedOut> { s, _ -> s.copy(user = null) }
+        }
+        model(CartModel()) {
+            on<AddItem> { s, a -> s.copy(items = s.items + a.item) }
+        }
+    }
+
+    @Test
+    fun single_model_handler_updates_its_model() {
+        val s = store()
+        s.dispatch(LoggedIn("ann"))
+        assertEquals("ann", s.state.get<UserModel>().user)
+    }
+
+    @Test
+    fun action_routes_only_to_its_model() {
+        val s = store()
+        val before = s.state.get<CartModel>()
+        s.dispatch(LoggedIn("ann"))
+        assertSame(before, s.state.get<CartModel>())
+    }
+
+    @Test
+    fun unhandled_action_leaves_state_identity_unchanged() {
+        val s = store()
+        val before = s.state
+        s.dispatch(NeverHandled)
+        assertSame(before, s.state)
+    }
+
+    @Test
+    fun logged_out_clears_user() {
+        val s = store()
+        s.dispatch(LoggedIn("ann"))
+        s.dispatch(LoggedOut)
+        assertNull(s.state.get<UserModel>().user)
+    }
+}

--- a/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/DevChecksTest.kt
+++ b/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/DevChecksTest.kt
@@ -1,0 +1,40 @@
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class DevChecksTest {
+
+    @Test
+    fun devChecks_throws_on_structurally_equal_new_instance() {
+        val s = createModelStore(devChecks = true) {
+            model(UserModel()) {
+                // Returns a brand-new instance that is structurally equal: a wasteful no-op write.
+                on<LoggedIn> { u, _ -> u.copy() }
+            }
+        }
+        assertFailsWith<IllegalStateException> {
+            s.dispatch(LoggedIn("ann"))
+        }
+    }
+
+    @Test
+    fun devChecks_allows_real_change() {
+        val s = createModelStore(devChecks = true) {
+            model(UserModel()) {
+                on<LoggedIn> { u, a -> u.copy(user = a.user) }
+            }
+        }
+        s.dispatch(LoggedIn("ann")) // does not throw
+    }
+
+    @Test
+    fun without_devChecks_no_op_copy_is_silently_committed() {
+        val s = createModelStore(devChecks = false) {
+            model(UserModel()) {
+                on<LoggedIn> { u, _ -> u.copy() }
+            }
+        }
+        s.dispatch(LoggedIn("ann")) // no throw; just a wasteful write
+    }
+}

--- a/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/ErrorSemanticsTest.kt
+++ b/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/ErrorSemanticsTest.kt
@@ -1,0 +1,26 @@
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+private class Boom : RuntimeException("boom")
+
+class ErrorSemanticsTest {
+
+    @Test
+    fun throwing_handler_aborts_dispatch_without_partial_commit() {
+        val s = createModelStore {
+            model(UserModel()) {
+                on<Checkout> { u, _ -> u.copy(user = "ann") } // staged first
+            }
+            onAction<Checkout> { _, _ -> throw Boom() } // throws before commit
+        }
+        val before = s.state
+        assertFailsWith<Boom> { s.dispatch(Checkout) }
+        // No partial commit: the earlier staged write must not survive.
+        assertSame(before, s.state)
+        assertTrue(s.state.get<UserModel>().user == null)
+    }
+}

--- a/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/ExactLeafMatchingTest.kt
+++ b/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/ExactLeafMatchingTest.kt
@@ -1,0 +1,36 @@
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+private sealed interface Nav
+private data class Open(val screen: String) : Nav
+private data class Close(val screen: String) : Nav
+
+private data class NavModel(val current: String = "home", val opens: Int = 0)
+
+class ExactLeafMatchingTest {
+
+    private fun store() = createModelStore {
+        model(NavModel()) {
+            on<Open> { s, a -> s.copy(current = a.screen, opens = s.opens + 1) }
+        }
+    }
+
+    @Test
+    fun handler_matches_its_exact_leaf_class() {
+        val s = store()
+        s.dispatch(Open("profile"))
+        assertEquals("profile", s.state.get<NavModel>().current)
+        assertEquals(1, s.state.get<NavModel>().opens)
+    }
+
+    @Test
+    fun handler_does_not_match_a_sibling_subtype() {
+        val s = store()
+        val before = s.state
+        s.dispatch(Close("profile")) // no handler registered for Close
+        assertSame(before, s.state)
+    }
+}

--- a/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/Fixtures.kt
+++ b/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/Fixtures.kt
@@ -1,0 +1,15 @@
+package org.reduxkotlin.routing
+
+/** A user model for tests. */
+internal data class UserModel(val user: String? = null, val lastOrder: Int = -1)
+
+/** A cart model for tests. */
+internal data class CartModel(val items: List<String> = emptyList(), val id: Int = 0, val closed: Boolean = false)
+
+/** Actions used across routing tests. */
+internal data class LoggedIn(val user: String)
+internal object LoggedOut
+internal data class AddItem(val item: String)
+internal object Checkout
+internal object ResetAll
+internal object NeverHandled

--- a/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/GranularIntegrationTest.kt
+++ b/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/GranularIntegrationTest.kt
@@ -1,0 +1,28 @@
+package org.reduxkotlin.routing
+
+import org.reduxkotlin.granular.subscribeTo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GranularIntegrationTest {
+
+    @Test
+    fun subscriber_fires_only_when_its_model_changes() {
+        val s = createModelStore {
+            model(UserModel()) {
+                on<LoggedIn> { u, a -> u.copy(user = a.user) }
+            }
+            model(CartModel()) {
+                on<AddItem> { c, a -> c.copy(items = c.items + a.item) }
+            }
+        }
+        var userFires = 0
+        s.subscribeTo(selector = { it.get<UserModel>() }, triggerOnSubscribe = false) { _, _ -> userFires++ }
+
+        s.dispatch(AddItem("book")) // cart only -> user selector unchanged
+        assertEquals(0, userFires)
+
+        s.dispatch(LoggedIn("ann")) // user changes
+        assertEquals(1, userFires)
+    }
+}

--- a/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/ModuleInstallTest.kt
+++ b/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/ModuleInstallTest.kt
@@ -1,0 +1,45 @@
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private data class Audit(val log: List<String> = emptyList())
+
+class ModuleInstallTest {
+
+    private val userModule = ReduxModule {
+        model(UserModel()) {
+            on<LoggedIn> { s, a -> s.copy(user = a.user) }
+        }
+    }
+
+    @Test
+    fun installed_module_contributes_models_and_handlers() {
+        val s = createModelStore {
+            install(userModule)
+        }
+        s.dispatch(LoggedIn("ann"))
+        assertEquals("ann", s.state.get<UserModel>().user)
+    }
+
+    @Test
+    fun handler_order_follows_install_order() {
+        val first = ReduxModule {
+            model(Audit()) {
+                on<Checkout> { a, _ -> a.copy(log = a.log + "first") }
+            }
+        }
+        val second = ReduxModule {
+            onAction<Checkout> { reads, _ ->
+                val a = reads.get<Audit>()
+                writeSet { set(a.copy(log = a.log + "second")) }
+            }
+        }
+        val s = createModelStore {
+            install(first)
+            install(second)
+        }
+        s.dispatch(Checkout)
+        assertEquals(listOf("first", "second"), s.state.get<Audit>().log)
+    }
+}

--- a/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/MultiModelTest.kt
+++ b/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/MultiModelTest.kt
@@ -1,0 +1,60 @@
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class MultiModelTest {
+
+    private fun store() = createModelStore {
+        model(UserModel()) {
+            on<LoggedIn> { s, a -> s.copy(user = a.user) }
+        }
+        model(CartModel(id = 7)) {
+            on<AddItem> { s, a -> s.copy(items = s.items + a.item) }
+        }
+        onAction<Checkout> { reads, _ ->
+            val cart = reads.get<CartModel>()
+            writeSet {
+                set(cart.copy(closed = true))
+                set(reads.get<UserModel>().copy(lastOrder = cart.id))
+            }
+        }
+    }
+
+    @Test
+    fun multi_model_handler_writes_several_models() {
+        val s = store()
+        s.dispatch(LoggedIn("ann"))
+        s.dispatch(AddItem("book"))
+        s.dispatch(Checkout)
+        assertTrue(s.state.get<CartModel>().closed)
+        assertEquals(7, s.state.get<UserModel>().lastOrder)
+    }
+
+    @Test
+    fun later_handler_in_same_action_sees_earlier_write() {
+        val s = createModelStore {
+            model(CartModel(id = 1)) {
+                on<Checkout> { c, _ -> c.copy(items = c.items + "auto") }
+            }
+            model(UserModel()) {}
+            onAction<Checkout> { reads, _ ->
+                val cart = reads.get<CartModel>() // must see the "auto" item
+                writeSet { set(reads.get<UserModel>().copy(user = cart.items.joinToString())) }
+            }
+        }
+        s.dispatch(Checkout)
+        assertEquals("auto", s.state.get<UserModel>().user)
+    }
+
+    @Test
+    fun unchanged_models_keep_identity_after_multi_write() {
+        val s = store()
+        s.dispatch(LoggedIn("ann"))
+        val userBefore = s.state.get<UserModel>()
+        s.dispatch(AddItem("book")) // touches only cart
+        assertSame(userBefore, s.state.get<UserModel>())
+    }
+}

--- a/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/OnWriteHookTest.kt
+++ b/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/OnWriteHookTest.kt
@@ -1,0 +1,65 @@
+package org.reduxkotlin.routing
+
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private data class Write(val modelClass: KClass<*>, val prev: Any, val next: Any, val source: String)
+
+class OnWriteHookTest {
+
+    @Test
+    fun hook_fires_once_per_effective_write_with_source() {
+        val writes = mutableListOf<Write>()
+        val s = createModelStore(
+            onWrite = { _, modelClass, prev, next, source -> writes += Write(modelClass, prev, next, source) },
+        ) {
+            model(UserModel()) {
+                on<LoggedIn> { u, a -> u.copy(user = a.user) }
+            }
+        }
+        s.dispatch(LoggedIn("ann"))
+        assertEquals(1, writes.size)
+        assertEquals(UserModel::class, writes[0].modelClass)
+        assertEquals(UserModel(), writes[0].prev)
+        assertEquals(UserModel(user = "ann"), writes[0].next)
+        assertTrue(writes[0].source.contains("UserModel"))
+    }
+
+    @Test
+    fun hook_does_not_fire_for_no_op_handler() {
+        val writes = mutableListOf<Write>()
+        val s = createModelStore(
+            onWrite = { _, modelClass, prev, next, source -> writes += Write(modelClass, prev, next, source) },
+        ) {
+            model(UserModel()) {
+                on<LoggedOut> { u, _ -> u } // returns same instance -> no write
+            }
+        }
+        s.dispatch(LoggedOut)
+        assertTrue(writes.isEmpty())
+    }
+
+    @Test
+    fun hook_observes_intermediate_values_under_last_write_wins() {
+        val nexts = mutableListOf<Any>()
+        val s = createModelStore(
+            onWrite = { _, _, _, next, _ -> nexts += next },
+        ) {
+            model(UserModel()) {
+                on<Checkout> { u, _ -> u.copy(user = "a") }
+            }
+            onAction<Checkout> { reads, _ ->
+                val next: UserModel = reads.get<UserModel>().copy(user = "b")
+                writeSet { set(next) }
+            }
+        }
+        s.dispatch(Checkout)
+        assertEquals(
+            listOf<Any>(UserModel(user = "a"), UserModel(user = "b")),
+            nexts.toList(),
+        )
+        assertEquals("b", s.state.get<UserModel>().user) // committed = last write
+    }
+}

--- a/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/RoutedReducerTest.kt
+++ b/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/RoutedReducerTest.kt
@@ -1,0 +1,50 @@
+package org.reduxkotlin.routing
+
+import org.reduxkotlin.multimodel.ModelState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+private data class Counter(val n: Int)
+private data class Flag(val on: Boolean)
+private object Inc
+private object Toggle
+private object Unhandled
+
+class RoutedReducerTest {
+
+    private fun table(): Map<Any, List<Cell>> = mapOf(
+        Inc::class to listOf(
+            Cell("counter") { working, _ ->
+                val c = working.get(Counter::class)
+                mapOf(Counter::class to c.copy(n = c.n + 1))
+            },
+        ),
+    )
+
+    @Test
+    fun dispatch_runs_only_the_matching_cell() {
+        val reducer = routedReducer(table(), broadcasts = emptyList(), devChecks = false, onWrite = null)
+        val s0 = ModelState.of(Counter(0), Flag(false))
+        val s1 = reducer(s0, Inc)
+        assertEquals(1, s1.get<Counter>().n)
+        assertEquals(false, s1.get<Flag>().on)
+    }
+
+    @Test
+    fun unhandled_action_returns_same_instance() {
+        val reducer = routedReducer(table(), broadcasts = emptyList(), devChecks = false, onWrite = null)
+        val s0 = ModelState.of(Counter(0), Flag(false))
+        assertSame(s0, reducer(s0, Unhandled))
+    }
+
+    @Test
+    fun handled_action_with_no_change_returns_same_instance() {
+        val noop = mapOf<Any, List<Cell>>(
+            Toggle::class to listOf(Cell("flag") { _, _ -> emptyMap() }),
+        )
+        val reducer = routedReducer(noop, broadcasts = emptyList(), devChecks = false, onWrite = null)
+        val s0 = ModelState.of(Flag(false))
+        assertSame(s0, reducer(s0, Toggle))
+    }
+}

--- a/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/RoutingGuardsTest.kt
+++ b/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/RoutingGuardsTest.kt
@@ -1,0 +1,31 @@
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+
+class RoutingGuardsTest {
+
+    @Test
+    fun registering_same_model_twice_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            createModelStore {
+                model(UserModel()) {}
+                model(UserModel(user = "dup")) {}
+            }
+        }
+    }
+
+    @Test
+    fun broadcast_transform_returning_same_instance_is_a_no_op() {
+        val s = createModelStore {
+            model(UserModel(user = "ann")) {}
+            model(CartModel(items = listOf("book"))) {}
+            // Transform returns each model unchanged -> no writes -> same ModelState.
+            onBroadcast<ResetAll> { model, _ -> model }
+        }
+        val before = s.state
+        s.dispatch(ResetAll)
+        assertSame(before, s.state)
+    }
+}

--- a/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/WriteSetTest.kt
+++ b/redux-kotlin-routing/src/commonTest/kotlin/org/reduxkotlin/routing/WriteSetTest.kt
@@ -1,0 +1,31 @@
+package org.reduxkotlin.routing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private data class Foo(val n: Int)
+private data class Bar(val s: String)
+
+class WriteSetTest {
+
+    @Test
+    fun writeSet_collects_models_keyed_by_class() {
+        val ws = writeSet {
+            set(Foo(1))
+            set(Bar("x"))
+        }
+        assertEquals(2, ws.changes.size)
+        assertEquals(Foo(1), ws.changes[Foo::class])
+        assertEquals(Bar("x"), ws.changes[Bar::class])
+    }
+
+    @Test
+    fun writeSet_last_set_for_a_class_wins() {
+        val ws = writeSet {
+            set(Foo(1))
+            set(Foo(2))
+        }
+        assertEquals(1, ws.changes.size)
+        assertEquals(Foo(2), ws.changes[Foo::class])
+    }
+}

--- a/redux-kotlin-routing/src/jvmTest/kotlin/org/reduxkotlin/routing/concurrency/RoutedThreadSafeStressTest.kt
+++ b/redux-kotlin-routing/src/jvmTest/kotlin/org/reduxkotlin/routing/concurrency/RoutedThreadSafeStressTest.kt
@@ -1,0 +1,38 @@
+package org.reduxkotlin.routing.concurrency
+
+import org.reduxkotlin.routing.AddItem
+import org.reduxkotlin.routing.CartModel
+import org.reduxkotlin.routing.createModelStore
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RoutedThreadSafeStressTest {
+
+    @Test
+    fun externally_synchronized_concurrent_dispatch_does_not_lose_writes() {
+        val store = createModelStore {
+            model(CartModel()) {
+                on<AddItem> { c, a -> c.copy(items = c.items + a.item) }
+            }
+        }
+        val lock = Any()
+        val threads = 8
+        val perThread = 1000
+        val pool = Executors.newFixedThreadPool(threads)
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(threads)
+        repeat(threads) {
+            pool.submit {
+                start.await()
+                repeat(perThread) { synchronized(lock) { store.dispatch(AddItem("x")) } }
+                done.countDown()
+            }
+        }
+        start.countDown()
+        done.await()
+        pool.shutdown()
+        assertEquals(threads * perThread, store.state.get<CartModel>().items.size)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ include(
     ":redux-kotlin-registry",
     ":redux-kotlin-granular",
     ":redux-kotlin-multimodel",
+    ":redux-kotlin-routing",
     ":redux-kotlin-compose",
     ":redux-kotlin-multimodel-granular",
     ":redux-kotlin-compose-multimodel",


### PR DESCRIPTION
## Summary

New opt-in companion module **`redux-kotlin-routing`** (Phase 1, Mechanism A): a runtime DSL for `(model, action)` *routed* dispatch over `ModelState`, replacing the `when(action){}` cascade with exact-leaf-class routing.

- An action only visits the handlers registered for its **exact** leaf class; only the models a handler changes are rebuilt, preserving `===` identity of the rest (so the granular subscription layer stays precise).
- **Single-model handlers** are pure `(M, A) -> M`; **multi-model** handlers return a `WriteSet`; **`onBroadcast`** fans out across every installed model (for cross-cutting actions like reset/logout).
- **Structural init** (no INIT fan-out — initial instances come from `model(initial)`), **last-write-wins** within a dispatch, **all-or-nothing** error semantics, opt-in `devChecks` immutability assertion, and an opt-in `!==`-gated `onWrite` observer.
- Supporting change: `ModelState.withAll(map)` in `redux-kotlin-multimodel` for a single-copy batch write (keeps the dispatch fold to ≤1 allocation, zero on no-op).

Design is captured in the RFC + plan under `docs/superpowers/` (also in this branch). KSP codegen, a compiler plugin, and a coroutine `-effects` module are explicitly out of scope (later phases).

Built on `redux-kotlin` + `redux-kotlin-multimodel`; composes unchanged with `granular`, `threadsafe`, and the Compose bindings. No runtime reflection; no new `expect/actual`.

## Test Plan

- [x] 31 tests in `redux-kotlin-routing` (exact-leaf matching, multi-model fold ordering, broadcast fan-out, install ordering, onWrite gating + intermediate values, devChecks, all-or-nothing, granular `===` precision, JVM concurrency stress, guard tests)
- [x] `ModelState.withAll` tests in `redux-kotlin-multimodel`
- [x] `./gradlew build apiCheck` green (all targets compile; detekt `explicitApi`+KDoc clean; committed API dumps for both modules)
- [ ] CI to run iOS-simulator + browser test execution (env-gated locally per `CLAUDE.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)