### PR TITLE
docs(agent): AGENTS.md (T0) + API-map index (Phase 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md
+
+Token-tight index for agents working in redux-kotlin. Read this first; it points
+to depth, it does not inline it.
+
+## What redux-kotlin is
+
+A Kotlin Multiplatform port of the Redux contract: a deliberately minimal core
+(`redux-kotlin`) holding the `Store<S>` contract, plus opt-in companion modules
+that layer thread-safety, concurrency, granular subscriptions, multi-store
+registries, a heterogeneous model bag, and Compose bindings — all sharing the
+same single `Store<S>` contract. Take the core, add only the companions you need.
+
+## Module map
+
+The nine published core modules (each "use for X"):
+
+- `redux-kotlin` — core contract: `Store`/`TypedStore`, `Reducer`, `Middleware`, `createStore`, `applyMiddleware`, `combineReducers`, `compose`.
+- `redux-kotlin-threadsafe` — `createThreadSafeStore` (atomicfu-locked store wrapper).
+- `redux-kotlin-concurrent` — `createConcurrentStore` (lock-free reads + reentrant-lock-serialized writes).
+- `redux-kotlin-granular` — `subscribeTo` / `subscribeFields` field-level subscriptions.
+- `redux-kotlin-registry` — `StoreRegistry<K,S>` / `TypedStoreRegistry` keyed multi-store container.
+- `redux-kotlin-multimodel` — `ModelState` typesafe heterogeneous model bag.
+- `redux-kotlin-multimodel-granular` — granular subscriptions for `ModelState`.
+- `redux-kotlin-compose` — Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`).
+- `redux-kotlin-compose-multimodel` — Compose bindings for `ModelState`.
+
+More modules exist (routing/bundle/bom/devtools/codegen) → see `docs/agent/api-map.md`.
+
+`examples/` = sample apps; `examples/taskflow` is the canonical app.
+
+## Build / test / lint
+
+- `./gradlew build` — full build (compile + test + detekt + `apiCheck`).
+- `./gradlew detektAll` — lint the whole tree.
+- `./gradlew apiCheck` — verify public API matches committed dumps (`apiDump` to regenerate).
+- `./gradlew :<module>:jvmTest` — one module's JVM tests.
+
+Hard rules: never `--no-verify` (git hooks run `detektAll`); `explicitApi()` is
+on, so every `public` declaration needs an explicit modifier AND a KDoc — KDoc
+does not auto-correct. Full gate detail → `CLAUDE.md`.
+
+## Design rules
+
+(There are no named Rules A or B.) Faithful one-liners from
+`examples/taskflow/ARCHITECTURE.md` §17:
+
+- **Rule C — render isolation.** No composable reads a slot wholesale; each leaf binds the narrowest slice via `selectorState`/`fieldStateOf`; list derivation lives in pure functions/reducers.
+- **Rule D — identity split.** A profile edit fans to the root account directory, the per-account model, and the session model so identity is never duplicated inconsistently.
+- **Rule E — off-main effects.** All repository/sync work runs off-main; dispatch marshals notifications back to main via `NotificationContext` (no explicit main hop in effects).
+- **Rule F — delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
+- **Rule G — mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
+- **Rule H — single inset point.** Window insets are applied once at the shell root.
+
+Full text → `examples/taskflow/ARCHITECTURE.md`.
+
+## Where things live
+
+Recommended app layout is package-by-feature: a `feature/<name>/` slice (model,
+actions, reducer, effects, screen, selectors, tests) plus shared `core` (domain
+kernel — no Compose/IO), `infra` (platform shims, db, data/sync), `app`
+(composition root: store factories, nav), and `ui` (theme, locals, widgets).
+Canonical example: `examples/taskflow`.
+
+## Deeper knowledge
+
+- **T1** per-concern guides → `docs/agent/references/` (`feature-slice.md` is live; the other six are planned — see `docs/agent/references/README.md`).
+- **T2** → `examples/taskflow/ARCHITECTURE.md` (full architecture + design rules) and `docs/agent/api-map.md` (module → `.api` index).

--- a/docs/agent/api-map.md
+++ b/docs/agent/api-map.md
@@ -1,0 +1,38 @@
+---
+tier: T2
+concern: api-map
+derives_from:
+  - "*/api/*.klib.api → committed public API surface"
+api_files: []
+rules: []
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: d388b46, date: 2026-06-03 }
+---
+
+# API map
+
+Read the committed `.api` dump for a module's public surface; regenerate with `./gradlew apiDump`.
+
+| Module | `.api` path | What's in it |
+|---|---|---|
+| `:redux-kotlin` | `redux-kotlin/api/redux-kotlin.klib.api` | Core contract: `Store`/`TypedStore`, `Reducer`, `Middleware`, `createStore`, `applyMiddleware`, `combineReducers`, `compose`. |
+| `:redux-kotlin-threadsafe` | `redux-kotlin-threadsafe/api/redux-kotlin-threadsafe.klib.api` | `createThreadSafeStore` (atomicfu-locked store wrapper). |
+| `:redux-kotlin-concurrent` | `redux-kotlin-concurrent/api/redux-kotlin-concurrent.klib.api` | `createConcurrentStore` (lock-free reads + reentrant-lock-serialized writes; CallerSerialized strategy). |
+| `:redux-kotlin-granular` | `redux-kotlin-granular/api/redux-kotlin-granular.klib.api` | `subscribeTo` / `subscribeFields` field-level subscriptions. |
+| `:redux-kotlin-registry` | `redux-kotlin-registry/api/redux-kotlin-registry.klib.api` | `StoreRegistry<K,S>` / `TypedStoreRegistry` keyed multi-store container. |
+| `:redux-kotlin-multimodel` | `redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api` | `ModelState` typesafe heterogeneous model bag. |
+| `:redux-kotlin-multimodel-granular` | `redux-kotlin-multimodel-granular/api/redux-kotlin-multimodel-granular.klib.api` | Granular subscriptions for `ModelState`. |
+| `:redux-kotlin-compose` | `redux-kotlin-compose/api/redux-kotlin-compose.klib.api` | Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`). |
+| `:redux-kotlin-compose-multimodel` | `redux-kotlin-compose-multimodel/api/redux-kotlin-compose-multimodel.klib.api` | Compose bindings for `ModelState`. |
+| `:redux-kotlin-routing` | `redux-kotlin-routing/api/redux-kotlin-routing.klib.api` | Routing DSL + `@Reduce`/`@ReduxInitial` annotations and `ReduxModule` contribution surface. |
+| `:redux-kotlin-routing-codegen-sample` | `redux-kotlin-routing-codegen-sample/api/redux-kotlin-routing-codegen-sample.klib.api` | Sample showing KSP-generated routing wiring (`ReduxModule` output). |
+| `:redux-kotlin-bundle` | `redux-kotlin-bundle/api/redux-kotlin-bundle.klib.api` | One-call assembly of a concurrent `ModelState` store + registry + routing (`createConcurrentModelStore`, `getOrCreateConcurrentModelStore`). |
+| `:redux-kotlin-bundle-compose` | `redux-kotlin-bundle-compose/api/redux-kotlin-bundle-compose.klib.api` | Compose-side bundle conveniences (no published declarations). |
+| `:redux-kotlin-devtools-core` | `redux-kotlin-devtools-core/api/redux-kotlin-devtools-core.klib.api` | DevTools core model: state/action diffing (`DiffOp`, `DiffEntry`). |
+| `:redux-kotlin-devtools-bridge` | `redux-kotlin-devtools-bridge/api/redux-kotlin-devtools-bridge.klib.api` | Wire protocol between app and DevTools UI (`BridgeMessage`). |
+| `:redux-kotlin-devtools-remote` | `redux-kotlin-devtools-remote/api/redux-kotlin-devtools-remote.klib.api` | Remote DevTools transport config (`RemoteConfig`). |
+| `:redux-kotlin-devtools-inapp` | `redux-kotlin-devtools-inapp/api/redux-kotlin-devtools-inapp.klib.api` | In-app DevTools overlay: triggers/config (`DevToolsTrigger`, `InAppConfig`, `DevToolsTab`). |
+| `:redux-kotlin-devtools-inapp-noop` | `redux-kotlin-devtools-inapp-noop/api/redux-kotlin-devtools-inapp-noop.klib.api` | No-op in-app DevTools (same config types, stripped for release builds). |
+| `:redux-kotlin-devtools-ui` | `redux-kotlin-devtools-ui/api/redux-kotlin-devtools-ui.klib.api` | Compose DevTools UI panels (tabs, theme). |
+
+`examples/*` are `convention.control` (not published, no `.api`).

--- a/docs/superpowers/plans/2026-06-03-agents-md-and-api-map-phase1.md
+++ b/docs/superpowers/plans/2026-06-03-agents-md-and-api-map-phase1.md
@@ -1,0 +1,84 @@
+# Phase 1 — AGENTS.md + API-map Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Assemble the T0 layer — `AGENTS.md` (repo-root, token-tight agent index) + `docs/agent/api-map.md` (module → `.api` index) — from existing canon, single-source (point, don't duplicate).
+
+**Architecture:** Docs-only. Two files. Content derived from `CLAUDE.md` (modules/commands), `examples/taskflow/ARCHITECTURE.md` §17 (Rules C–H), `docs/agent/references/` (T1 pointers), and `*/api/*.klib.api` (the 19 committed dumps). Gate = reference integrity (every cited path/module/command resolves).
+
+**Tech Stack:** Markdown; bash/grep for the gate.
+
+---
+
+## Task 1: `docs/agent/api-map.md`
+
+**Files:** Create `docs/agent/api-map.md`
+
+- [ ] **Step 1:** Enumerate the committed dumps: `ls */api/*.klib.api` (expect 19). 
+- [ ] **Step 2:** Write `docs/agent/api-map.md` with provenance frontmatter (`tier: T2`, `concern: api-map`, `derives_from:` the dump glob, `rules: []`, `assembles_into: [AGENTS.md, claude-skill]`, `last_verified: {commit: <git rev-parse --short HEAD>, date: 2026-06-03}`) and a markdown table with one row per dump: **module** (the `:name` from `settings.gradle.kts`) · **`.api` path** (e.g. `redux-kotlin/api/redux-kotlin.klib.api`) · **what's in it** (one line; for the 9 core modules use CLAUDE.md's descriptions; for routing/bundle/bom/devtools/codegen give a terse one-liner inferred from the module name + a peek at the dump). Add a note: `examples/*` are `convention.control` (no `.api`); read source/`ARCHITECTURE.md` for those.
+- [ ] **Step 3:** Verify every path in the table exists: `for f in $(grep -oE '[a-z0-9-]+/api/[a-z0-9-]+\.klib\.api' docs/agent/api-map.md); do test -f "$f" || echo "MISS $f"; done; echo done` → no MISS.
+- [ ] **Step 4:** Commit: `git commit -am "docs(agent): add API-map index (T2)"`
+
+---
+
+## Task 2: `AGENTS.md` (repo root)
+
+**Files:** Create `AGENTS.md`
+
+Read first: `CLAUDE.md`, `examples/taskflow/ARCHITECTURE.md` §17 (lines ~866–886, Rules **C–H** — there are no named A/B; do not invent them), `docs/agent/references/README.md`.
+
+- [ ] **Step 1:** Write `AGENTS.md` (repo root), token-tight (~120–180 lines), these sections:
+  1. **One-paragraph "what redux-kotlin is"** — KMP port of the Redux contract; minimal core + opt-in companion modules on one `Store<S>` contract.
+  2. **Module map** — the 9 core published modules with the one-line "use this for X" from `CLAUDE.md`; one line noting additional modules (routing, bundle, bom, devtools, codegen) exist — see `docs/agent/api-map.md`. `examples/` = samples (taskflow is the canonical app).
+  3. **Build / test / lint** — the four gate commands (`./gradlew build`, `./gradlew detektAll`, `./gradlew apiCheck`, `./gradlew :<module>:jvmTest`) each one line; pointer: "full gate detail → `CLAUDE.md`". State the hard rule: never `--no-verify`; `explicitApi()` requires KDoc on every public decl.
+  4. **Design rules** — Rules **C–H** as one line each, verbatim-faithful to ARCHITECTURE §17 (C render isolation · D identity split · E off-main effects · F delta-only status · G mint-at-edge · H single inset point). Pointer: full text → `examples/taskflow/ARCHITECTURE.md` §17.
+  5. **Where things live** — the recommended app layout is **package-by-feature** (strategy §5.1): `feature/<name>/` slice + shared `core` (kernel) · `infra` · `app` · `ui`; the canonical example is `examples/taskflow`. One line.
+  6. **Deeper knowledge (T1/T2)** — point into `docs/agent/references/` (list the 7 guides via the README, noting feature-slice.md is live, others planned) and T2 (`examples/taskflow/ARCHITECTURE.md`, `docs/agent/api-map.md`).
+  Use plain `` `path` `` references (backtick-wrapped, no line numbers). Keep prose to the minimum an index needs.
+- [ ] **Step 2:** Length check: `wc -l AGENTS.md` ≤ ~180. If over, cut prose (it's an index).
+- [ ] **Step 3:** Commit: `git commit -am "docs(agent): add AGENTS.md T0 index"`
+
+---
+
+## Task 3: Reference-integrity gate (acceptance)
+
+**Files:** none.
+
+- [ ] **Step 1:** Run from worktree root:
+```bash
+bash -c '
+miss=0
+# all backtick `path` and `path/api/*.klib.api` refs in both files exist
+for F in AGENTS.md docs/agent/api-map.md; do
+  for p in $(grep -oE "[A-Za-z0-9_./-]+/[A-Za-z0-9_./-]+\.(md|api|kts)" "$F" | sort -u); do
+    [ -e "$p" ] || { echo "MISS path ($F): $p"; miss=1; }
+  done
+done
+# referenced docs exist
+for p in docs/agent/references/feature-slice.md docs/agent/references/README.md examples/taskflow/ARCHITECTURE.md CLAUDE.md docs/agent/api-map.md; do
+  test -e "$p" || { echo "MISS doc: $p"; miss=1; }
+done
+# the 9 core module names resolve in settings.gradle.kts
+for m in redux-kotlin redux-kotlin-threadsafe redux-kotlin-concurrent redux-kotlin-granular redux-kotlin-registry redux-kotlin-multimodel redux-kotlin-multimodel-granular redux-kotlin-compose redux-kotlin-compose-multimodel; do
+  grep -q "\":$m\"" settings.gradle.kts || { echo "MISS module: $m"; miss=1; }
+done
+[ "$miss" = 0 ] && echo "REFS RESOLVE OK" || echo "REFS FAILED"
+'
+```
+Expected: `REFS RESOLVE OK`. Fix any MISS (correct the path/name in the doc), re-run, commit fixes.
+- [ ] **Step 2:** No-collateral: `git diff --name-only origin/master...HEAD` shows only `AGENTS.md`, `docs/agent/`, `docs/superpowers/`. No `.kt`/`website/`/`examples/`.
+
+---
+
+## Task 4: PR
+
+- [ ] **Step 1:** `git push -u origin agents-md-phase1`
+- [ ] **Step 2:** `gh pr create --base feature-slice-pilot --head agents-md-phase1` (stacked on the pilot) — title `docs(agent): AGENTS.md (T0) + API-map index (Phase 1)`; body: assembled-from-canon, single-source (points into refs/CLAUDE.md), the reference-integrity gate result, merge-after-#313 note, link the spec.
+
+---
+
+## Self-review notes
+- Spec coverage: api-map (T1), AGENTS.md (T2), gate (T3), PR (T4). All spec deliverables mapped.
+- Rules: C–H only (no A/B) — plan instructs not to fabricate.
+- Module scope: api-map covers all 19 dumps; AGENTS module-map highlights the core 9 + pointer.
+- No duplication of CLAUDE.md — AGENTS.md references it.

--- a/docs/superpowers/specs/2026-06-03-agents-md-and-api-map-phase1-design.md
+++ b/docs/superpowers/specs/2026-06-03-agents-md-and-api-map-phase1-design.md
@@ -1,0 +1,47 @@
+# Phase 1: `AGENTS.md` (T0) + API-map index
+
+**Date:** 2026-06-03
+**Phase:** 1 of the redux-kotlin AI integration strategy.
+**Branch:** `agents-md-phase1` (stacked on `feature-slice-pilot`).
+**Type:** Documentation assembly. No source/build changes.
+
+## Why
+
+Phase 0 established the single-source reference set under `docs/agent/references/`. Phase 1 produces the **T0 layer** — the always-in-context, token-tight index every agent/tool (Cursor, Copilot, Codex, Claude) reads first — by **assembling** it from existing canon, plus an **API-map index** so an agent reads the committed public-API surface (`.api`) instead of source. Single-source discipline: AGENTS.md *points into* `docs/agent/references/` and `CLAUDE.md`; it does not duplicate their content.
+
+Decisions (recommended, locked for unattended execution):
+- **AGENTS.md** lives at repo root (tool-agnostic convention).
+- **`CLAUDE.md` stays as-is** (maintainer/build-gate doc). AGENTS.md cross-links it for build/lint/publish detail rather than merging (avoids disrupting a working doc; resolves strategy open-question 6 minimally).
+- **API map** at `docs/agent/api-map.md` — table of the 9 published modules → `.api` dump path + one-line surface summary.
+
+## Deliverables
+
+1. **`AGENTS.md`** (repo root) — T0 index, token-tight (~120–180 lines). Sections:
+   - **What redux-kotlin is** — 1 paragraph.
+   - **Module map** — which module for which job (the 9 published modules + the `examples/` samples), derived from `CLAUDE.md`.
+   - **Build / test / lint commands** — the gate one-liners (`./gradlew build`, `detektAll`, `apiCheck`, target-scoped test), pointer to `CLAUDE.md` for detail.
+   - **Design rules** — one line each. ARCHITECTURE.md §17 names **Rules C–H** only (the strategy's "A–H" is loose shorthand; there are no named Rules A/B). Use the canonical C–H statements verbatim — do **not** fabricate A/B.
+   - **Where things live** — the package-by-feature layout (`core/ infra/ feature/ app/ ui/`) as the recommended app organization (§5.1), citing taskflow.
+   - **Deeper knowledge** — pointers into T1 (`docs/agent/references/` — list the 7 guides + status) and T2 (`examples/taskflow/ARCHITECTURE.md`, `docs/agent/api-map.md`).
+2. **`docs/agent/api-map.md`** — provenance-headed (same YAML convention as the ref set, `tier: T2`); a table: module → `api/<module>.klib.api` → one-line "what's in it". Covers **every published module that has a committed `.api` dump** (enumerate via `ls */api/*.klib.api` — `settings.gradle.kts` lists ~20 modules incl. routing/bundle/bom/devtools, more than CLAUDE.md's "core 9"; map exactly those with a dump). Note `examples/*` are `convention.control` (no `.api`).
+
+## Constraints
+
+- **Anchor convention** (inherited from Phase 0): file references use backtick-wrapped `` `path → Symbol` `` or plain `` `path` `` for whole-file/dir; no line numbers. Every cited path must exist (Phase-3 anchor checker will enforce; Phase 1 self-checks).
+- AGENTS.md must be **token-tight** — it is always in context. Prose minimal; it is an index, not a manual. Defer depth to T1/T2 via pointers.
+- Rules A–H wording must match `ARCHITECTURE.md` (don't invent new phrasings).
+- No duplication of `CLAUDE.md` content — reference it.
+
+## Acceptance gate
+
+Docs-only. Gate = **reference integrity**: every path referenced in `AGENTS.md` and `api-map.md` exists (the 9 `.api` files, `docs/agent/references/*`, `examples/taskflow/ARCHITECTURE.md`, `CLAUDE.md`); the 9 module names match `settings.gradle.kts`; cited gradle tasks are real. Implemented as a grep/test sweep (extends the Phase-0 sweep; a dry-run of the Phase-3 checker). Plus: `AGENTS.md` ≤ ~180 lines (token-tight); no `.kt`/`website/`/`examples/` changes.
+
+## Out of scope
+
+- The Claude skill (Phase 2), L4 CI (Phase 3), sync agent (Phase 4).
+- Authoring the remaining six T1 guides (Phase 0-rest) — AGENTS.md lists them with status, pointing at the canonical location as they land.
+- Any merge/rewrite of `CLAUDE.md`.
+
+## Next
+
+Phase 2 (Claude skill) consumes this T0 + the ref set.


### PR DESCRIPTION
## What
**Phase 1** of the AI-integration strategy: the **T0 layer**, assembled from existing canon (single-source — points into the refs/`CLAUDE.md`, no duplication).
- **`AGENTS.md`** (repo root) — token-tight (68 lines) agent index every tool reads first: what redux-kotlin is · module map · build/test/lint gate · **Design Rules C–H** (faithful to `ARCHITECTURE.md` §17; there are no named Rules A/B) · package-by-feature "where things live" · pointers into T1 (`docs/agent/references/`) and T2.
- **`docs/agent/api-map.md`** (T2) — maps every published module with a committed `.api` dump (19) → its `.api` path → one-line surface, so agents read the public surface, not source.

## Verification
- Reference-integrity gate: all 19 `.api` paths exist, referenced docs present, 9 core module names resolve in `settings.gradle.kts`. **REFS OK.**
- Spec+quality review: APPROVE — Rules C–H accurate, no fabricated A/B, no `CLAUDE.md` duplication, correct provenance.
- Docs-only (no `.kt`/`website/`/`examples/`).

## Stacking
Stacked on `feature-slice-pilot` (#313) — **merge #313 first**. Base will retarget to `master` once #313 lands.

Spec: `docs/superpowers/specs/2026-06-03-agents-md-and-api-map-phase1-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
