### PR TITLE
docs(agent): feature-slice reference guide + reference-set conventions (Phase 0-pilot)

### DIFF
--- a/docs/agent/references/README.md
+++ b/docs/agent/references/README.md
@@ -1,0 +1,20 @@
+# redux-kotlin agent reference set (T1)
+
+Single-source, per-concern guides for building with redux-kotlin. `AGENTS.md` (Phase 1) and the
+Claude skill (Phase 2) assemble from these — edit knowledge here, not in copies.
+
+Anchor convention: source references are written `repo-relative-path → Symbol` (in backticks) and are
+checked to resolve (path exists, symbol present). See [_template.md](./_template.md).
+
+| Concern | Guide | Status |
+|---|---|---|
+| Add a feature slice | [feature-slice.md](./feature-slice.md) | ✅ |
+| Store setup & topology | `store-setup.md` | planned (0-rest) |
+| Compose binding (Rule C) | `compose-binding.md` | planned (0-rest) |
+| Effects + sync (Rule E) | `effects-sync.md` | planned (0-rest) |
+| Testing & the verify loop | `testing.md` | planned (0-rest) |
+| The 6 platform shims | `platform-shims.md` | planned (0-rest) |
+| Modularization | `modularization.md` | planned (0-rest) |
+
+Tiers: **T0** = rules card + module map + commands (assembled into `AGENTS.md`). **T1** = these guides.
+**T2** = [`examples/taskflow/ARCHITECTURE.md`](../../../examples/taskflow/ARCHITECTURE.md) + committed `.api` dumps.

--- a/docs/agent/references/_template.md
+++ b/docs/agent/references/_template.md
@@ -1,0 +1,26 @@
+---
+tier: T1
+concern: <kebab-concern-name>
+derives_from:
+  # each entry is `<repo-relative-path> → <Symbol>[, <Symbol>]`
+  - <path> → <Symbol>
+api_files:
+  # committed library .api dumps backing the APIs this guide uses (taskflow itself has none)
+  - <module>/api/<module>.klib.api
+rules: []          # subset of A–H this guide enforces
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: <short-sha>, date: <YYYY-MM-DD> }
+---
+
+# <Title>
+
+> One-line statement of what this guide answers.
+
+## <Section>
+
+Prose explains the *why* and the *rule*. Every source reference uses the anchor form
+`path → Symbol` wrapped in backticks — repo-relative path, a literal " → ", then the symbol(s).
+
+## See also
+
+- Cross-links to sibling guides via [README](./README.md).

--- a/docs/agent/references/feature-slice.md
+++ b/docs/agent/references/feature-slice.md
@@ -1,0 +1,168 @@
+---
+tier: T1
+concern: feature-slice
+derives_from:
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/boardlist → BoardListModel, boardListReducer, BoardListScreen, CreateBoard, BoardSummaryCard
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/EffectsMiddleware.kt → effectsMiddleware
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardSelectors.kt → deriveVisibleCardIds
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/Action.kt → Action, Undoable
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/CardActions.kt → InverseOp
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt → declareAccountModels
+api_files:
+  - redux-kotlin-compose-multimodel/api/redux-kotlin-compose-multimodel.klib.api
+  - redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api
+rules: [C, E, G]
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: 06214a9, date: 2026-06-03 }
+---
+
+# Feature slice
+
+> How to add a vertical feature slice to the package-by-feature `examples/taskflow` app: the seven
+> elements, where each lives, the design rule it honors, and how to wire it into the store.
+
+## What a feature slice is here
+
+A feature slice is **one directory `feature/<name>/`** that co-locates everything a feature owns:
+its slot model(s), actions, reducer(s), effect handler, screen + child composables, selectors, and
+tests. The `boardlist` slice is the smallest complete example — a slot model, leaf actions, one pure
+reducer, a screen, and a card — so it is the spine of this guide; the heavier `board` slice supplies
+the effects/selectors callouts.
+
+Shared homes sit outside `feature/*`:
+
+- **`core`** — the domain kernel: entities (`BoardEntities.kt`), the `Action`/`Undoable` marker
+  interfaces (`Action.kt`), and the cross-feature card/sync-contract actions + `InverseOp`
+  (`CardActions.kt`). No Compose, no IO.
+- **`infra`** — platform shims (expect/actual), the db, the data/sync layer, util.
+- **`app`** — the composition root: `App.kt`, the store factories (`AppStore.kt`, `AccountStore.kt`),
+  and `app/nav`.
+- **`ui`** — theme, `CompositionLocal`s, and cross-feature widgets.
+
+Dependency direction (one way, never back): `core ← infra`; `core / infra / ui ← feature/*`;
+everything `← app`. A feature may depend on `core`/`infra`/`ui` and may reference another feature's
+public leaf actions (e.g. `board`'s effects import `boardlist`'s `CreateBoard`), but `core` never
+imports a feature.
+
+## The seven elements
+
+### 1. Models
+
+Two homes. The **slot model** is the immutable per-account state the store holds for this feature; it
+lives in the slice: `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/boardlist → BoardListModel`.
+The **entity** it caches is a domain type, so it lives in the kernel:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/AccountEntities.kt → BoardSummary`.
+Rule: feature-private projection state stays in the feature; anything more than one feature needs (or
+that is fundamentally a domain noun) goes to `core`. Slot models default every field so the store can
+declare an empty slot.
+
+### 2. Actions
+
+Feature leaves live in the slice:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/boardlist → CreateBoard, LoadBoardListSucceeded`.
+The markers and the cross-feature card contract live in the kernel:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/Action.kt → Action, Undoable`
+and `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/CardActions.kt → InverseOp`.
+
+Every concrete action implements `Action`; user card mutations also implement `Undoable` (drives the
+undo stack). **`Action` and `Undoable` are plain interfaces, NOT `sealed`.** Kotlin requires every
+subtype of a `sealed` type to live in the same package, but package-by-feature spreads action leaves
+across many feature packages — a sealed root would force every action back into `core`, defeating the
+slicing. The cost is exhaustiveness: a non-sealed root means `when (action)` has no compiler-checked
+totality, so every routing/reducer `when` ends in an `else` that returns state unchanged — which is
+the correct Redux semantics anyway, so the choice is behavior-preserving. By contrast `InverseOp`
+**stays `sealed`**: its leaves are a fixed, small set co-located in `core/CardActions.kt`, so
+`when (inverse)` can be exhaustive with no `else`.
+
+### 3. Reducer
+
+Pure `(model, action) -> model`, same instance returned for unhandled actions:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/boardlist → boardListReducer`.
+The store's routing DSL (`model<M> { on<T> { } }`) dispatches each registered action class to the
+reducer, so the reducer's own `when` only needs the leaves it handles plus `else -> model`. The
+reducer is the home for **Rule G** at the *consume* side: it never reads a clock or generates an id —
+`CreateBoard` carries a pre-minted `boardId` and `now`, and the reducer stamps the new `BoardSummary`
+straight from the action. (Multi-slot reducers — see `board` — take a captured `selfId` argument from
+the store wiring rather than reading identity at runtime.)
+
+### 4. Effects
+
+**Rule E — off-main effects.** The ONLY place intent becomes IO is a middleware; each feature's
+handler is a per-feature `Middleware<ModelState>` composed into the pipeline. Board callout:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/EffectsMiddleware.kt → effectsMiddleware`.
+All repository/sync work runs on the per-account background `scope` (off-main); dispatches marshal
+back to main through the store's `NotificationContext`, so the effect code does no explicit main hop.
+The handler routes by exact action class, runs the optimistic reducer via `next(action)`, then
+launches the matching repository call — capturing the per-op `InverseOp` *before* `next` so a backend
+rejection can revert exactly that op. A feature ships its own handler only if it performs IO: `boardlist`
+adds no `boardlist` middleware — its `CreateBoard` and board-load actions are persisted by the shared
+effects handler in `feature.board`, which owns the repository.
+
+### 5. Screen
+
+**Rule C — render isolation.** No composable reads a slot wholesale; each binds the narrowest slice.
+Boardlist spine:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/boardlist → BoardListScreen`.
+Board callout:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardScreen.kt → BoardScreen`.
+The screen wraps its store once via `rememberStableStore(store).value`, then binds slices with
+`fieldStateOf` (a whole field, value-equal) or `selectorState` (a derived snapshot). Child composables
+receive finished immutable data plus a remembered callback — the store never reaches a child. Editor
+text and dialog-open flags stay in transient local `remember`, never the store. Rule G lives at the
+*mint* side here: ids/clock for `CreateBoard` come from `LocalIdGenerator` / `LocalClock` at the
+dispatch site.
+
+### 6. Selectors
+
+Pure derivation functions, the home for all list/filter work that Rule C bans from composable bodies:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardSelectors.kt → deriveVisibleCardIds`.
+A selector takes the bound model(s) and returns a value-equal result (a `PersistentList`, a small
+data class) so a `selectorState` recomposes only when the derived value genuinely changes. Keep them
+free of Compose and IO — they are plain testable functions.
+
+### 7. Tests
+
+`commonTest` by default (multiplatform); `jvmTest` only for jvm-only assertions. Cite:
+`examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardReducersTest.kt → BoardReducersTest`.
+Reducers and selectors are pure, so they test directly with no store. Each new slice adds at least a
+reducer test (one case per handled action, plus an unchanged-on-unhandled assertion) and, where it has
+them, selector tests.
+
+## Store wiring
+
+A slice is inert until the composition root registers it. Two edits in `app`:
+
+1. **Declare the slot + route its actions** (order matters: declare every slot up front so
+   `ModelState.get` never misses):
+   `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt → declareAccountModels`.
+   Add a `model(MyModel()) { on<MyAction> { s, a -> myReducer(s, a) } }` block. Register the SAME
+   reducer on each slot that handles a shared action (the routing layer fires each registered handler
+   and leaves other slots untouched). Root-scoped models register in
+   `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AppStore.kt → createAppStore`
+   instead.
+2. **Compose the effect handler** into the per-account pipeline, in fixed order: `activityLogger`,
+   then `undo`, then `effects` (see the `named(...)` pipeline in `createAccountStore`). A new
+   feature's middleware is added to that `devToolsMiddleware(...)` list at the right position.
+
+## Verify loop
+
+Tight inner loop, fast to slow: `compile <target>`, then `commonTest` / `jvmTest`, then `detektAll`,
+then `apiCheck`.
+`apiCheck` matters only when you touch a library module's public API (taskflow itself has none);
+the backing `.api` dumps are listed in `api_files`. iOS-sim targets are host-gated — run them
+locally only on macOS; trust CI otherwise. Full treatment → testing.md.
+
+`detektAll` is the gate that bites first: `explicitApi()` is on, so every new `public` declaration in a
+slice (models, actions, reducer, screen, selectors) needs an explicit visibility modifier **and** a KDoc
+comment — including nested `data class`es and their properties. Formatting auto-corrects; missing KDoc does
+not. Document public symbols as you write them, and never bypass the hook with `--no-verify`.
+
+## Codegen note
+
+KSP `@Reduce` codegen is packaging-agnostic: a `@Reduce`-annotated reducer can live in any
+`feature/*` package and the generated routing wiring follows it — package-by-feature does not change
+how codegen resolves it. Full treatment → the feature / testing guides.
+
+## See also
+
+- [README](./README.md)

--- a/docs/superpowers/plans/2026-06-03-feature-slice-reference-pilot.md
+++ b/docs/superpowers/plans/2026-06-03-feature-slice-reference-pilot.md
@@ -1,0 +1,296 @@
+# Feature-Slice Reference Pilot — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Author the first T1 agent-reference guide (`docs/agent/references/feature-slice.md`) and lock the reference-set conventions (provenance header, `path → symbol` anchor style, template, index) that Phase 0-rest's six remaining guides will replicate.
+
+**Architecture:** Documentation-only sub-project. Three markdown files under a new `docs/agent/references/` tree, derived from the merged package-by-feature `examples/taskflow` (Phase 0a). No source or build changes. The acceptance gate is **citation integrity** — every backtick-wrapped `` `path → symbol` `` anchor resolves (path exists + symbol present) — implemented as a grep sweep that doubles as a manual dry-run of the Phase-3 L4 anchor checker.
+
+**Tech Stack:** Markdown; bash/grep for the citation-integrity gate. Source-of-truth being documented: Kotlin Multiplatform taskflow (`core/ infra/ feature/ app/ ui/`), Rules A–H (`examples/taskflow/ARCHITECTURE.md`), redux-kotlin library `.api` dumps.
+
+---
+
+## Conventions locked by this pilot (every guide inherits these)
+
+- **Anchor form:** all source citations are backtick-wrapped `` `<repo-relative-path> → <Symbol>[, <Symbol>...]` ``. Machine-extractable (a literal ` → ` separator inside backticks). Paths are repo-relative (start `examples/...` or `redux-kotlin.../...`). No line numbers (drift-resilient; the Phase-0a lesson).
+- **Provenance header:** YAML frontmatter, fields `tier, concern, derives_from, api_files, rules, assembles_into, last_verified{commit,date}` (see spec).
+- **Location:** `docs/agent/references/`. Out of `website/` and `.claude/`.
+- **Tone/length:** tight, scannable, citation-dense; ~250–400 lines; prose carries the *why/rule*, anchors carry the *where*.
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `docs/agent/references/_template.md` | Frontmatter + section skeleton + the anchor-form rule, for the other six guides to copy. |
+| `docs/agent/references/README.md` | Index of the seven T1 guides with status; the cross-reference hub. |
+| `docs/agent/references/feature-slice.md` | The worked guide: how to add a feature slice, anchored on `feature.boardlist` with `feature.board` callouts. |
+
+Base revision for `last_verified`: `06214a9` (this worktree's `master` base). Confirm with `git rev-parse --short HEAD` before writing headers; use that value.
+
+---
+
+## Task 1: Lock the template (`_template.md`)
+
+**Files:** Create `docs/agent/references/_template.md`
+
+- [ ] **Step 1: Confirm base commit for provenance headers**
+
+Run: `git rev-parse --short HEAD`
+Expected: `06214a9` (or the current base — use whatever it prints in all `last_verified.commit` fields below).
+
+- [ ] **Step 2: Write `_template.md`**
+
+Create the file with this exact content (it is both the copy-source for future guides AND itself a valid, citation-free skeleton):
+
+````markdown
+---
+tier: T1
+concern: <kebab-concern-name>
+derives_from:
+  # backtick-free here; each entry is `<repo-relative-path> → <Symbol>[, <Symbol>]`
+  - <path> → <Symbol>
+api_files:
+  # committed library .api dumps backing the APIs this guide uses (taskflow itself has none)
+  - <module>/api/<module>.klib.api
+rules: []          # subset of A–H this guide enforces
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: <short-sha>, date: <YYYY-MM-DD> }
+---
+
+# <Title>
+
+> One-line statement of what this guide answers.
+
+## <Section>
+
+Prose explains the *why* and the *rule*. Every source reference uses the anchor form
+`` `path → Symbol` `` — repo-relative path, a literal ` → `, then the symbol(s). Example:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/boardlist → boardListReducer`.
+
+## See also
+
+- Cross-links to sibling guides via [README](./README.md).
+````
+
+- [ ] **Step 3: Verify it has no dangling anchors**
+
+Run: `grep -oE '\`[^\`]+ → [^\`]+\`' docs/agent/references/_template.md || echo "no concrete anchors (template is a skeleton) — OK"`
+Expected: the only ` → ` occurrences are the illustrative one in prose; the template is not citation-checked (it is a skeleton). OK either way.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/agent/references/_template.md
+git commit -m "docs(agent): add reference-set template + anchor conventions"
+```
+
+---
+
+## Task 2: Index (`README.md`)
+
+**Files:** Create `docs/agent/references/README.md`
+
+- [ ] **Step 1: Write `README.md`**
+
+Create with this content:
+
+```markdown
+# redux-kotlin agent reference set (T1)
+
+Single-source, per-concern guides for building with redux-kotlin. `AGENTS.md` (Phase 1) and the
+Claude skill (Phase 2) assemble from these — edit knowledge here, not in copies.
+
+Anchor convention: source references are written `` `repo-relative-path → Symbol` `` and are
+checked to resolve (path exists, symbol present). See [_template.md](./_template.md).
+
+| Concern | Guide | Status |
+|---|---|---|
+| Add a feature slice | [feature-slice.md](./feature-slice.md) | ✅ |
+| Store setup & topology | `store-setup.md` | planned (0-rest) |
+| Compose binding (Rule C) | `compose-binding.md` | planned (0-rest) |
+| Effects + sync (Rule E) | `effects-sync.md` | planned (0-rest) |
+| Testing & the verify loop | `testing.md` | planned (0-rest) |
+| The 6 platform shims | `platform-shims.md` | planned (0-rest) |
+| Modularization | `modularization.md` | planned (0-rest) |
+
+Tiers: **T0** = rules card + module map + commands (assembled into `AGENTS.md`). **T1** = these guides.
+**T2** = [`examples/taskflow/ARCHITECTURE.md`](../../../examples/taskflow/ARCHITECTURE.md) + committed `.api` dumps.
+```
+
+- [ ] **Step 2: Verify the two relative links resolve**
+
+Run:
+```bash
+test -f examples/taskflow/ARCHITECTURE.md && echo "ARCHITECTURE OK"
+# the planned-guide names are intentionally NOT links yet (files don't exist) — confirm none are bracketed links:
+grep -E '\[`?(store-setup|compose-binding|effects-sync|testing|platform-shims|modularization)\.md' docs/agent/references/README.md && echo "ERROR: planned guide is a live link" || echo "planned guides are plain code spans — OK"
+```
+Expected: `ARCHITECTURE OK` and `planned guides are plain code spans — OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/agent/references/README.md
+git commit -m "docs(agent): add reference-set index"
+```
+
+---
+
+## Task 3: Author `feature-slice.md`
+
+**Files:** Create `docs/agent/references/feature-slice.md`
+
+Read the real sources first so every anchor is accurate (do not invent symbols):
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/` →
+`feature/boardlist/*`, `feature/board/{EffectsMiddleware.kt,BoardSelectors.kt,BoardReducers.kt,BoardScreen.kt}`,
+`core/{Action.kt,CardActions.kt,BoardEntities.kt}`, `app/{AccountStore.kt,AppStore.kt}`, and
+`examples/taskflow/ARCHITECTURE.md` (Rules A–H wording). Find one existing reducer test under
+`examples/taskflow/composeApp/src/commonTest/.../feature/board/` to cite for the Tests element.
+
+- [ ] **Step 1: Write the frontmatter**
+
+Use the locked header. Confirmed-resolving `derives_from` anchors (verified against base `06214a9`):
+
+```yaml
+---
+tier: T1
+concern: feature-slice
+derives_from:
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/boardlist → BoardListModel, boardListReducer, BoardListScreen, CreateBoard, BoardSummaryCard
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/EffectsMiddleware.kt → effectsMiddleware
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardSelectors.kt → deriveVisibleCardIds
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/Action.kt → Action, Undoable
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/CardActions.kt → InverseOp
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt → declareAccountModels
+api_files:
+  - redux-kotlin-compose-multimodel/api/redux-kotlin-compose-multimodel.klib.api
+  - redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api
+rules: [C, E, G]
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: 06214a9, date: 2026-06-03 }
+---
+```
+
+- [ ] **Step 2: Write the intro + "where things live"**
+
+A one-paragraph definition of a feature slice in this codebase, then a mini-map. Content (write as prose + a list; anchors backtick-wrapped):
+- Slice = one directory `feature/<name>/` co-locating that feature's slot model, actions, reducer, effect handler, screen, selectors, tests.
+- Shared homes: `core` (domain kernel — entities + `Action`/`Undoable` markers + card/sync-contract actions), `infra` (platform shims, db, data/sync, util), `app` (composition root: `App.kt`, store factories, `app/nav`), `ui` (theme + cross-feature widgets).
+- State the dependency direction: `core ← infra`; `core/infra/ui ← feature/*`; everything `← app`.
+
+- [ ] **Step 3: Write the seven slice elements**
+
+One subsection per element. Each: *what · where it lives · the Rule it honors · a `` `path → Symbol` `` anchor* (boardlist spine; board callout where noted). Required anchors (all verified to resolve):
+
+1. **Models** — `` `…/feature/boardlist → BoardListModel` `` (slot model) + `` `…/core/BoardEntities.kt → BoardSummary` `` (kernel entity).
+2. **Actions** — `` `…/feature/boardlist → CreateBoard, LoadBoardListSucceeded` `` (feature leaves) + `` `…/core/Action.kt → Action, Undoable` `` + `` `…/core/CardActions.kt → InverseOp` ``. Include the **plain-marker rationale**: `Action`/`Undoable` are plain interfaces, not `sealed`, because Kotlin requires sealed subtypes in the same package; package-by-feature spreads leaves across packages. `InverseOp` stays `sealed` (leaves co-located in `core`). Behavior-preserving: every `when(action)` uses `else`.
+3. **Reducer** — `` `…/feature/boardlist → boardListReducer` ``. Note the hand-written `model<M> { on<T> { … } }` routing DSL and **Rule G** (mint ids/timestamps at the dispatch edge, never in the reducer).
+4. **Effects** — **Rule E**: effects originate only in middleware; the feature's handler is composed into `` `…/feature/board/EffectsMiddleware.kt → effectsMiddleware` ``, runs off-main. (boardlist's load is handled there → board callout.)
+5. **Screen** — **Rule C** render isolation; bind narrowest slice via `selectorState`/`fieldState`. `` `…/feature/boardlist → BoardListScreen` `` (+ `` `…/feature/board/BoardScreen.kt → BoardScreen` `` callout).
+6. **Selectors** — pure derivation. `` `…/feature/board/BoardSelectors.kt → deriveVisibleCardIds` `` (board callout; boardlist derives inline).
+7. **Tests** — `commonTest` default, `jvmTest` for jvm-only. Cite `` `…/commonTest/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardReducersTest.kt → BoardReducersTest` ``.
+
+- [ ] **Step 4: Write store wiring + verify loop + codegen note + cross-refs**
+
+- **Store wiring:** register the slot (order matters) and compose the effect handler (order `activityLogger → undo → effects`). Anchors `` `…/app/AccountStore.kt → declareAccountModels` `` and `` `…/app/AppStore.kt → createAppStore` ``.
+- **Verify loop (brief):** `compile <target> → commonTest/jvmTest → detektAll → apiCheck`; iOS-sim host-gating caveat (trust CI). One line: full treatment → `testing.md`.
+- **Codegen note (brief):** KSP `@Reduce` is packaging-agnostic. One line: full treatment → feature/testing guides.
+- **See also:** link `[README](./README.md)` for sibling guides.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/agent/references/feature-slice.md
+git commit -m "docs(agent): add feature-slice T1 reference guide"
+```
+
+---
+
+## Task 4: Citation-integrity gate (acceptance test + L4 dry-run)
+
+**Files:** none committed (verification only; this logic becomes the Phase-3 anchor checker later).
+
+- [ ] **Step 1: Run the anchor sweep**
+
+Extract every backtick-wrapped `path → symbol` anchor from the guide AND the frontmatter `derives_from`, and verify each resolves. Run from the worktree root:
+
+```bash
+GUIDE=docs/agent/references/feature-slice.md
+fail=0
+# 1) inline backtick anchors: `path → Sym, Sym`
+grep -oE '`[^`]+ → [^`]+`' "$GUIDE" | sed 's/^`//; s/`$//' | while IFS= read -r anchor; do
+  path="${anchor%% → *}"; syms="${anchor##* → }"
+  [ -e "$path" ] || { echo "MISS path: $path"; continue; }
+  IFS=',' read -ra arr <<< "$syms"
+  for s in "${arr[@]}"; do s="$(echo "$s" | xargs)"; grep -rq "$s" "$path" || echo "MISS symbol: $s in $path"; done
+done
+# 2) frontmatter derives_from entries: "  - path → Sym, Sym"
+sed -n '/^derives_from:/,/^[a-z_]*:/p' "$GUIDE" | grep -E '→' | sed 's/^[[:space:]]*-[[:space:]]*//' | while IFS= read -r anchor; do
+  path="${anchor%% → *}"; syms="${anchor##* → }"
+  [ -e "$path" ] || { echo "MISS df-path: $path"; continue; }
+  IFS=',' read -ra arr <<< "$syms"
+  for s in "${arr[@]}"; do s="$(echo "$s" | xargs)"; grep -rq "$s" "$path" || echo "MISS df-symbol: $s in $path"; done
+done
+# 3) api_files exist
+sed -n '/^api_files:/,/^[a-z_]*:/p' "$GUIDE" | grep -E '\.api' | sed 's/^[[:space:]]*-[[:space:]]*//' | while IFS= read -r f; do
+  test -f "$f" || echo "MISS api_file: $f"; done
+echo "sweep done"
+```
+Expected: only `sweep done` with **no `MISS` lines**.
+
+- [ ] **Step 2: Fix any MISS**
+
+For each `MISS`, correct the anchor in `feature-slice.md` to the real path/symbol (read the source to find the right one). Re-run Step 1 until clean. Commit fixes if any:
+
+```bash
+git commit -am "docs(agent): fix feature-slice anchors to resolve"
+```
+
+- [ ] **Step 3: Markdown link + base-commit checks**
+
+Run:
+```bash
+# intra-docs links resolve (README/template/guide + ARCHITECTURE/.api relative paths)
+test -f docs/agent/references/README.md && test -f docs/agent/references/_template.md && echo "set present"
+grep -q "$(git rev-parse --short HEAD)" docs/agent/references/feature-slice.md && echo "last_verified matches base" || echo "WARN: bump last_verified.commit"
+```
+Expected: `set present` and `last_verified matches base`.
+
+---
+
+## Task 5: Final read-through + no-collateral check
+
+**Files:** none.
+
+- [ ] **Step 1: Confirm no website/source impact**
+
+Run:
+```bash
+git diff --name-only origin/master...HEAD
+```
+Expected: only files under `docs/agent/references/` and `docs/superpowers/` (spec + plan). No `website/`, no `examples/`, no `*.kt`.
+
+- [ ] **Step 2: Length/tone check**
+
+Run: `wc -l docs/agent/references/feature-slice.md`
+Expected: roughly 250–400 lines. If far outside, tighten (over) or deepen (under) — prose carries why/rule, anchors carry where.
+
+- [ ] **Step 3: Read the guide top-to-bottom** as a cold agent: can you build a new feature slice from it alone, following each anchor? Fix gaps; re-run Task 4 Step 1 if any anchor changed.
+
+---
+
+## Task 6: Open PR
+
+**Files:** none.
+
+- [ ] **Step 1:** `git push -u origin feature-slice-pilot`
+- [ ] **Step 2:** `gh pr create --base master --title "docs(agent): feature-slice reference guide + reference-set conventions (Phase 0-pilot)" --body-file <body>` — body summarizes: Phase 0-pilot, the three files, the locked conventions (provenance header, `path → symbol` anchors, location), the citation-integrity gate result, and that 0-rest replicates the template across the remaining six guides. Link the spec.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** `_template.md` (Task 1) = convention lock; `README.md` (Task 2) = index deliverable; `feature-slice.md` (Task 3) = the guide with all seven elements + wiring/verify/codegen/mini-map; citation-integrity gate (Task 4) = the spec's acceptance gate + L4 dry-run; no-collateral (Task 5) = "out of scope: no source/website changes". All spec deliverables mapped.
+- **No placeholders:** every file's content is given inline; the only intentional "fill from source" is Task 3's Tests anchor (the real test filename) and AppStore's top-level symbol — both with explicit "verify the real symbol" instructions and caught by the Task 4 sweep.
+- **Anchor consistency:** the same backtick `path → Symbol` form is used in `_template.md`, the guide, and the Task 4 extractor (it greps exactly that form). Frontmatter `derives_from` uses the un-backticked `- path → Symbol` YAML form, which the extractor handles separately.
+- **Drift-resilience:** no line numbers anywhere; `last_verified.commit` pins the revision.

--- a/docs/superpowers/specs/2026-06-03-feature-slice-reference-pilot-design.md
+++ b/docs/superpowers/specs/2026-06-03-feature-slice-reference-pilot-design.md
@@ -1,0 +1,83 @@
+# Phase 0-pilot: `feature-slice.md` + Reference-Set Conventions
+
+**Date:** 2026-06-03
+**Phase:** 0-pilot of the redux-kotlin AI integration strategy (the keystone Phase 0, scoped pilot-first).
+**Branch:** `feature-slice-pilot` (off latest `master`), worktree-isolated.
+**Type:** Documentation authoring. Creates agent-facing knowledge under `docs/agent/`; no source/build changes.
+
+## Why
+
+Phase 0 is the keystone of the strategy: a single-source T1 reference set that Phase 1 (`AGENTS.md`) and Phase 2 (Claude skill) assemble from. Authoring all seven guides at once risks propagating format mistakes across seven docs before review. This pilot authors the **first** guide (`feature-slice.md` — the exemplar that the now-merged package-by-feature taskflow refactor, Phase 0a, unblocked) and **locks the conventions** (provenance header, anchor style, tier/dir layout, template) that the remaining six guides (`0-rest`) replicate.
+
+Prereq satisfied: Phase 0a is merged to `master` (`examples/taskflow` is package-by-feature: `core/ infra/ feature/ app/ ui/`).
+
+## Decisions (settled in brainstorming)
+
+- **Location:** canonical refs live at `docs/agent/references/` — neutral, versioned, tool-agnostic; out of `website/` (agent-facing, not end-user) and out of `.claude/` (detekt-excluded + Claude-coupled). Both `AGENTS.md` (Phase 1) and the Claude skill (Phase 2) point INTO this location (single-source).
+- **Exemplar:** `feature.boardlist` as the end-to-end spine (complete slice without board's heavy optimistic/sync/undo machinery); `feature.board` referenced in callouts for advanced concerns.
+- **Anchor style:** `path → symbol` (e.g. `feature/board/BoardReducers.kt → boardReducer`). Resilient to line drift (the churn Phase 0a avoided); the future L4 anchor checker verifies the path exists AND the symbol is present.
+
+## Deliverables
+
+1. **`docs/agent/references/feature-slice.md`** — the worked guide (structure below).
+2. **`docs/agent/references/_template.md`** — provenance-header + section skeleton for the remaining six guides to copy.
+3. **`docs/agent/references/README.md`** — index of the seven planned T1 guides with status (feature-slice ✅; store-setup, compose-binding, effects-sync, testing, platform-shims, modularization — planned), so cross-references resolve and the set is legible.
+
+## Provenance header (the format all guides reuse)
+
+YAML frontmatter at the top of every reference guide. This is exactly what the Phase-3 L4 anchor checker will parse, so the format is a deliverable, not decoration.
+
+```yaml
+---
+tier: T1
+concern: feature-slice
+derives_from:                       # path → symbol (line-drift-resilient)
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/boardlist → BoardListModel, boardListReducer, BoardListScreen, BoardListActions
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/EffectsMiddleware.kt → effectsMiddleware
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/CardActions.kt → InverseOp
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt → declareAccountModels
+api_files:                          # taskflow is convention.control (NO .api); cite the library .api it consumes
+  - redux-kotlin-compose-multimodel/api/redux-kotlin-compose-multimodel.klib.api
+  - redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api
+rules: [C, E, G]
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: 06214a9, date: 2026-06-03 }
+---
+```
+
+Field intent: `derives_from` = the source-of-truth this doc paraphrases (anchor-checked); `api_files` = committed public-API surface backing the APIs used; `rules` = which of Rules A–H the guide enforces; `assembles_into` = downstream consumers (single-source map); `last_verified` = the revision the citations were checked against.
+
+## feature-slice.md structure
+
+A feature author's walkthrough. Opens with a one-paragraph "what is a feature slice here" (package-by-feature; one dir `feature/<name>/`; what lives in the slice vs. the shared `core` kernel / `infra` / `app` / `ui`). Then **the seven elements**, each as: *what it is · where it lives · which Rule it honors · `path → symbol` citation* (boardlist spine; board callout where the boardlist case is too simple):
+
+1. **Models** — feature slot model in `feature/<name>/`; domain entities in the `core` kernel. Cite `feature/boardlist → BoardListModel`, `core/BoardEntities.kt → BoardSummary`.
+2. **Actions** — feature actions in the slice; card-mutation / sync-contract actions + `InverseOp` in `core`; **why `Action`/`Undoable` are plain marker interfaces, not `sealed`** (Kotlin same-package rule; the Phase-0a finding). Cite `feature/boardlist → BoardListActions`, `core/Action.kt`, `core/CardActions.kt → InverseOp`.
+3. **Reducer** — the hand-written `model<M> { on<T> { … } }` routing DSL; pure; **Rule G** (mint ids/timestamps at the dispatch edge, never in the reducer). Cite `feature/boardlist → boardListReducer`.
+4. **Effects** — **Rule E** (effects originate only in middleware, never reducers/UI); the feature's effect handler is **composed into** `effectsMiddleware`, runs off-main. boardlist's load is handled there → board callout. Cite `feature/board/EffectsMiddleware.kt → effectsMiddleware`.
+5. **Screen** — Compose; **Rule C** render isolation (bind the narrowest slice via `selectorState`/`fieldState`, never read a whole model wholesale). Cite `feature/boardlist → BoardListScreen`; board callout for richer binding.
+6. **Selectors** — pure derivation functions for rendering. Cite `feature/board/BoardSelectors.kt` (board callout; boardlist's derivation is inline).
+7. **Tests** — `commonTest` is the default home; `jvmTest` for jvm-only concerns. Cite a boardlist/board reducer test.
+
+Then:
+- **Store wiring** — register the feature's model slot (declaration order matters) and compose its effect handler (middleware order `activityLogger → undo → effects` matters). Cite `app/AccountStore.kt → declareAccountModels`, `app/AppStore.kt`.
+- **Verify loop** (L3 fold-in, brief) — `compile <target> → commonTest/jvmTest → detektAll → apiCheck`; how to read a failure; iOS-simulator host-gating caveat (trust CI). Full treatment deferred to the `testing` guide.
+- **Codegen note** (L2 fold-in, brief) — KSP `@Reduce` is packaging-agnostic (top-level annotated handlers discovered regardless of package). Full treatment deferred to feature/testing guides.
+- **"Where things live"** mini-map — `core` (kernel) · `infra` · `feature/<name>` · `app` (composition root) · `ui` — and forward cross-references to the other six guides (via `README.md`).
+
+Tone/length budget (a convention the template encodes): tight, scannable, citation-dense; target ~250–400 lines; prose explains the *why/rule*, citations carry the *where*.
+
+## Acceptance gate
+
+Docs-only sub-project — no Kotlin compile/test. The gate is **citation integrity**: every `path → symbol` in `feature-slice.md` (and the header `derives_from`) is verified to resolve — the cited path exists under the worktree AND the symbol appears in that file. Implemented as a grep sweep over the citation list; this is a manual dry-run of the Phase-3 anchor checker and validates the chosen anchor style end-to-end. Also confirm `api_files` paths exist.
+
+Secondary checks: no broken intra-`docs/agent/` markdown links (README ↔ guide ↔ template); `last_verified.commit` matches the worktree base.
+
+## Out of scope
+
+- The other six T1 guides, the API-map index, `AGENTS.md`, the Claude skill, the automated L4 anchor checker / CI (all later sub-projects).
+- Any change to `examples/taskflow` source or to `website/`.
+
+## Next
+
+After approval → writing-plans for the authoring steps, then execute with the citation-integrity gate, then PR. On completion, `0-rest` replicates the locked template across the remaining six guides.


### PR DESCRIPTION
## What

**Phase 0-pilot** of the redux-kotlin AI-integration strategy: authors the first T1 agent-reference guide and **locks the reference-set conventions** the remaining six guides (Phase 0-rest) will replicate.

Adds `docs/agent/references/`:
- **`feature-slice.md`** — "how to add a feature slice" to the package-by-feature taskflow, worked on `feature.boardlist` with `feature.board` callouts. Covers the seven slice elements (models · actions · reducer · effects · screen · selectors · tests), the plain-`Action`-marker rationale, Rules C/E/G, store wiring, and brief verify-loop + codegen notes.
- **`_template.md`** — provenance-header + section skeleton for the other guides to copy.
- **`README.md`** — index of the seven planned T1 guides.

## Conventions locked (inherited by all future guides)

- **Location:** `docs/agent/references/` — single-source; `AGENTS.md` (Phase 1) and the Claude skill (Phase 2) will assemble from here, not copy.
- **Provenance header:** YAML frontmatter (`tier · concern · derives_from · api_files · rules · assembles_into · last_verified`).
- **Anchor style:** backtick-wrapped `` `repo-relative-path → Symbol` `` — **no line numbers** (drift-resilient, the lesson from the Phase-0a refactor). The future L4 anchor checker parses exactly this form.

## Verification

- **Citation-integrity gate:** every `path → symbol` anchor (inline + frontmatter `derives_from`) verified to resolve — path exists *and* symbol present — plus `api_files` exist. **All anchors resolve ✓.** This is a manual dry-run of the Phase-3 L4 anchor checker and validates the chosen anchor style end-to-end.
- Spec+quality review: APPROVE (spec-complete, accurate, faithful to `ARCHITECTURE.md` Rules C/E/G; one real anchor bug caught + fixed — `BoardSummary` lives in `core/AccountEntities.kt`).
- Docs-only: no `.kt`, `website/`, or `examples/` changes.

## Next

`0-rest` replicates `_template.md` across the remaining six guides (store-setup, compose-binding, effects-sync, testing, platform-shims, modularization) + the API-map index.

Design spec: `docs/superpowers/specs/2026-06-03-feature-slice-reference-pilot-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
