### PR TITLE
ci(agent): knowledge-sync drift-review agent (Phase 4)

### DIFF
--- a/.claude/skills/redux-kotlin/SKILL.md
+++ b/.claude/skills/redux-kotlin/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: redux-kotlin
+description: Use when building or reviewing redux-kotlin (Kotlin Multiplatform Redux) code — adding/editing a feature slice, wiring the store, Compose state binding, effects/sync middleware, testing, the platform expect/actual shims, or modularization. Enforces the project's render-isolation / off-main-effects / mint-at-edge rules.
+---
+
+# redux-kotlin
+
+Kotlin Multiplatform port of the Redux contract: a minimal core (`redux-kotlin`) plus opt-in
+companion modules on one `Store<S>` contract. Recommended app organization is **package-by-feature**
+(`feature/<name>/` slice + shared `core` · `infra` · `app` · `ui`); the canonical example is `examples/taskflow`.
+
+## Always-apply rules (full text → `../../../examples/taskflow/ARCHITECTURE.md` §17)
+
+- **Rule C — Render isolation.** No composable reads a model wholesale; bind the narrowest slice via `selectorState`/`fieldStateOf`, wrapped in `key(...)`. Derivation lives in pure functions/reducers.
+- **Rule D — Identity split.** A profile edit fans to the root account directory, per-account `CollaboratorsModel`, and `SessionModel` — never duplicate identity inconsistently.
+- **Rule E — Off-main effects.** Effects originate only in middleware and run off-main; dispatch marshals back to main via `NotificationContext`. Per-feature handlers compose into one `effectsMiddleware`.
+- **Rule F — Delta-only status.** Emit status only on a real change.
+- **Rule G — Mint at the edge.** Ids/timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
+- **Rule H — Single inset point.** Window insets applied once at the shell root.
+
+## Decision routing
+
+| If you are… | Read |
+|---|---|
+| Adding or editing a **feature** | [`feature-slice.md`](../../../docs/agent/references/feature-slice.md) |
+| Setting up the **store / topology** | `../../../docs/agent/references/store-setup.md` *(planned — see README)* |
+| **Compose** state binding (Rule C) | `../../../docs/agent/references/compose-binding.md` *(planned)* |
+| **Effects + sync** (Rule E) | `../../../docs/agent/references/effects-sync.md` *(planned)* |
+| **Testing** + the verify loop | `../../../docs/agent/references/testing.md` *(planned)* |
+| The 6 **platform shims** | `../../../docs/agent/references/platform-shims.md` *(planned)* |
+| **Modularization** | `../../../docs/agent/references/modularization.md` *(planned)* |
+
+## Pointers
+
+- T0 index (modules, commands, layout): [`AGENTS.md`](../../../AGENTS.md)
+- Public API surface per module: [`api-map.md`](../../../docs/agent/api-map.md)
+- Architecture deep-dive: [`ARCHITECTURE.md`](../../../examples/taskflow/ARCHITECTURE.md)
+- Reference index: [`references/README.md`](../../../docs/agent/references/README.md)
+
+Build/lint gate (never `--no-verify`; `explicitApi()` needs KDoc on every public decl): `./gradlew build`, `./gradlew detektAll`, `./gradlew apiCheck`. Detail → `../../../CLAUDE.md`.

--- a/.github/workflows/agent-knowledge.yml
+++ b/.github/workflows/agent-knowledge.yml
@@ -1,0 +1,33 @@
+name: Agent knowledge
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, labeled]
+permissions:
+  contents: read
+concurrency:
+  cancel-in-progress: true
+  group: agent-knowledge-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+jobs:
+  anchor-check:
+    name: Anchor check (refs resolve)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check agent reference anchors
+        run: bash scripts/check-agent-refs.sh
+  api-tripwire:
+    name: API-change tripwire
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Tripwire on committed .api changes
+        env:
+          API_REVIEW_OK: ${{ contains(github.event.pull_request.labels.*.name, 'api-reviewed') && '1' || '0' }}
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1 || true
+          bash scripts/check-api-tripwire.sh "origin/${{ github.base_ref }}"

--- a/.github/workflows/knowledge-sync.yml
+++ b/.github/workflows/knowledge-sync.yml
@@ -1,0 +1,53 @@
+name: Knowledge sync
+on:
+  pull_request:
+    paths:
+      - 'redux-kotlin*/**/src/**'
+      - '**/api/*.api'
+      - 'examples/taskflow/**'
+  workflow_dispatch:
+permissions:
+  contents: read
+  pull-requests: write
+concurrency:
+  cancel-in-progress: true
+  group: knowledge-sync-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+jobs:
+  sync:
+    name: Knowledge drift review
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Gate on API key presence
+        id: gate
+        run: echo "enabled=${{ secrets.ANTHROPIC_API_KEY != '' }}" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Claude knowledge-drift review
+        if: steps.gate.outputs.enabled == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are the redux-kotlin knowledge-sync reviewer. This PR changed library source, a committed
+            `.api` dump, and/or `examples/taskflow` (the canonical reference app).
+
+            The agent knowledge lives under `docs/agent/`:
+            - `docs/agent/references/*.md` — T1 per-concern guides; each has a YAML `derives_from:` header
+              listing the `path → Symbol` sources it paraphrases.
+            - `AGENTS.md` — the T0 index (modules, commands, Rules C–H, layout).
+            - `docs/agent/api-map.md` — module → `.api` map.
+
+            Do this:
+            1. Read the PR diff (changed files).
+            2. For each knowledge doc, read its `derives_from` provenance; a doc is IN SCOPE if any changed
+               file matches one of its `derives_from` paths (or it documents a changed module / Rule).
+            3. For each in-scope doc, judge whether the change makes its prose, patterns, citations, or rule
+               statements stale — focus on SEMANTIC drift (deterministic anchor/API checks run separately).
+            4. Post ONE concise PR comment: a bullet per doc needing an update with the specific reason, or
+               exactly "No knowledge drift detected." Do not modify files. Do not restate the rules.
+            Keep it short and high-signal. Cite `path → Symbol` for any claim.

--- a/.gitignore
+++ b/.gitignore
@@ -97,7 +97,8 @@ website/translated_docs/
 website/build/
 website/node_modules/
 website/.docusaurus/
-.claude/
+.claude/*
+!.claude/skills/
 .vercel
 .env*.local
 .superpowers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md
+
+Token-tight index for agents working in redux-kotlin. Read this first; it points
+to depth, it does not inline it.
+
+## What redux-kotlin is
+
+A Kotlin Multiplatform port of the Redux contract: a deliberately minimal core
+(`redux-kotlin`) holding the `Store<S>` contract, plus opt-in companion modules
+that layer thread-safety, concurrency, granular subscriptions, multi-store
+registries, a heterogeneous model bag, and Compose bindings — all sharing the
+same single `Store<S>` contract. Take the core, add only the companions you need.
+
+## Module map
+
+The nine published core modules (each "use for X"):
+
+- `redux-kotlin` — core contract: `Store`/`TypedStore`, `Reducer`, `Middleware`, `createStore`, `applyMiddleware`, `combineReducers`, `compose`.
+- `redux-kotlin-threadsafe` — `createThreadSafeStore` (atomicfu-locked store wrapper).
+- `redux-kotlin-concurrent` — `createConcurrentStore` (lock-free reads + reentrant-lock-serialized writes).
+- `redux-kotlin-granular` — `subscribeTo` / `subscribeFields` field-level subscriptions.
+- `redux-kotlin-registry` — `StoreRegistry<K,S>` / `TypedStoreRegistry` keyed multi-store container.
+- `redux-kotlin-multimodel` — `ModelState` typesafe heterogeneous model bag.
+- `redux-kotlin-multimodel-granular` — granular subscriptions for `ModelState`.
+- `redux-kotlin-compose` — Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`).
+- `redux-kotlin-compose-multimodel` — Compose bindings for `ModelState`.
+
+More modules exist (routing/bundle/bom/devtools/codegen) → see `docs/agent/api-map.md`.
+
+`examples/` = sample apps; `examples/taskflow` is the canonical app.
+
+## Build / test / lint
+
+- `./gradlew build` — full build (compile + test + detekt + `apiCheck`).
+- `./gradlew detektAll` — lint the whole tree.
+- `./gradlew apiCheck` — verify public API matches committed dumps (`apiDump` to regenerate).
+- `./gradlew :<module>:jvmTest` — one module's JVM tests.
+
+Hard rules: never `--no-verify` (git hooks run `detektAll`); `explicitApi()` is
+on, so every `public` declaration needs an explicit modifier AND a KDoc — KDoc
+does not auto-correct. Full gate detail → `CLAUDE.md`.
+
+## Design rules
+
+(There are no named Rules A or B.) Faithful one-liners from
+`examples/taskflow/ARCHITECTURE.md` §17:
+
+- **Rule C — render isolation.** No composable reads a slot wholesale; each leaf binds the narrowest slice via `selectorState`/`fieldStateOf`; list derivation lives in pure functions/reducers.
+- **Rule D — identity split.** A profile edit fans to the root account directory, the per-account model, and the session model so identity is never duplicated inconsistently.
+- **Rule E — off-main effects.** All repository/sync work runs off-main; dispatch marshals notifications back to main via `NotificationContext` (no explicit main hop in effects).
+- **Rule F — delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
+- **Rule G — mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
+- **Rule H — single inset point.** Window insets are applied once at the shell root.
+
+Full text → `examples/taskflow/ARCHITECTURE.md`.
+
+## Where things live
+
+Recommended app layout is package-by-feature: a `feature/<name>/` slice (model,
+actions, reducer, effects, screen, selectors, tests) plus shared `core` (domain
+kernel — no Compose/IO), `infra` (platform shims, db, data/sync), `app`
+(composition root: store factories, nav), and `ui` (theme, locals, widgets).
+Canonical example: `examples/taskflow`.
+
+## Deeper knowledge
+
+- **T1** per-concern guides → `docs/agent/references/` (`feature-slice.md` is live; the other six are planned — see `docs/agent/references/README.md`).
+- **T2** → `examples/taskflow/ARCHITECTURE.md` (full architecture + design rules) and `docs/agent/api-map.md` (module → `.api` index).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,4 +65,5 @@ Canonical example: `examples/taskflow`.
 ## Deeper knowledge
 
 - **T1** per-concern guides → `docs/agent/references/` (`feature-slice.md` is live; the other six are planned — see `docs/agent/references/README.md`).
+- Task → guide routing (decision table) → `docs/agent/references/README.md`.
 - **T2** → `examples/taskflow/ARCHITECTURE.md` (full architecture + design rules) and `docs/agent/api-map.md` (module → `.api` index).

--- a/docs/agent/api-map.md
+++ b/docs/agent/api-map.md
@@ -1,0 +1,38 @@
+---
+tier: T2
+concern: api-map
+derives_from:
+  - "*/api/*.klib.api → committed public API surface"
+api_files: []
+rules: []
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: d388b46, date: 2026-06-03 }
+---
+
+# API map
+
+Read the committed `.api` dump for a module's public surface; regenerate with `./gradlew apiDump`.
+
+| Module | `.api` path | What's in it |
+|---|---|---|
+| `:redux-kotlin` | `redux-kotlin/api/redux-kotlin.klib.api` | Core contract: `Store`/`TypedStore`, `Reducer`, `Middleware`, `createStore`, `applyMiddleware`, `combineReducers`, `compose`. |
+| `:redux-kotlin-threadsafe` | `redux-kotlin-threadsafe/api/redux-kotlin-threadsafe.klib.api` | `createThreadSafeStore` (atomicfu-locked store wrapper). |
+| `:redux-kotlin-concurrent` | `redux-kotlin-concurrent/api/redux-kotlin-concurrent.klib.api` | `createConcurrentStore` (lock-free reads + reentrant-lock-serialized writes; CallerSerialized strategy). |
+| `:redux-kotlin-granular` | `redux-kotlin-granular/api/redux-kotlin-granular.klib.api` | `subscribeTo` / `subscribeFields` field-level subscriptions. |
+| `:redux-kotlin-registry` | `redux-kotlin-registry/api/redux-kotlin-registry.klib.api` | `StoreRegistry<K,S>` / `TypedStoreRegistry` keyed multi-store container. |
+| `:redux-kotlin-multimodel` | `redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api` | `ModelState` typesafe heterogeneous model bag. |
+| `:redux-kotlin-multimodel-granular` | `redux-kotlin-multimodel-granular/api/redux-kotlin-multimodel-granular.klib.api` | Granular subscriptions for `ModelState`. |
+| `:redux-kotlin-compose` | `redux-kotlin-compose/api/redux-kotlin-compose.klib.api` | Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`). |
+| `:redux-kotlin-compose-multimodel` | `redux-kotlin-compose-multimodel/api/redux-kotlin-compose-multimodel.klib.api` | Compose bindings for `ModelState`. |
+| `:redux-kotlin-routing` | `redux-kotlin-routing/api/redux-kotlin-routing.klib.api` | Routing DSL + `@Reduce`/`@ReduxInitial` annotations and `ReduxModule` contribution surface. |
+| `:redux-kotlin-routing-codegen-sample` | `redux-kotlin-routing-codegen-sample/api/redux-kotlin-routing-codegen-sample.klib.api` | Sample showing KSP-generated routing wiring (`ReduxModule` output). |
+| `:redux-kotlin-bundle` | `redux-kotlin-bundle/api/redux-kotlin-bundle.klib.api` | One-call assembly of a concurrent `ModelState` store + registry + routing (`createConcurrentModelStore`, `getOrCreateConcurrentModelStore`). |
+| `:redux-kotlin-bundle-compose` | `redux-kotlin-bundle-compose/api/redux-kotlin-bundle-compose.klib.api` | Compose-side bundle conveniences (no published declarations). |
+| `:redux-kotlin-devtools-core` | `redux-kotlin-devtools-core/api/redux-kotlin-devtools-core.klib.api` | DevTools core model: state/action diffing (`DiffOp`, `DiffEntry`). |
+| `:redux-kotlin-devtools-bridge` | `redux-kotlin-devtools-bridge/api/redux-kotlin-devtools-bridge.klib.api` | Wire protocol between app and DevTools UI (`BridgeMessage`). |
+| `:redux-kotlin-devtools-remote` | `redux-kotlin-devtools-remote/api/redux-kotlin-devtools-remote.klib.api` | Remote DevTools transport config (`RemoteConfig`). |
+| `:redux-kotlin-devtools-inapp` | `redux-kotlin-devtools-inapp/api/redux-kotlin-devtools-inapp.klib.api` | In-app DevTools overlay: triggers/config (`DevToolsTrigger`, `InAppConfig`, `DevToolsTab`). |
+| `:redux-kotlin-devtools-inapp-noop` | `redux-kotlin-devtools-inapp-noop/api/redux-kotlin-devtools-inapp-noop.klib.api` | No-op in-app DevTools (same config types, stripped for release builds). |
+| `:redux-kotlin-devtools-ui` | `redux-kotlin-devtools-ui/api/redux-kotlin-devtools-ui.klib.api` | Compose DevTools UI panels (tabs, theme). |
+
+`examples/*` are `convention.control` (not published, no `.api`).

--- a/docs/agent/api-map.md
+++ b/docs/agent/api-map.md
@@ -6,7 +6,7 @@ derives_from:
 api_files: []
 rules: []
 assembles_into: [AGENTS.md, claude-skill]
-last_verified: { commit: d388b46, date: 2026-06-03 }
+last_verified: { commit: 06214a9, date: 2026-06-03 }
 ---
 
 # API map
@@ -34,5 +34,9 @@ Read the committed `.api` dump for a module's public surface; regenerate with `.
 | `:redux-kotlin-devtools-inapp` | `redux-kotlin-devtools-inapp/api/redux-kotlin-devtools-inapp.klib.api` | In-app DevTools overlay: triggers/config (`DevToolsTrigger`, `InAppConfig`, `DevToolsTab`). |
 | `:redux-kotlin-devtools-inapp-noop` | `redux-kotlin-devtools-inapp-noop/api/redux-kotlin-devtools-inapp-noop.klib.api` | No-op in-app DevTools (same config types, stripped for release builds). |
 | `:redux-kotlin-devtools-ui` | `redux-kotlin-devtools-ui/api/redux-kotlin-devtools-ui.klib.api` | Compose DevTools UI panels (tabs, theme). |
+
+`redux-kotlin-bom` (BOM platform), `redux-kotlin-routing-codegen` (KSP processor), and
+`redux-kotlin-devtools-standalone` (sample app) are published/built but carry no `.api` dump, so
+they're not listed.
 
 `examples/*` are `convention.control` (not published, no `.api`).

--- a/docs/agent/knowledge-sync.md
+++ b/docs/agent/knowledge-sync.md
@@ -1,0 +1,38 @@
+---
+tier: T2
+concern: knowledge-sync
+derives_from: []
+api_files: []
+rules: []
+assembles_into: []
+last_verified: { commit: b089596, date: 2026-06-03 }
+---
+
+# Knowledge-sync agent
+
+An advisory GitHub Action (`.github/workflows/knowledge-sync.yml`) that catches **semantic** drift the
+deterministic L4 checks (`scripts/check-agent-refs.sh`, `scripts/check-api-tripwire.sh`) cannot see:
+when a code change makes a guide's prose or patterns subtly wrong while every cited path still resolves.
+
+## What it does
+
+On a PR touching library `*/src/**`, a committed `**/api/*.api`, or `examples/taskflow/**`, it runs Claude
+to diff the change against the provenance-headed knowledge under `docs/agent/` and posts **one** PR comment
+listing which references likely need updating (using each doc's `derives_from` header to target the review),
+or "No knowledge drift detected." It is **advisory** — it never fails the build.
+
+## Enabling it
+
+1. Add a repository secret **`ANTHROPIC_API_KEY`** (Settings → Secrets and variables → Actions). Without it
+   the workflow's single job **cleanly skips** (the `gate` step yields `enabled=false`).
+2. **Pin the action.** Verify `anthropics/claude-code-action` inputs against its current README and pin to a
+   release tag or commit SHA before relying on it (this workflow uses `@v1`).
+3. (Optional) The workflow also supports `workflow_dispatch` for manual runs.
+
+## Relationship to the deterministic checks
+
+| Check | Catches | Blocking |
+|---|---|---|
+| `check-agent-refs.sh` (Phase 3) | broken `path → symbol` anchors, bad module/task names | yes |
+| `check-api-tripwire.sh` (Phase 3) | any committed `.api` change | yes (bypass label `api-reviewed`) |
+| knowledge-sync (this) | semantic / prose / pattern drift | no (advisory comment) |

--- a/docs/agent/knowledge-sync.md
+++ b/docs/agent/knowledge-sync.md
@@ -5,7 +5,7 @@ derives_from: []
 api_files: []
 rules: []
 assembles_into: []
-last_verified: { commit: b089596, date: 2026-06-03 }
+last_verified: { commit: 06214a9, date: 2026-06-03 }
 ---
 
 # Knowledge-sync agent

--- a/docs/agent/references/README.md
+++ b/docs/agent/references/README.md
@@ -1,0 +1,20 @@
+# redux-kotlin agent reference set (T1)
+
+Single-source, per-concern guides for building with redux-kotlin. `AGENTS.md` (Phase 1) and the
+Claude skill (Phase 2) assemble from these — edit knowledge here, not in copies.
+
+Anchor convention: source references are written `repo-relative-path → Symbol` (in backticks) and are
+checked to resolve (path exists, symbol present). See [_template.md](./_template.md).
+
+| Concern | Guide | Status |
+|---|---|---|
+| Add a feature slice | [feature-slice.md](./feature-slice.md) | ✅ |
+| Store setup & topology | `store-setup.md` | planned (0-rest) |
+| Compose binding (Rule C) | `compose-binding.md` | planned (0-rest) |
+| Effects + sync (Rule E) | `effects-sync.md` | planned (0-rest) |
+| Testing & the verify loop | `testing.md` | planned (0-rest) |
+| The 6 platform shims | `platform-shims.md` | planned (0-rest) |
+| Modularization | `modularization.md` | planned (0-rest) |
+
+Tiers: **T0** = rules card + module map + commands (assembled into `AGENTS.md`). **T1** = these guides.
+**T2** = [`examples/taskflow/ARCHITECTURE.md`](../../../examples/taskflow/ARCHITECTURE.md) + committed `.api` dumps.

--- a/docs/agent/references/_template.md
+++ b/docs/agent/references/_template.md
@@ -1,0 +1,26 @@
+---
+tier: T1
+concern: <kebab-concern-name>
+derives_from:
+  # each entry is `<repo-relative-path> → <Symbol>[, <Symbol>]`
+  - <path> → <Symbol>
+api_files:
+  # committed library .api dumps backing the APIs this guide uses (taskflow itself has none)
+  - <module>/api/<module>.klib.api
+rules: []          # subset of A–H this guide enforces
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: <short-sha>, date: <YYYY-MM-DD> }
+---
+
+# <Title>
+
+> One-line statement of what this guide answers.
+
+## <Section>
+
+Prose explains the *why* and the *rule*. Every source reference uses the anchor form
+`path → Symbol` wrapped in backticks — repo-relative path, a literal " → ", then the symbol(s).
+
+## See also
+
+- Cross-links to sibling guides via [README](./README.md).

--- a/docs/agent/references/_template.md
+++ b/docs/agent/references/_template.md
@@ -9,6 +9,8 @@ api_files:
   - <module>/api/<module>.klib.api
 rules: []          # subset of A–H this guide enforces
 assembles_into: [AGENTS.md, claude-skill]
+# last_verified.commit: the commit the cited `derives_from` sources were verified against
+# (use the repo base commit if this doc derives from nothing).
 last_verified: { commit: <short-sha>, date: <YYYY-MM-DD> }
 ---
 
@@ -20,6 +22,14 @@ last_verified: { commit: <short-sha>, date: <YYYY-MM-DD> }
 
 Prose explains the *why* and the *rule*. Every source reference uses the anchor form
 `path → Symbol` wrapped in backticks — repo-relative path, a literal " → ", then the symbol(s).
+
+## Anchor rules (enforced by `scripts/check-agent-refs.sh`)
+
+- A source citation is `` `path → Symbol` `` where **path must contain `/`** — bare names are not
+  validated (they're treated as convention/example placeholders).
+- The checker also verifies cited `:redux-kotlin*` **module names** exist in `settings.gradle.kts`
+  and that cited `./gradlew <task>` names are in its allowlist.
+- Lines containing `(planned` are skipped (so you can point at not-yet-written guides).
 
 ## See also
 

--- a/docs/agent/references/feature-slice.md
+++ b/docs/agent/references/feature-slice.md
@@ -1,0 +1,168 @@
+---
+tier: T1
+concern: feature-slice
+derives_from:
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/boardlist → BoardListModel, boardListReducer, BoardListScreen, CreateBoard, BoardSummaryCard
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/EffectsMiddleware.kt → effectsMiddleware
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardSelectors.kt → deriveVisibleCardIds
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/Action.kt → Action, Undoable
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/CardActions.kt → InverseOp
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt → declareAccountModels
+api_files:
+  - redux-kotlin-compose-multimodel/api/redux-kotlin-compose-multimodel.klib.api
+  - redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api
+rules: [C, E, G]
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: 06214a9, date: 2026-06-03 }
+---
+
+# Feature slice
+
+> How to add a vertical feature slice to the package-by-feature `examples/taskflow` app: the seven
+> elements, where each lives, the design rule it honors, and how to wire it into the store.
+
+## What a feature slice is here
+
+A feature slice is **one directory `feature/<name>/`** that co-locates everything a feature owns:
+its slot model(s), actions, reducer(s), effect handler, screen + child composables, selectors, and
+tests. The `boardlist` slice is the smallest complete example — a slot model, leaf actions, one pure
+reducer, a screen, and a card — so it is the spine of this guide; the heavier `board` slice supplies
+the effects/selectors callouts.
+
+Shared homes sit outside `feature/*`:
+
+- **`core`** — the domain kernel: entities (`BoardEntities.kt`), the `Action`/`Undoable` marker
+  interfaces (`Action.kt`), and the cross-feature card/sync-contract actions + `InverseOp`
+  (`CardActions.kt`). No Compose, no IO.
+- **`infra`** — platform shims (expect/actual), the db, the data/sync layer, util.
+- **`app`** — the composition root: `App.kt`, the store factories (`AppStore.kt`, `AccountStore.kt`),
+  and `app/nav`.
+- **`ui`** — theme, `CompositionLocal`s, and cross-feature widgets.
+
+Dependency direction (one way, never back): `core ← infra`; `core / infra / ui ← feature/*`;
+everything `← app`. A feature may depend on `core`/`infra`/`ui` and may reference another feature's
+public leaf actions (e.g. `board`'s effects import `boardlist`'s `CreateBoard`), but `core` never
+imports a feature.
+
+## The seven elements
+
+### 1. Models
+
+Two homes. The **slot model** is the immutable per-account state the store holds for this feature; it
+lives in the slice: `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/boardlist → BoardListModel`.
+The **entity** it caches is a domain type, so it lives in the kernel:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/AccountEntities.kt → BoardSummary`.
+Rule: feature-private projection state stays in the feature; anything more than one feature needs (or
+that is fundamentally a domain noun) goes to `core`. Slot models default every field so the store can
+declare an empty slot.
+
+### 2. Actions
+
+Feature leaves live in the slice:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/boardlist → CreateBoard, LoadBoardListSucceeded`.
+The markers and the cross-feature card contract live in the kernel:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/Action.kt → Action, Undoable`
+and `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/CardActions.kt → InverseOp`.
+
+Every concrete action implements `Action`; user card mutations also implement `Undoable` (drives the
+undo stack). **`Action` and `Undoable` are plain interfaces, NOT `sealed`.** Kotlin requires every
+subtype of a `sealed` type to live in the same package, but package-by-feature spreads action leaves
+across many feature packages — a sealed root would force every action back into `core`, defeating the
+slicing. The cost is exhaustiveness: a non-sealed root means `when (action)` has no compiler-checked
+totality, so every routing/reducer `when` ends in an `else` that returns state unchanged — which is
+the correct Redux semantics anyway, so the choice is behavior-preserving. By contrast `InverseOp`
+**stays `sealed`**: its leaves are a fixed, small set co-located in `core/CardActions.kt`, so
+`when (inverse)` can be exhaustive with no `else`.
+
+### 3. Reducer
+
+Pure `(model, action) -> model`, same instance returned for unhandled actions:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/boardlist → boardListReducer`.
+The store's routing DSL (`model<M> { on<T> { } }`) dispatches each registered action class to the
+reducer, so the reducer's own `when` only needs the leaves it handles plus `else -> model`. The
+reducer is the home for **Rule G** at the *consume* side: it never reads a clock or generates an id —
+`CreateBoard` carries a pre-minted `boardId` and `now`, and the reducer stamps the new `BoardSummary`
+straight from the action. (Multi-slot reducers — see `board` — take a captured `selfId` argument from
+the store wiring rather than reading identity at runtime.)
+
+### 4. Effects
+
+**Rule E — off-main effects.** The ONLY place intent becomes IO is a middleware; each feature's
+handler is a per-feature `Middleware<ModelState>` composed into the pipeline. Board callout:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/EffectsMiddleware.kt → effectsMiddleware`.
+All repository/sync work runs on the per-account background `scope` (off-main); dispatches marshal
+back to main through the store's `NotificationContext`, so the effect code does no explicit main hop.
+The handler routes by exact action class, runs the optimistic reducer via `next(action)`, then
+launches the matching repository call — capturing the per-op `InverseOp` *before* `next` so a backend
+rejection can revert exactly that op. A feature ships its own handler only if it performs IO: `boardlist`
+adds no `boardlist` middleware — its `CreateBoard` and board-load actions are persisted by the shared
+effects handler in `feature.board`, which owns the repository.
+
+### 5. Screen
+
+**Rule C — render isolation.** No composable reads a slot wholesale; each binds the narrowest slice.
+Boardlist spine:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/boardlist → BoardListScreen`.
+Board callout:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardScreen.kt → BoardScreen`.
+The screen wraps its store once via `rememberStableStore(store).value`, then binds slices with
+`fieldStateOf` (a whole field, value-equal) or `selectorState` (a derived snapshot). Child composables
+receive finished immutable data plus a remembered callback — the store never reaches a child. Editor
+text and dialog-open flags stay in transient local `remember`, never the store. Rule G lives at the
+*mint* side here: ids/clock for `CreateBoard` come from `LocalIdGenerator` / `LocalClock` at the
+dispatch site.
+
+### 6. Selectors
+
+Pure derivation functions, the home for all list/filter work that Rule C bans from composable bodies:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardSelectors.kt → deriveVisibleCardIds`.
+A selector takes the bound model(s) and returns a value-equal result (a `PersistentList`, a small
+data class) so a `selectorState` recomposes only when the derived value genuinely changes. Keep them
+free of Compose and IO — they are plain testable functions.
+
+### 7. Tests
+
+`commonTest` by default (multiplatform); `jvmTest` only for jvm-only assertions. Cite:
+`examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardReducersTest.kt → BoardReducersTest`.
+Reducers and selectors are pure, so they test directly with no store. Each new slice adds at least a
+reducer test (one case per handled action, plus an unchanged-on-unhandled assertion) and, where it has
+them, selector tests.
+
+## Store wiring
+
+A slice is inert until the composition root registers it. Two edits in `app`:
+
+1. **Declare the slot + route its actions** (order matters: declare every slot up front so
+   `ModelState.get` never misses):
+   `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt → declareAccountModels`.
+   Add a `model(MyModel()) { on<MyAction> { s, a -> myReducer(s, a) } }` block. Register the SAME
+   reducer on each slot that handles a shared action (the routing layer fires each registered handler
+   and leaves other slots untouched). Root-scoped models register in
+   `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AppStore.kt → createAppStore`
+   instead.
+2. **Compose the effect handler** into the per-account pipeline, in fixed order: `activityLogger`,
+   then `undo`, then `effects` (see the `named(...)` pipeline in `createAccountStore`). A new
+   feature's middleware is added to that `devToolsMiddleware(...)` list at the right position.
+
+## Verify loop
+
+Tight inner loop, fast to slow: `compile <target>`, then `commonTest` / `jvmTest`, then `detektAll`,
+then `apiCheck`.
+`apiCheck` matters only when you touch a library module's public API (taskflow itself has none);
+the backing `.api` dumps are listed in `api_files`. iOS-sim targets are host-gated — run them
+locally only on macOS; trust CI otherwise. Full treatment → testing.md.
+
+`detektAll` is the gate that bites first: `explicitApi()` is on, so every new `public` declaration in a
+slice (models, actions, reducer, screen, selectors) needs an explicit visibility modifier **and** a KDoc
+comment — including nested `data class`es and their properties. Formatting auto-corrects; missing KDoc does
+not. Document public symbols as you write them, and never bypass the hook with `--no-verify`.
+
+## Codegen note
+
+KSP `@Reduce` codegen is packaging-agnostic: a `@Reduce`-annotated reducer can live in any
+`feature/*` package and the generated routing wiring follows it — package-by-feature does not change
+how codegen resolves it. Full treatment → the feature / testing guides.
+
+## See also
+
+- [README](./README.md)

--- a/docs/agent/references/feature-slice.md
+++ b/docs/agent/references/feature-slice.md
@@ -106,7 +106,8 @@ Boardlist spine:
 Board callout:
 `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardScreen.kt → BoardScreen`.
 The screen wraps its store once via `rememberStableStore(store).value`, then binds slices with
-`fieldStateOf` (a whole field, value-equal) or `selectorState` (a derived snapshot). Child composables
+`fieldStateOf` (a whole field, value-equal) or `selectorState` (a derived snapshot); per ARCHITECTURE
+§17, each narrowly-bound leaf is wrapped in `key(...)` so it recomposes independently. Child composables
 receive finished immutable data plus a remembered callback — the store never reaches a child. Editor
 text and dialog-open flags stay in transient local `remember`, never the store. Rule G lives at the
 *mint* side here: ids/clock for `CreateBoard` come from `LocalIdGenerator` / `LocalClock` at the
@@ -150,7 +151,7 @@ Tight inner loop, fast to slow: `compile <target>`, then `commonTest` / `jvmTest
 then `apiCheck`.
 `apiCheck` matters only when you touch a library module's public API (taskflow itself has none);
 the backing `.api` dumps are listed in `api_files`. iOS-sim targets are host-gated — run them
-locally only on macOS; trust CI otherwise. Full treatment → testing.md.
+locally only on macOS; trust CI otherwise. Full treatment → `testing.md` *(planned)*.
 
 `detektAll` is the gate that bites first: `explicitApi()` is on, so every new `public` declaration in a
 slice (models, actions, reducer, screen, selectors) needs an explicit visibility modifier **and** a KDoc
@@ -159,9 +160,10 @@ not. Document public symbols as you write them, and never bypass the hook with `
 
 ## Codegen note
 
-KSP `@Reduce` codegen is packaging-agnostic: a `@Reduce`-annotated reducer can live in any
-`feature/*` package and the generated routing wiring follows it — package-by-feature does not change
-how codegen resolves it. Full treatment → the feature / testing guides.
+KSP `@Reduce` / `@ReduxInitial` codegen is packaging-agnostic: a `@Reduce`-annotated reducer can live
+in any `feature/*` package and the generated routing wiring follows it — package-by-feature does not
+change how codegen resolves it. Full codegen treatment is deferred to a planned guide
+*(planned — 0-rest)*.
 
 ## See also
 

--- a/docs/superpowers/plans/2026-06-03-agents-md-and-api-map-phase1.md
+++ b/docs/superpowers/plans/2026-06-03-agents-md-and-api-map-phase1.md
@@ -1,0 +1,84 @@
+# Phase 1 — AGENTS.md + API-map Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Assemble the T0 layer — `AGENTS.md` (repo-root, token-tight agent index) + `docs/agent/api-map.md` (module → `.api` index) — from existing canon, single-source (point, don't duplicate).
+
+**Architecture:** Docs-only. Two files. Content derived from `CLAUDE.md` (modules/commands), `examples/taskflow/ARCHITECTURE.md` §17 (Rules C–H), `docs/agent/references/` (T1 pointers), and `*/api/*.klib.api` (the 19 committed dumps). Gate = reference integrity (every cited path/module/command resolves).
+
+**Tech Stack:** Markdown; bash/grep for the gate.
+
+---
+
+## Task 1: `docs/agent/api-map.md`
+
+**Files:** Create `docs/agent/api-map.md`
+
+- [ ] **Step 1:** Enumerate the committed dumps: `ls */api/*.klib.api` (expect 19). 
+- [ ] **Step 2:** Write `docs/agent/api-map.md` with provenance frontmatter (`tier: T2`, `concern: api-map`, `derives_from:` the dump glob, `rules: []`, `assembles_into: [AGENTS.md, claude-skill]`, `last_verified: {commit: <git rev-parse --short HEAD>, date: 2026-06-03}`) and a markdown table with one row per dump: **module** (the `:name` from `settings.gradle.kts`) · **`.api` path** (e.g. `redux-kotlin/api/redux-kotlin.klib.api`) · **what's in it** (one line; for the 9 core modules use CLAUDE.md's descriptions; for routing/bundle/bom/devtools/codegen give a terse one-liner inferred from the module name + a peek at the dump). Add a note: `examples/*` are `convention.control` (no `.api`); read source/`ARCHITECTURE.md` for those.
+- [ ] **Step 3:** Verify every path in the table exists: `for f in $(grep -oE '[a-z0-9-]+/api/[a-z0-9-]+\.klib\.api' docs/agent/api-map.md); do test -f "$f" || echo "MISS $f"; done; echo done` → no MISS.
+- [ ] **Step 4:** Commit: `git commit -am "docs(agent): add API-map index (T2)"`
+
+---
+
+## Task 2: `AGENTS.md` (repo root)
+
+**Files:** Create `AGENTS.md`
+
+Read first: `CLAUDE.md`, `examples/taskflow/ARCHITECTURE.md` §17 (lines ~866–886, Rules **C–H** — there are no named A/B; do not invent them), `docs/agent/references/README.md`.
+
+- [ ] **Step 1:** Write `AGENTS.md` (repo root), token-tight (~120–180 lines), these sections:
+  1. **One-paragraph "what redux-kotlin is"** — KMP port of the Redux contract; minimal core + opt-in companion modules on one `Store<S>` contract.
+  2. **Module map** — the 9 core published modules with the one-line "use this for X" from `CLAUDE.md`; one line noting additional modules (routing, bundle, bom, devtools, codegen) exist — see `docs/agent/api-map.md`. `examples/` = samples (taskflow is the canonical app).
+  3. **Build / test / lint** — the four gate commands (`./gradlew build`, `./gradlew detektAll`, `./gradlew apiCheck`, `./gradlew :<module>:jvmTest`) each one line; pointer: "full gate detail → `CLAUDE.md`". State the hard rule: never `--no-verify`; `explicitApi()` requires KDoc on every public decl.
+  4. **Design rules** — Rules **C–H** as one line each, verbatim-faithful to ARCHITECTURE §17 (C render isolation · D identity split · E off-main effects · F delta-only status · G mint-at-edge · H single inset point). Pointer: full text → `examples/taskflow/ARCHITECTURE.md` §17.
+  5. **Where things live** — the recommended app layout is **package-by-feature** (strategy §5.1): `feature/<name>/` slice + shared `core` (kernel) · `infra` · `app` · `ui`; the canonical example is `examples/taskflow`. One line.
+  6. **Deeper knowledge (T1/T2)** — point into `docs/agent/references/` (list the 7 guides via the README, noting feature-slice.md is live, others planned) and T2 (`examples/taskflow/ARCHITECTURE.md`, `docs/agent/api-map.md`).
+  Use plain `` `path` `` references (backtick-wrapped, no line numbers). Keep prose to the minimum an index needs.
+- [ ] **Step 2:** Length check: `wc -l AGENTS.md` ≤ ~180. If over, cut prose (it's an index).
+- [ ] **Step 3:** Commit: `git commit -am "docs(agent): add AGENTS.md T0 index"`
+
+---
+
+## Task 3: Reference-integrity gate (acceptance)
+
+**Files:** none.
+
+- [ ] **Step 1:** Run from worktree root:
+```bash
+bash -c '
+miss=0
+# all backtick `path` and `path/api/*.klib.api` refs in both files exist
+for F in AGENTS.md docs/agent/api-map.md; do
+  for p in $(grep -oE "[A-Za-z0-9_./-]+/[A-Za-z0-9_./-]+\.(md|api|kts)" "$F" | sort -u); do
+    [ -e "$p" ] || { echo "MISS path ($F): $p"; miss=1; }
+  done
+done
+# referenced docs exist
+for p in docs/agent/references/feature-slice.md docs/agent/references/README.md examples/taskflow/ARCHITECTURE.md CLAUDE.md docs/agent/api-map.md; do
+  test -e "$p" || { echo "MISS doc: $p"; miss=1; }
+done
+# the 9 core module names resolve in settings.gradle.kts
+for m in redux-kotlin redux-kotlin-threadsafe redux-kotlin-concurrent redux-kotlin-granular redux-kotlin-registry redux-kotlin-multimodel redux-kotlin-multimodel-granular redux-kotlin-compose redux-kotlin-compose-multimodel; do
+  grep -q "\":$m\"" settings.gradle.kts || { echo "MISS module: $m"; miss=1; }
+done
+[ "$miss" = 0 ] && echo "REFS RESOLVE OK" || echo "REFS FAILED"
+'
+```
+Expected: `REFS RESOLVE OK`. Fix any MISS (correct the path/name in the doc), re-run, commit fixes.
+- [ ] **Step 2:** No-collateral: `git diff --name-only origin/master...HEAD` shows only `AGENTS.md`, `docs/agent/`, `docs/superpowers/`. No `.kt`/`website/`/`examples/`.
+
+---
+
+## Task 4: PR
+
+- [ ] **Step 1:** `git push -u origin agents-md-phase1`
+- [ ] **Step 2:** `gh pr create --base feature-slice-pilot --head agents-md-phase1` (stacked on the pilot) — title `docs(agent): AGENTS.md (T0) + API-map index (Phase 1)`; body: assembled-from-canon, single-source (points into refs/CLAUDE.md), the reference-integrity gate result, merge-after-#313 note, link the spec.
+
+---
+
+## Self-review notes
+- Spec coverage: api-map (T1), AGENTS.md (T2), gate (T3), PR (T4). All spec deliverables mapped.
+- Rules: C–H only (no A/B) — plan instructs not to fabricate.
+- Module scope: api-map covers all 19 dumps; AGENTS module-map highlights the core 9 + pointer.
+- No duplication of CLAUDE.md — AGENTS.md references it.

--- a/docs/superpowers/plans/2026-06-03-claude-skill-phase2.md
+++ b/docs/superpowers/plans/2026-06-03-claude-skill-phase2.md
@@ -1,0 +1,115 @@
+# Phase 2 — Claude Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Add the `redux-kotlin` Claude Code project skill — a rules-card + decision-routing `SKILL.md` that links into the canonical `docs/agent/references/` set (single-source).
+
+**Architecture:** One `.gitignore` change to make `.claude/skills/` trackable, plus `SKILL.md`. No content duplication; routing links point to the Phase-0/1 docs. Gate = gitignore behavior + link resolution.
+
+**Tech Stack:** Markdown + `.gitignore`.
+
+---
+
+## Task 1: Make `.claude/skills/` trackable
+
+**Files:** Modify `.gitignore`
+
+- [ ] **Step 1:** In `.gitignore`, replace the line `.claude/` with two lines:
+```
+.claude/*
+!.claude/skills/
+```
+- [ ] **Step 2:** Verify behavior:
+```bash
+git check-ignore .claude/worktrees/foo >/dev/null && echo "worktrees still ignored ✓"
+git check-ignore .claude/skills/redux-kotlin/SKILL.md && echo "SKILL still ignored ✗" || echo "skills trackable ✓"
+```
+Expected: `worktrees still ignored ✓` and `skills trackable ✓`.
+- [ ] **Step 3:** Commit: `git commit -am "chore: track .claude/skills (keep worktrees ignored)"`
+
+---
+
+## Task 2: `SKILL.md`
+
+**Files:** Create `.claude/skills/redux-kotlin/SKILL.md`
+
+Read first: `AGENTS.md`, `examples/taskflow/ARCHITECTURE.md` §17 (Rules C–H), `docs/agent/references/README.md`.
+
+- [ ] **Step 1:** Create `.claude/skills/redux-kotlin/SKILL.md`:
+
+````markdown
+---
+name: redux-kotlin
+description: Use when building or reviewing redux-kotlin (Kotlin Multiplatform Redux) code — adding/editing a feature slice, wiring the store, Compose state binding, effects/sync middleware, testing, the platform expect/actual shims, or modularization. Enforces the project's render-isolation / off-main-effects / mint-at-edge rules.
+---
+
+# redux-kotlin
+
+Kotlin Multiplatform port of the Redux contract: a minimal core (`redux-kotlin`) plus opt-in
+companion modules on one `Store<S>` contract. Recommended app organization is **package-by-feature**
+(`feature/<name>/` slice + shared `core` · `infra` · `app` · `ui`); the canonical example is `examples/taskflow`.
+
+## Always-apply rules (full text → `../../../examples/taskflow/ARCHITECTURE.md` §17)
+
+- **Rule C — Render isolation.** No composable reads a model wholesale; bind the narrowest slice via `selectorState`/`fieldStateOf`, wrapped in `key(...)`. Derivation lives in pure functions/reducers.
+- **Rule D — Identity split.** A profile edit fans to the root account directory, per-account `CollaboratorsModel`, and `SessionModel` — never duplicate identity inconsistently.
+- **Rule E — Off-main effects.** Effects originate only in middleware and run off-main; dispatch marshals back to main via `NotificationContext`. Per-feature handlers compose into one `effectsMiddleware`.
+- **Rule F — Delta-only status.** Emit status only on a real change.
+- **Rule G — Mint at the edge.** Ids/timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
+- **Rule H — Single inset point.** Window insets applied once at the shell root.
+
+## Decision routing
+
+| If you are… | Read |
+|---|---|
+| Adding or editing a **feature** | [`feature-slice.md`](../../../docs/agent/references/feature-slice.md) |
+| Setting up the **store / topology** | `../../../docs/agent/references/store-setup.md` *(planned — see README)* |
+| **Compose** state binding (Rule C) | `../../../docs/agent/references/compose-binding.md` *(planned)* |
+| **Effects + sync** (Rule E) | `../../../docs/agent/references/effects-sync.md` *(planned)* |
+| **Testing** + the verify loop | `../../../docs/agent/references/testing.md` *(planned)* |
+| The 6 **platform shims** | `../../../docs/agent/references/platform-shims.md` *(planned)* |
+| **Modularization** | `../../../docs/agent/references/modularization.md` *(planned)* |
+
+## Pointers
+
+- T0 index (modules, commands, layout): [`AGENTS.md`](../../../AGENTS.md)
+- Public API surface per module: [`api-map.md`](../../../docs/agent/api-map.md)
+- Architecture deep-dive: [`ARCHITECTURE.md`](../../../examples/taskflow/ARCHITECTURE.md)
+- Reference index: [`references/README.md`](../../../docs/agent/references/README.md)
+
+Build/lint gate (never `--no-verify`; `explicitApi()` needs KDoc on every public decl): `./gradlew build`, `./gradlew detektAll`, `./gradlew apiCheck`. Detail → `../../../CLAUDE.md`.
+````
+
+- [ ] **Step 2:** Verify the existing-file links resolve (planned ones are labelled, skip them):
+```bash
+cd .claude/skills/redux-kotlin
+for p in ../../../docs/agent/references/feature-slice.md ../../../docs/agent/references/README.md ../../../AGENTS.md ../../../docs/agent/api-map.md ../../../examples/taskflow/ARCHITECTURE.md ../../../CLAUDE.md; do test -f "$p" && echo "OK $p" || echo "MISS $p"; done
+cd - >/dev/null
+```
+Expected: all `OK`, no `MISS`.
+- [ ] **Step 3:** Confirm Rules C–H match ARCHITECTURE §17 wording (no A/B). 
+- [ ] **Step 4:** Commit: `git add .claude/skills/redux-kotlin/SKILL.md && git commit -m "feat(agent): add redux-kotlin Claude skill (rules + routing)"`
+
+---
+
+## Task 3: Acceptance gate
+
+**Files:** none.
+
+- [ ] **Step 1:** Re-run Task 1 Step 2 (gitignore) + Task 2 Step 2 (links) — all green.
+- [ ] **Step 2:** `git status --porcelain` shows `.claude/skills/redux-kotlin/SKILL.md` tracked; `git diff --name-only agents-md-phase1...HEAD` shows only `.gitignore`, `.claude/skills/...`, `docs/superpowers/...`. No `.kt`/`website/`/`examples/`.
+
+---
+
+## Task 4: PR
+
+- [ ] **Step 1:** `git push -u origin claude-skill-phase2`
+- [ ] **Step 2:** `gh pr create --base agents-md-phase1 --head claude-skill-phase2` — title `feat(agent): redux-kotlin Claude skill (Phase 2)`; body: rules-card + routing, single-source (links into refs, no duplication), the `.gitignore` rationale, gate result, stacked-on-#314 merge-order note, link the spec.
+
+---
+
+## Self-review notes
+- Spec coverage: gitignore (T1), SKILL.md (T2), gate (T3), PR (T4).
+- Single-source: routing links point to canonical docs; no guide content copied into SKILL.md.
+- Planned guides are labelled, not asserted present — gate only checks existing files.
+- gitignore change keeps worktrees ignored (verified in T1 Step 2).

--- a/docs/superpowers/plans/2026-06-03-feature-slice-reference-pilot.md
+++ b/docs/superpowers/plans/2026-06-03-feature-slice-reference-pilot.md
@@ -1,0 +1,296 @@
+# Feature-Slice Reference Pilot — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Author the first T1 agent-reference guide (`docs/agent/references/feature-slice.md`) and lock the reference-set conventions (provenance header, `path → symbol` anchor style, template, index) that Phase 0-rest's six remaining guides will replicate.
+
+**Architecture:** Documentation-only sub-project. Three markdown files under a new `docs/agent/references/` tree, derived from the merged package-by-feature `examples/taskflow` (Phase 0a). No source or build changes. The acceptance gate is **citation integrity** — every backtick-wrapped `` `path → symbol` `` anchor resolves (path exists + symbol present) — implemented as a grep sweep that doubles as a manual dry-run of the Phase-3 L4 anchor checker.
+
+**Tech Stack:** Markdown; bash/grep for the citation-integrity gate. Source-of-truth being documented: Kotlin Multiplatform taskflow (`core/ infra/ feature/ app/ ui/`), Rules A–H (`examples/taskflow/ARCHITECTURE.md`), redux-kotlin library `.api` dumps.
+
+---
+
+## Conventions locked by this pilot (every guide inherits these)
+
+- **Anchor form:** all source citations are backtick-wrapped `` `<repo-relative-path> → <Symbol>[, <Symbol>...]` ``. Machine-extractable (a literal ` → ` separator inside backticks). Paths are repo-relative (start `examples/...` or `redux-kotlin.../...`). No line numbers (drift-resilient; the Phase-0a lesson).
+- **Provenance header:** YAML frontmatter, fields `tier, concern, derives_from, api_files, rules, assembles_into, last_verified{commit,date}` (see spec).
+- **Location:** `docs/agent/references/`. Out of `website/` and `.claude/`.
+- **Tone/length:** tight, scannable, citation-dense; ~250–400 lines; prose carries the *why/rule*, anchors carry the *where*.
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `docs/agent/references/_template.md` | Frontmatter + section skeleton + the anchor-form rule, for the other six guides to copy. |
+| `docs/agent/references/README.md` | Index of the seven T1 guides with status; the cross-reference hub. |
+| `docs/agent/references/feature-slice.md` | The worked guide: how to add a feature slice, anchored on `feature.boardlist` with `feature.board` callouts. |
+
+Base revision for `last_verified`: `06214a9` (this worktree's `master` base). Confirm with `git rev-parse --short HEAD` before writing headers; use that value.
+
+---
+
+## Task 1: Lock the template (`_template.md`)
+
+**Files:** Create `docs/agent/references/_template.md`
+
+- [ ] **Step 1: Confirm base commit for provenance headers**
+
+Run: `git rev-parse --short HEAD`
+Expected: `06214a9` (or the current base — use whatever it prints in all `last_verified.commit` fields below).
+
+- [ ] **Step 2: Write `_template.md`**
+
+Create the file with this exact content (it is both the copy-source for future guides AND itself a valid, citation-free skeleton):
+
+````markdown
+---
+tier: T1
+concern: <kebab-concern-name>
+derives_from:
+  # backtick-free here; each entry is `<repo-relative-path> → <Symbol>[, <Symbol>]`
+  - <path> → <Symbol>
+api_files:
+  # committed library .api dumps backing the APIs this guide uses (taskflow itself has none)
+  - <module>/api/<module>.klib.api
+rules: []          # subset of A–H this guide enforces
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: <short-sha>, date: <YYYY-MM-DD> }
+---
+
+# <Title>
+
+> One-line statement of what this guide answers.
+
+## <Section>
+
+Prose explains the *why* and the *rule*. Every source reference uses the anchor form
+`` `path → Symbol` `` — repo-relative path, a literal ` → `, then the symbol(s). Example:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/boardlist → boardListReducer`.
+
+## See also
+
+- Cross-links to sibling guides via [README](./README.md).
+````
+
+- [ ] **Step 3: Verify it has no dangling anchors**
+
+Run: `grep -oE '\`[^\`]+ → [^\`]+\`' docs/agent/references/_template.md || echo "no concrete anchors (template is a skeleton) — OK"`
+Expected: the only ` → ` occurrences are the illustrative one in prose; the template is not citation-checked (it is a skeleton). OK either way.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/agent/references/_template.md
+git commit -m "docs(agent): add reference-set template + anchor conventions"
+```
+
+---
+
+## Task 2: Index (`README.md`)
+
+**Files:** Create `docs/agent/references/README.md`
+
+- [ ] **Step 1: Write `README.md`**
+
+Create with this content:
+
+```markdown
+# redux-kotlin agent reference set (T1)
+
+Single-source, per-concern guides for building with redux-kotlin. `AGENTS.md` (Phase 1) and the
+Claude skill (Phase 2) assemble from these — edit knowledge here, not in copies.
+
+Anchor convention: source references are written `` `repo-relative-path → Symbol` `` and are
+checked to resolve (path exists, symbol present). See [_template.md](./_template.md).
+
+| Concern | Guide | Status |
+|---|---|---|
+| Add a feature slice | [feature-slice.md](./feature-slice.md) | ✅ |
+| Store setup & topology | `store-setup.md` | planned (0-rest) |
+| Compose binding (Rule C) | `compose-binding.md` | planned (0-rest) |
+| Effects + sync (Rule E) | `effects-sync.md` | planned (0-rest) |
+| Testing & the verify loop | `testing.md` | planned (0-rest) |
+| The 6 platform shims | `platform-shims.md` | planned (0-rest) |
+| Modularization | `modularization.md` | planned (0-rest) |
+
+Tiers: **T0** = rules card + module map + commands (assembled into `AGENTS.md`). **T1** = these guides.
+**T2** = [`examples/taskflow/ARCHITECTURE.md`](../../../examples/taskflow/ARCHITECTURE.md) + committed `.api` dumps.
+```
+
+- [ ] **Step 2: Verify the two relative links resolve**
+
+Run:
+```bash
+test -f examples/taskflow/ARCHITECTURE.md && echo "ARCHITECTURE OK"
+# the planned-guide names are intentionally NOT links yet (files don't exist) — confirm none are bracketed links:
+grep -E '\[`?(store-setup|compose-binding|effects-sync|testing|platform-shims|modularization)\.md' docs/agent/references/README.md && echo "ERROR: planned guide is a live link" || echo "planned guides are plain code spans — OK"
+```
+Expected: `ARCHITECTURE OK` and `planned guides are plain code spans — OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/agent/references/README.md
+git commit -m "docs(agent): add reference-set index"
+```
+
+---
+
+## Task 3: Author `feature-slice.md`
+
+**Files:** Create `docs/agent/references/feature-slice.md`
+
+Read the real sources first so every anchor is accurate (do not invent symbols):
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/` →
+`feature/boardlist/*`, `feature/board/{EffectsMiddleware.kt,BoardSelectors.kt,BoardReducers.kt,BoardScreen.kt}`,
+`core/{Action.kt,CardActions.kt,BoardEntities.kt}`, `app/{AccountStore.kt,AppStore.kt}`, and
+`examples/taskflow/ARCHITECTURE.md` (Rules A–H wording). Find one existing reducer test under
+`examples/taskflow/composeApp/src/commonTest/.../feature/board/` to cite for the Tests element.
+
+- [ ] **Step 1: Write the frontmatter**
+
+Use the locked header. Confirmed-resolving `derives_from` anchors (verified against base `06214a9`):
+
+```yaml
+---
+tier: T1
+concern: feature-slice
+derives_from:
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/boardlist → BoardListModel, boardListReducer, BoardListScreen, CreateBoard, BoardSummaryCard
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/EffectsMiddleware.kt → effectsMiddleware
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardSelectors.kt → deriveVisibleCardIds
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/Action.kt → Action, Undoable
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/CardActions.kt → InverseOp
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt → declareAccountModels
+api_files:
+  - redux-kotlin-compose-multimodel/api/redux-kotlin-compose-multimodel.klib.api
+  - redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api
+rules: [C, E, G]
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: 06214a9, date: 2026-06-03 }
+---
+```
+
+- [ ] **Step 2: Write the intro + "where things live"**
+
+A one-paragraph definition of a feature slice in this codebase, then a mini-map. Content (write as prose + a list; anchors backtick-wrapped):
+- Slice = one directory `feature/<name>/` co-locating that feature's slot model, actions, reducer, effect handler, screen, selectors, tests.
+- Shared homes: `core` (domain kernel — entities + `Action`/`Undoable` markers + card/sync-contract actions), `infra` (platform shims, db, data/sync, util), `app` (composition root: `App.kt`, store factories, `app/nav`), `ui` (theme + cross-feature widgets).
+- State the dependency direction: `core ← infra`; `core/infra/ui ← feature/*`; everything `← app`.
+
+- [ ] **Step 3: Write the seven slice elements**
+
+One subsection per element. Each: *what · where it lives · the Rule it honors · a `` `path → Symbol` `` anchor* (boardlist spine; board callout where noted). Required anchors (all verified to resolve):
+
+1. **Models** — `` `…/feature/boardlist → BoardListModel` `` (slot model) + `` `…/core/BoardEntities.kt → BoardSummary` `` (kernel entity).
+2. **Actions** — `` `…/feature/boardlist → CreateBoard, LoadBoardListSucceeded` `` (feature leaves) + `` `…/core/Action.kt → Action, Undoable` `` + `` `…/core/CardActions.kt → InverseOp` ``. Include the **plain-marker rationale**: `Action`/`Undoable` are plain interfaces, not `sealed`, because Kotlin requires sealed subtypes in the same package; package-by-feature spreads leaves across packages. `InverseOp` stays `sealed` (leaves co-located in `core`). Behavior-preserving: every `when(action)` uses `else`.
+3. **Reducer** — `` `…/feature/boardlist → boardListReducer` ``. Note the hand-written `model<M> { on<T> { … } }` routing DSL and **Rule G** (mint ids/timestamps at the dispatch edge, never in the reducer).
+4. **Effects** — **Rule E**: effects originate only in middleware; the feature's handler is composed into `` `…/feature/board/EffectsMiddleware.kt → effectsMiddleware` ``, runs off-main. (boardlist's load is handled there → board callout.)
+5. **Screen** — **Rule C** render isolation; bind narrowest slice via `selectorState`/`fieldState`. `` `…/feature/boardlist → BoardListScreen` `` (+ `` `…/feature/board/BoardScreen.kt → BoardScreen` `` callout).
+6. **Selectors** — pure derivation. `` `…/feature/board/BoardSelectors.kt → deriveVisibleCardIds` `` (board callout; boardlist derives inline).
+7. **Tests** — `commonTest` default, `jvmTest` for jvm-only. Cite `` `…/commonTest/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardReducersTest.kt → BoardReducersTest` ``.
+
+- [ ] **Step 4: Write store wiring + verify loop + codegen note + cross-refs**
+
+- **Store wiring:** register the slot (order matters) and compose the effect handler (order `activityLogger → undo → effects`). Anchors `` `…/app/AccountStore.kt → declareAccountModels` `` and `` `…/app/AppStore.kt → createAppStore` ``.
+- **Verify loop (brief):** `compile <target> → commonTest/jvmTest → detektAll → apiCheck`; iOS-sim host-gating caveat (trust CI). One line: full treatment → `testing.md`.
+- **Codegen note (brief):** KSP `@Reduce` is packaging-agnostic. One line: full treatment → feature/testing guides.
+- **See also:** link `[README](./README.md)` for sibling guides.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/agent/references/feature-slice.md
+git commit -m "docs(agent): add feature-slice T1 reference guide"
+```
+
+---
+
+## Task 4: Citation-integrity gate (acceptance test + L4 dry-run)
+
+**Files:** none committed (verification only; this logic becomes the Phase-3 anchor checker later).
+
+- [ ] **Step 1: Run the anchor sweep**
+
+Extract every backtick-wrapped `path → symbol` anchor from the guide AND the frontmatter `derives_from`, and verify each resolves. Run from the worktree root:
+
+```bash
+GUIDE=docs/agent/references/feature-slice.md
+fail=0
+# 1) inline backtick anchors: `path → Sym, Sym`
+grep -oE '`[^`]+ → [^`]+`' "$GUIDE" | sed 's/^`//; s/`$//' | while IFS= read -r anchor; do
+  path="${anchor%% → *}"; syms="${anchor##* → }"
+  [ -e "$path" ] || { echo "MISS path: $path"; continue; }
+  IFS=',' read -ra arr <<< "$syms"
+  for s in "${arr[@]}"; do s="$(echo "$s" | xargs)"; grep -rq "$s" "$path" || echo "MISS symbol: $s in $path"; done
+done
+# 2) frontmatter derives_from entries: "  - path → Sym, Sym"
+sed -n '/^derives_from:/,/^[a-z_]*:/p' "$GUIDE" | grep -E '→' | sed 's/^[[:space:]]*-[[:space:]]*//' | while IFS= read -r anchor; do
+  path="${anchor%% → *}"; syms="${anchor##* → }"
+  [ -e "$path" ] || { echo "MISS df-path: $path"; continue; }
+  IFS=',' read -ra arr <<< "$syms"
+  for s in "${arr[@]}"; do s="$(echo "$s" | xargs)"; grep -rq "$s" "$path" || echo "MISS df-symbol: $s in $path"; done
+done
+# 3) api_files exist
+sed -n '/^api_files:/,/^[a-z_]*:/p' "$GUIDE" | grep -E '\.api' | sed 's/^[[:space:]]*-[[:space:]]*//' | while IFS= read -r f; do
+  test -f "$f" || echo "MISS api_file: $f"; done
+echo "sweep done"
+```
+Expected: only `sweep done` with **no `MISS` lines**.
+
+- [ ] **Step 2: Fix any MISS**
+
+For each `MISS`, correct the anchor in `feature-slice.md` to the real path/symbol (read the source to find the right one). Re-run Step 1 until clean. Commit fixes if any:
+
+```bash
+git commit -am "docs(agent): fix feature-slice anchors to resolve"
+```
+
+- [ ] **Step 3: Markdown link + base-commit checks**
+
+Run:
+```bash
+# intra-docs links resolve (README/template/guide + ARCHITECTURE/.api relative paths)
+test -f docs/agent/references/README.md && test -f docs/agent/references/_template.md && echo "set present"
+grep -q "$(git rev-parse --short HEAD)" docs/agent/references/feature-slice.md && echo "last_verified matches base" || echo "WARN: bump last_verified.commit"
+```
+Expected: `set present` and `last_verified matches base`.
+
+---
+
+## Task 5: Final read-through + no-collateral check
+
+**Files:** none.
+
+- [ ] **Step 1: Confirm no website/source impact**
+
+Run:
+```bash
+git diff --name-only origin/master...HEAD
+```
+Expected: only files under `docs/agent/references/` and `docs/superpowers/` (spec + plan). No `website/`, no `examples/`, no `*.kt`.
+
+- [ ] **Step 2: Length/tone check**
+
+Run: `wc -l docs/agent/references/feature-slice.md`
+Expected: roughly 250–400 lines. If far outside, tighten (over) or deepen (under) — prose carries why/rule, anchors carry where.
+
+- [ ] **Step 3: Read the guide top-to-bottom** as a cold agent: can you build a new feature slice from it alone, following each anchor? Fix gaps; re-run Task 4 Step 1 if any anchor changed.
+
+---
+
+## Task 6: Open PR
+
+**Files:** none.
+
+- [ ] **Step 1:** `git push -u origin feature-slice-pilot`
+- [ ] **Step 2:** `gh pr create --base master --title "docs(agent): feature-slice reference guide + reference-set conventions (Phase 0-pilot)" --body-file <body>` — body summarizes: Phase 0-pilot, the three files, the locked conventions (provenance header, `path → symbol` anchors, location), the citation-integrity gate result, and that 0-rest replicates the template across the remaining six guides. Link the spec.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** `_template.md` (Task 1) = convention lock; `README.md` (Task 2) = index deliverable; `feature-slice.md` (Task 3) = the guide with all seven elements + wiring/verify/codegen/mini-map; citation-integrity gate (Task 4) = the spec's acceptance gate + L4 dry-run; no-collateral (Task 5) = "out of scope: no source/website changes". All spec deliverables mapped.
+- **No placeholders:** every file's content is given inline; the only intentional "fill from source" is Task 3's Tests anchor (the real test filename) and AppStore's top-level symbol — both with explicit "verify the real symbol" instructions and caught by the Task 4 sweep.
+- **Anchor consistency:** the same backtick `path → Symbol` form is used in `_template.md`, the guide, and the Task 4 extractor (it greps exactly that form). Frontmatter `derives_from` uses the un-backticked `- path → Symbol` YAML form, which the extractor handles separately.
+- **Drift-resilience:** no line numbers anywhere; `last_verified.commit` pins the revision.

--- a/docs/superpowers/plans/2026-06-03-knowledge-sync-agent-phase4.md
+++ b/docs/superpowers/plans/2026-06-03-knowledge-sync-agent-phase4.md
@@ -1,0 +1,150 @@
+# Phase 4 — Knowledge-Sync Agent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Add an advisory LLM workflow that, on PRs touching library source / `.api` / `examples/taskflow`, diffs the change against the provenance-headed knowledge refs and comments which refs likely need updating. Ships ready; requires the `ANTHROPIC_API_KEY` secret (documented; cleanly skips without it).
+
+**Architecture:** One `.github/workflows/knowledge-sync.yml` (path-filtered `pull_request` + `workflow_dispatch`, advisory/non-blocking, secret-guarded) + `docs/agent/knowledge-sync.md` setup doc. No source changes. Not locally runnable (LLM action) — verified by YAML validity + structure.
+
+**Tech Stack:** GitHub Actions YAML, `anthropics/claude-code-action`.
+
+---
+
+## Task 1: `.github/workflows/knowledge-sync.yml`
+
+**Files:** Create `.github/workflows/knowledge-sync.yml`
+
+- [ ] **Step 1:** Write:
+```yaml
+name: Knowledge sync
+on:
+  pull_request:
+    paths:
+      - 'redux-kotlin*/**/src/**'
+      - '**/api/*.api'
+      - 'examples/taskflow/**'
+  workflow_dispatch:
+permissions:
+  contents: read
+  pull-requests: write
+concurrency:
+  cancel-in-progress: true
+  group: knowledge-sync-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+jobs:
+  sync:
+    name: Knowledge drift review
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Gate on API key presence
+        id: gate
+        run: echo "enabled=${{ secrets.ANTHROPIC_API_KEY != '' }}" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Claude knowledge-drift review
+        if: steps.gate.outputs.enabled == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are the redux-kotlin knowledge-sync reviewer. This PR changed library source, a committed
+            `.api` dump, and/or `examples/taskflow` (the canonical reference app).
+
+            The agent knowledge lives under `docs/agent/`:
+            - `docs/agent/references/*.md` — T1 per-concern guides; each has a YAML `derives_from:` header
+              listing the `path → Symbol` sources it paraphrases.
+            - `AGENTS.md` — the T0 index (modules, commands, Rules C–H, layout).
+            - `docs/agent/api-map.md` — module → `.api` map.
+
+            Do this:
+            1. Read the PR diff (changed files).
+            2. For each knowledge doc, read its `derives_from` provenance; a doc is IN SCOPE if any changed
+               file matches one of its `derives_from` paths (or it documents a changed module / Rule).
+            3. For each in-scope doc, judge whether the change makes its prose, patterns, citations, or rule
+               statements stale — focus on SEMANTIC drift (deterministic anchor/API checks run separately).
+            4. Post ONE concise PR comment: a bullet per doc needing an update with the specific reason, or
+               exactly "No knowledge drift detected." Do not modify files. Do not restate the rules.
+            Keep it short and high-signal. Cite `path → Symbol` for any claim.
+```
+- [ ] **Step 2:** Validate: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/knowledge-sync.yml')); print('yaml ok')"`. If `actionlint` is installed, run it.
+- [ ] **Step 3:** Sanity-check trigger globs resolve to real locations:
+```bash
+ls -d redux-kotlin*/src >/dev/null 2>&1 && echo "src glob ok"
+ls */api/*.api >/dev/null 2>&1 && echo "api glob ok"
+ls -d examples/taskflow >/dev/null 2>&1 && echo "taskflow ok"
+```
+Expected: all three echo. (Note: the workflow uses `redux-kotlin*/**/src/**` which covers `<module>/src/...`.)
+- [ ] **Step 4:** Commit: `git add .github/workflows/knowledge-sync.yml && git commit -m "ci(agent): add knowledge-sync drift-review workflow"`
+
+---
+
+## Task 2: `docs/agent/knowledge-sync.md`
+
+**Files:** Create `docs/agent/knowledge-sync.md`
+
+- [ ] **Step 1:** Write:
+```markdown
+---
+tier: T2
+concern: knowledge-sync
+derives_from: []
+api_files: []
+rules: []
+assembles_into: []
+last_verified: { commit: <short-sha>, date: 2026-06-03 }
+---
+
+# Knowledge-sync agent
+
+An advisory GitHub Action (`.github/workflows/knowledge-sync.yml`) that catches **semantic** drift the
+deterministic L4 checks (`scripts/check-agent-refs.sh`, `scripts/check-api-tripwire.sh`) cannot see:
+when a code change makes a guide's prose or patterns subtly wrong while every cited path still resolves.
+
+## What it does
+
+On a PR touching library `*/src/**`, a committed `**/api/*.api`, or `examples/taskflow/**`, it runs Claude
+to diff the change against the provenance-headed knowledge under `docs/agent/` and posts **one** PR comment
+listing which references likely need updating (using each doc's `derives_from` header to target the review),
+or "No knowledge drift detected." It is **advisory** — it never fails the build.
+
+## Enabling it
+
+1. Add a repository secret **`ANTHROPIC_API_KEY`** (Settings → Secrets and variables → Actions). Without it
+   the workflow's single job **cleanly skips** (the `gate` step yields `enabled=false`).
+2. **Pin the action.** Verify `anthropics/claude-code-action` inputs against its current README and pin to a
+   release tag or commit SHA before relying on it (this workflow uses `@v1`).
+3. (Optional) The workflow also supports `workflow_dispatch` for manual runs.
+
+## Relationship to the deterministic checks
+
+| Check | Catches | Blocking |
+|---|---|---|
+| `check-agent-refs.sh` (Phase 3) | broken `path → symbol` anchors, bad module/task names | yes |
+| `check-api-tripwire.sh` (Phase 3) | any committed `.api` change | yes (bypass label `api-reviewed`) |
+| knowledge-sync (this) | semantic / prose / pattern drift | no (advisory comment) |
+```
+Replace `<short-sha>` with `git rev-parse --short HEAD`.
+- [ ] **Step 2:** If `scripts/check-agent-refs.sh` exists on this branch, run it — `docs/agent/knowledge-sync.md` must not break it (it adds no `path → symbol` anchors, so it should pass). Expected `ANCHOR CHECK OK`.
+- [ ] **Step 3:** Commit: `git add docs/agent/knowledge-sync.md && git commit -m "docs(agent): document the knowledge-sync agent + required secret"`
+
+---
+
+## Task 3: Acceptance + PR
+
+- [ ] **Step 1:** YAML valid; trigger globs resolve; secret-guard present (`grep -q "ANTHROPIC_API_KEY != ''" .github/workflows/knowledge-sync.yml`); `permissions` minimal; `bash scripts/check-agent-refs.sh` → `ANCHOR CHECK OK`.
+- [ ] **Step 2:** No-collateral: `git diff --name-only l4-ci-phase3...HEAD` → only `.github/workflows/knowledge-sync.yml`, `docs/agent/knowledge-sync.md`, `docs/superpowers/`. No `.kt`/`website/`/`examples/`.
+- [ ] **Step 3:** `git push -u origin knowledge-sync-phase4`
+- [ ] **Step 4:** `gh pr create --base l4-ci-phase3 --head knowledge-sync-phase4` — title `ci(agent): knowledge-sync drift-review agent (Phase 4)`; body: what it does, advisory + secret-guarded (skips without `ANTHROPIC_API_KEY`), pin-the-action caveat, completes the L4 drift-control pair (deterministic + semantic), stacked merge-order note, link the spec.
+
+---
+
+## Self-review notes
+- Spec coverage: workflow (T1), doc (T2), acceptance+PR (T3).
+- Not locally runnable (LLM) — verification is YAML/structure/secret-guard, explicitly per spec.
+- Secret-guard uses a `run`-step boolean output (`secrets` usable in `${{ }}`, not in job `if:`) — the robust pattern.
+- Advisory: `continue-on-error: true`, no required status.
+- Single-source: prompt points at `docs/agent/`; embeds no rule copies.

--- a/docs/superpowers/plans/2026-06-03-l4-deterministic-ci-phase3.md
+++ b/docs/superpowers/plans/2026-06-03-l4-deterministic-ci-phase3.md
@@ -1,0 +1,177 @@
+# Phase 3 — L4 Deterministic CI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Two deterministic, locally-runnable shell checks + one GitHub Actions workflow: an **anchor check** (refs cite real paths/symbols/modules/tasks) and an **API-change tripwire** (`*.api` change → knowledge review required).
+
+**Architecture:** `scripts/*.sh` (detekt-excluded, bash) + `.github/workflows/agent-knowledge.yml` (`pull_request: [master]`, mirrors `pr.yml`). No library source changes. TDD: each script has a positive (exit 0 on good state) and negative (exit non-zero on injected breakage) test the implementer MUST run.
+
+**Tech Stack:** bash, GitHub Actions YAML.
+
+---
+
+## Task 1: `scripts/check-agent-refs.sh` (anchor check)
+
+**Files:** Create `scripts/check-agent-refs.sh` (chmod +x)
+
+Behavior: scan `AGENTS.md`, `docs/agent/api-map.md`, and `docs/agent/references/*.md` (EXCLUDE `_template.md`). Skip any line containing `(planned`. Verify, collecting all failures then exiting non-zero if any:
+- backtick anchors `` `path → Sym[, Sym]` `` → path exists AND each Sym appears in path (`grep -rqF`).
+- module tokens matching `:redux-kotlin[a-z-]*` → present in `settings.gradle.kts`.
+- `./gradlew <task>` → `<task>` (after stripping any `:module:` prefix) ∈ allowlist `build detekt detektAll apiCheck apiDump allTests jvmTest test assemble assembleDebug`.
+- YAML `api_files:` list entries → each path exists.
+SKILL.md is intentionally NOT scanned (it routes to planned guides).
+
+- [ ] **Step 1:** Write the script (reference implementation; harden as needed):
+```bash
+#!/usr/bin/env bash
+# L4 anchor check: verify the agent reference set cites real paths/symbols/modules/tasks.
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 2
+fail=0
+note() { printf 'ANCHOR-FAIL: %s\n' "$*"; fail=1; }
+ALLOWED=" build detekt detektAll apiCheck apiDump allTests jvmTest test assemble assembleDebug "
+
+files=(AGENTS.md docs/agent/api-map.md)
+while IFS= read -r f; do files+=("$f"); done < <(find docs/agent/references -name '*.md' ! -name '_template.md' 2>/dev/null | sort)
+
+for F in "${files[@]}"; do
+  [ -f "$F" ] || { note "missing doc: $F"; continue; }
+  # --- line-scoped checks (skip planned lines) ---
+  while IFS= read -r line; do
+    case "$line" in *'(planned'*) continue ;; esac
+    # path → symbol anchors
+    while IFS= read -r a; do
+      a="${a#\`}"; a="${a%\`}"
+      p="${a%% → *}"; syms="${a##* → }"
+      if [ ! -e "$p" ]; then note "$F: path not found: $p"; continue; fi
+      IFS=',' read -ra arr <<< "$syms"
+      for s in "${arr[@]}"; do s="$(printf '%s' "$s" | xargs)"; [ -n "$s" ] || continue
+        grep -rqF -- "$s" "$p" || note "$F: symbol '$s' not found in $p"
+      done
+    done < <(printf '%s\n' "$line" | grep -oE '`[^`]+ → [^`]+`' || true)
+    # module tokens
+    while IFS= read -r m; do
+      grep -qF "\"$m\"" settings.gradle.kts || note "$F: module $m not in settings.gradle.kts"
+    done < <(printf '%s\n' "$line" | grep -oE ':redux-kotlin[a-z-]*' | sort -u || true)
+    # gradle tasks
+    while IFS= read -r t; do
+      t="${t##*:}"; case "$ALLOWED" in *" $t "*) ;; *) note "$F: gradle task '$t' not in allowlist" ;; esac
+    done < <(printf '%s\n' "$line" | grep -oE '\./gradlew [:a-zA-Z-]+' | sed 's#\./gradlew ##' || true)
+  done < "$F"
+  # --- frontmatter api_files paths ---
+  while IFS= read -r p; do
+    p="$(printf '%s' "$p" | xargs)"; [ -n "$p" ] || continue
+    [ -e "$p" ] || note "$F: api_file not found: $p"
+  done < <(awk '/^api_files:/{f=1;next} /^[a-zA-Z_]+:/{f=0} f && /^[[:space:]]*-/{sub(/^[[:space:]]*-[[:space:]]*/,"");print}' "$F")
+done
+
+if [ "$fail" -ne 0 ]; then echo "ANCHOR CHECK FAILED"; exit 1; fi
+echo "ANCHOR CHECK OK"
+```
+- [ ] **Step 2:** `chmod +x scripts/check-agent-refs.sh`
+- [ ] **Step 3 (positive test):** `bash scripts/check-agent-refs.sh` → prints `ANCHOR CHECK OK`, exit 0. If any ANCHOR-FAIL, the docs are right and the script is wrong — fix the script (do NOT weaken a real check).
+- [ ] **Step 4 (negative test):** append a bogus anchor to a scratch copy and confirm it fails:
+```bash
+cp docs/agent/references/feature-slice.md /tmp/fs.bak
+printf '\n`docs/agent/does-not-exist.md → Ghost`\n' >> docs/agent/references/feature-slice.md
+bash scripts/check-agent-refs.sh; echo "exit=$?"   # expect ANCHOR-FAIL ... + exit=1
+mv /tmp/fs.bak docs/agent/references/feature-slice.md
+bash scripts/check-agent-refs.sh && echo "restored OK"
+```
+Expected: the injected line fails (exit 1), then restored passes (exit 0).
+- [ ] **Step 5:** Commit: `git add scripts/check-agent-refs.sh && git commit -m "build(agent): add L4 anchor-check script"`
+
+---
+
+## Task 2: `scripts/check-api-tripwire.sh`
+
+**Files:** Create `scripts/check-api-tripwire.sh` (chmod +x)
+
+- [ ] **Step 1:** Write:
+```bash
+#!/usr/bin/env bash
+# L4 API-change tripwire: flag committed *.api changes so knowledge gets re-reviewed.
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 2
+BASE="${1:-origin/master}"
+changed="$(git diff --name-only "$BASE...HEAD" -- '*.api' 2>/dev/null || true)"
+[ -z "$changed" ] && changed="$(git diff --name-only "$BASE" -- '*.api' 2>/dev/null || true)"
+if [ -z "$changed" ]; then echo "api-tripwire: no .api changes vs $BASE ✓"; exit 0; fi
+echo "api-tripwire: public API changed — knowledge review required."
+printf '%s\n' "$changed" | sed 's#/api/.*##' | sort -u | sed 's/^/  module: /'
+echo "Action: update docs/agent/api-map.md if the surface summary changed, then add PR label 'api-reviewed' to acknowledge."
+if [ "${API_REVIEW_OK:-0}" = "1" ]; then echo "api-tripwire: acknowledged (api-reviewed) — passing."; exit 0; fi
+exit 1
+```
+- [ ] **Step 2:** `chmod +x scripts/check-api-tripwire.sh`
+- [ ] **Step 3 (positive test):** `bash scripts/check-api-tripwire.sh origin/master; echo exit=$?` → `no .api changes` + exit 0 (this stack is docs/CI only). If `origin/master` is unfetched, run `git fetch origin master` first.
+- [ ] **Step 4 (negative test):**
+```bash
+echo "// scratch" >> redux-kotlin/api/redux-kotlin.klib.api
+bash scripts/check-api-tripwire.sh origin/master; echo "exit=$?"          # expect tripwire + exit=1
+API_REVIEW_OK=1 bash scripts/check-api-tripwire.sh origin/master; echo "exit=$?"  # expect acknowledged + exit=0
+git checkout -- redux-kotlin/api/redux-kotlin.klib.api
+```
+Expected: trips (exit 1), bypass passes (exit 0), then reverted.
+- [ ] **Step 5:** Commit: `git add scripts/check-api-tripwire.sh && git commit -m "build(agent): add L4 API-change tripwire script"`
+
+---
+
+## Task 3: `.github/workflows/agent-knowledge.yml`
+
+**Files:** Create `.github/workflows/agent-knowledge.yml`
+
+- [ ] **Step 1:** Write:
+```yaml
+name: Agent knowledge
+on:
+  pull_request:
+    branches: [master]
+permissions:
+  contents: read
+concurrency:
+  cancel-in-progress: true
+  group: agent-knowledge-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+jobs:
+  anchor-check:
+    name: Anchor check (refs resolve)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check agent reference anchors
+        run: bash scripts/check-agent-refs.sh
+  api-tripwire:
+    name: API-change tripwire
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Tripwire on committed .api changes
+        env:
+          API_REVIEW_OK: ${{ contains(github.event.pull_request.labels.*.name, 'api-reviewed') && '1' || '0' }}
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1 || true
+          bash scripts/check-api-tripwire.sh "origin/${{ github.base_ref }}"
+```
+- [ ] **Step 2:** Validate YAML: `actionlint .github/workflows/agent-knowledge.yml` if available, else `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/agent-knowledge.yml')); print('yaml ok')"`. Expected: clean / `yaml ok`.
+- [ ] **Step 3:** Commit: `git add .github/workflows/agent-knowledge.yml && git commit -m "ci(agent): add agent-knowledge workflow (anchor check + API tripwire)"`
+
+---
+
+## Task 4: Acceptance + PR
+
+- [ ] **Step 1:** Re-run both scripts clean (`scripts/check-agent-refs.sh` → OK; `check-api-tripwire.sh origin/master` → no changes). 
+- [ ] **Step 2:** No-collateral: `git diff --name-only claude-skill-phase2...HEAD` → only `scripts/`, `.github/workflows/agent-knowledge.yml`, `docs/superpowers/`. No `.kt`/`website/`/`examples/`.
+- [ ] **Step 3:** `git push -u origin l4-ci-phase3`
+- [ ] **Step 4:** `gh pr create --base claude-skill-phase2 --head l4-ci-phase3` — title `ci(agent): L4 deterministic checks — anchor + API tripwire (Phase 3)`; body: the two scripts + workflow, positive/negative test results, the `api-reviewed` bypass-label mechanism, stacked merge-order note, link the spec.
+
+---
+
+## Self-review notes
+- Spec coverage: anchor script (T1), tripwire script (T2), workflow (T3), acceptance+PR (T4).
+- Determinism: no gradle invocation; static task allowlist; pure git/grep.
+- Planned guides skipped (line contains `(planned`); `_template.md` excluded; SKILL.md not scanned.
+- Both scripts are locally runnable and TDD-tested (positive + negative) before commit.

--- a/docs/superpowers/specs/2026-06-03-agents-md-and-api-map-phase1-design.md
+++ b/docs/superpowers/specs/2026-06-03-agents-md-and-api-map-phase1-design.md
@@ -1,0 +1,47 @@
+# Phase 1: `AGENTS.md` (T0) + API-map index
+
+**Date:** 2026-06-03
+**Phase:** 1 of the redux-kotlin AI integration strategy.
+**Branch:** `agents-md-phase1` (stacked on `feature-slice-pilot`).
+**Type:** Documentation assembly. No source/build changes.
+
+## Why
+
+Phase 0 established the single-source reference set under `docs/agent/references/`. Phase 1 produces the **T0 layer** — the always-in-context, token-tight index every agent/tool (Cursor, Copilot, Codex, Claude) reads first — by **assembling** it from existing canon, plus an **API-map index** so an agent reads the committed public-API surface (`.api`) instead of source. Single-source discipline: AGENTS.md *points into* `docs/agent/references/` and `CLAUDE.md`; it does not duplicate their content.
+
+Decisions (recommended, locked for unattended execution):
+- **AGENTS.md** lives at repo root (tool-agnostic convention).
+- **`CLAUDE.md` stays as-is** (maintainer/build-gate doc). AGENTS.md cross-links it for build/lint/publish detail rather than merging (avoids disrupting a working doc; resolves strategy open-question 6 minimally).
+- **API map** at `docs/agent/api-map.md` — table of the 9 published modules → `.api` dump path + one-line surface summary.
+
+## Deliverables
+
+1. **`AGENTS.md`** (repo root) — T0 index, token-tight (~120–180 lines). Sections:
+   - **What redux-kotlin is** — 1 paragraph.
+   - **Module map** — which module for which job (the 9 published modules + the `examples/` samples), derived from `CLAUDE.md`.
+   - **Build / test / lint commands** — the gate one-liners (`./gradlew build`, `detektAll`, `apiCheck`, target-scoped test), pointer to `CLAUDE.md` for detail.
+   - **Design rules** — one line each. ARCHITECTURE.md §17 names **Rules C–H** only (the strategy's "A–H" is loose shorthand; there are no named Rules A/B). Use the canonical C–H statements verbatim — do **not** fabricate A/B.
+   - **Where things live** — the package-by-feature layout (`core/ infra/ feature/ app/ ui/`) as the recommended app organization (§5.1), citing taskflow.
+   - **Deeper knowledge** — pointers into T1 (`docs/agent/references/` — list the 7 guides + status) and T2 (`examples/taskflow/ARCHITECTURE.md`, `docs/agent/api-map.md`).
+2. **`docs/agent/api-map.md`** — provenance-headed (same YAML convention as the ref set, `tier: T2`); a table: module → `api/<module>.klib.api` → one-line "what's in it". Covers **every published module that has a committed `.api` dump** (enumerate via `ls */api/*.klib.api` — `settings.gradle.kts` lists ~20 modules incl. routing/bundle/bom/devtools, more than CLAUDE.md's "core 9"; map exactly those with a dump). Note `examples/*` are `convention.control` (no `.api`).
+
+## Constraints
+
+- **Anchor convention** (inherited from Phase 0): file references use backtick-wrapped `` `path → Symbol` `` or plain `` `path` `` for whole-file/dir; no line numbers. Every cited path must exist (Phase-3 anchor checker will enforce; Phase 1 self-checks).
+- AGENTS.md must be **token-tight** — it is always in context. Prose minimal; it is an index, not a manual. Defer depth to T1/T2 via pointers.
+- Rules A–H wording must match `ARCHITECTURE.md` (don't invent new phrasings).
+- No duplication of `CLAUDE.md` content — reference it.
+
+## Acceptance gate
+
+Docs-only. Gate = **reference integrity**: every path referenced in `AGENTS.md` and `api-map.md` exists (the 9 `.api` files, `docs/agent/references/*`, `examples/taskflow/ARCHITECTURE.md`, `CLAUDE.md`); the 9 module names match `settings.gradle.kts`; cited gradle tasks are real. Implemented as a grep/test sweep (extends the Phase-0 sweep; a dry-run of the Phase-3 checker). Plus: `AGENTS.md` ≤ ~180 lines (token-tight); no `.kt`/`website/`/`examples/` changes.
+
+## Out of scope
+
+- The Claude skill (Phase 2), L4 CI (Phase 3), sync agent (Phase 4).
+- Authoring the remaining six T1 guides (Phase 0-rest) — AGENTS.md lists them with status, pointing at the canonical location as they land.
+- Any merge/rewrite of `CLAUDE.md`.
+
+## Next
+
+Phase 2 (Claude skill) consumes this T0 + the ref set.

--- a/docs/superpowers/specs/2026-06-03-claude-skill-phase2-design.md
+++ b/docs/superpowers/specs/2026-06-03-claude-skill-phase2-design.md
@@ -1,0 +1,45 @@
+# Phase 2: Claude skill
+
+**Date:** 2026-06-03
+**Phase:** 2 of the redux-kotlin AI integration strategy.
+**Branch:** `claude-skill-phase2` (stacked on `agents-md-phase1`).
+**Type:** Docs + a one-line `.gitignore` change. No source/build changes.
+
+## Why
+
+The premium Claude Code path: a project skill whose `SKILL.md` is a **rules card + decision routing** that sends Claude to the right T1 guide on demand (progressive disclosure). Single-source: the skill **links into** the canonical `docs/agent/references/` set authored in Phase 0 — it does not copy guide content. The skill *is* the Claude-facing progressive-disclosure layer over the same knowledge `AGENTS.md` indexes.
+
+## Decisions (recommended, locked)
+
+- **Location:** `.claude/skills/redux-kotlin/SKILL.md` — the conventional Claude Code project-skill path (auto-discovered). Requires un-ignoring it: `.gitignore` currently has `.claude/`; change to `.claude/*` + `!.claude/skills/` so `.claude/skills/` is tracked while `.claude/worktrees/` and other transient `.claude/` content stay ignored.
+- **No duplicated `references/` dir.** `SKILL.md` routing links point up to the canonical `docs/agent/references/*.md` (relative `../../../docs/agent/references/...`), plus `AGENTS.md` (T0) and `docs/agent/api-map.md` (T2). This preserves single-source (one boundary: refs ↔ implementation).
+
+## Deliverables
+
+1. **`.gitignore`** — `.claude/` → `.claude/*` and `!.claude/skills/` (worktrees etc. remain ignored). Verify `git check-ignore .claude/worktrees/x` still ignored and `.claude/skills/redux-kotlin/SKILL.md` is NOT ignored.
+2. **`.claude/skills/redux-kotlin/SKILL.md`** — frontmatter + body:
+   - **Frontmatter:** `name: redux-kotlin`; `description:` a tight trigger statement (use when building/reviewing redux-kotlin KMP code — features, store setup, Compose binding, effects/sync, testing, platform shims, modularization).
+   - **Rules card:** Rules C–H one-liners (faithful to `ARCHITECTURE.md` §17; no fabricated A/B) — the always-apply constraints. Keep terse; point to `AGENTS.md` / `ARCHITECTURE.md` for full text.
+   - **Decision routing:** a table mapping intent → guide, e.g. "Adding/editing a feature → `docs/agent/references/feature-slice.md`"; the other six concerns (store-setup, compose-binding, effects-sync, testing, platform-shims, modularization) routed to their planned `docs/agent/references/*.md` paths, each marked *(planned — see README)* until 0-rest lands.
+   - **Pointers:** T0 index → `AGENTS.md`; public API → `docs/agent/api-map.md`; deep dive → `examples/taskflow/ARCHITECTURE.md`; ref index → `docs/agent/references/README.md`.
+
+## Constraints
+
+- `SKILL.md` is loaded into context when the skill activates — keep it tight (rules card + routing, not a manual). Depth lives in the linked guides.
+- Single-source: do NOT restate guide content in `SKILL.md`; link to it.
+- Routing links use repo-relative paths from the skill dir (`../../../docs/agent/references/...`); every linked path that already exists must resolve (planned guides are explicitly marked, not broken-linked as if present).
+
+## Acceptance gate
+
+- `.gitignore` behaves: `.claude/worktrees/<x>` still ignored; `.claude/skills/redux-kotlin/SKILL.md` tracked (`git check-ignore` + `git status` confirm).
+- Every routing/pointer link in `SKILL.md` that points to an **existing** file resolves (feature-slice.md, README.md, AGENTS.md, api-map.md, ARCHITECTURE.md). Planned-guide paths are present in the table but clearly labelled *(planned)*; they are not asserted to exist.
+- Rules C–H faithful to ARCHITECTURE §17; no A/B fabrication.
+- No `.kt`/`website/`/`examples/` changes.
+
+## Out of scope
+
+- L4 CI (Phase 3), sync agent (Phase 4), authoring the six planned guides (0-rest).
+
+## Next
+
+Phase 3 (L4 deterministic CI) anchor-checks the refs the skill routes to + AGENTS.md/api-map.

--- a/docs/superpowers/specs/2026-06-03-feature-slice-reference-pilot-design.md
+++ b/docs/superpowers/specs/2026-06-03-feature-slice-reference-pilot-design.md
@@ -1,0 +1,83 @@
+# Phase 0-pilot: `feature-slice.md` + Reference-Set Conventions
+
+**Date:** 2026-06-03
+**Phase:** 0-pilot of the redux-kotlin AI integration strategy (the keystone Phase 0, scoped pilot-first).
+**Branch:** `feature-slice-pilot` (off latest `master`), worktree-isolated.
+**Type:** Documentation authoring. Creates agent-facing knowledge under `docs/agent/`; no source/build changes.
+
+## Why
+
+Phase 0 is the keystone of the strategy: a single-source T1 reference set that Phase 1 (`AGENTS.md`) and Phase 2 (Claude skill) assemble from. Authoring all seven guides at once risks propagating format mistakes across seven docs before review. This pilot authors the **first** guide (`feature-slice.md` — the exemplar that the now-merged package-by-feature taskflow refactor, Phase 0a, unblocked) and **locks the conventions** (provenance header, anchor style, tier/dir layout, template) that the remaining six guides (`0-rest`) replicate.
+
+Prereq satisfied: Phase 0a is merged to `master` (`examples/taskflow` is package-by-feature: `core/ infra/ feature/ app/ ui/`).
+
+## Decisions (settled in brainstorming)
+
+- **Location:** canonical refs live at `docs/agent/references/` — neutral, versioned, tool-agnostic; out of `website/` (agent-facing, not end-user) and out of `.claude/` (detekt-excluded + Claude-coupled). Both `AGENTS.md` (Phase 1) and the Claude skill (Phase 2) point INTO this location (single-source).
+- **Exemplar:** `feature.boardlist` as the end-to-end spine (complete slice without board's heavy optimistic/sync/undo machinery); `feature.board` referenced in callouts for advanced concerns.
+- **Anchor style:** `path → symbol` (e.g. `feature/board/BoardReducers.kt → boardReducer`). Resilient to line drift (the churn Phase 0a avoided); the future L4 anchor checker verifies the path exists AND the symbol is present.
+
+## Deliverables
+
+1. **`docs/agent/references/feature-slice.md`** — the worked guide (structure below).
+2. **`docs/agent/references/_template.md`** — provenance-header + section skeleton for the remaining six guides to copy.
+3. **`docs/agent/references/README.md`** — index of the seven planned T1 guides with status (feature-slice ✅; store-setup, compose-binding, effects-sync, testing, platform-shims, modularization — planned), so cross-references resolve and the set is legible.
+
+## Provenance header (the format all guides reuse)
+
+YAML frontmatter at the top of every reference guide. This is exactly what the Phase-3 L4 anchor checker will parse, so the format is a deliverable, not decoration.
+
+```yaml
+---
+tier: T1
+concern: feature-slice
+derives_from:                       # path → symbol (line-drift-resilient)
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/boardlist → BoardListModel, boardListReducer, BoardListScreen, BoardListActions
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/EffectsMiddleware.kt → effectsMiddleware
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/CardActions.kt → InverseOp
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt → declareAccountModels
+api_files:                          # taskflow is convention.control (NO .api); cite the library .api it consumes
+  - redux-kotlin-compose-multimodel/api/redux-kotlin-compose-multimodel.klib.api
+  - redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api
+rules: [C, E, G]
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: 06214a9, date: 2026-06-03 }
+---
+```
+
+Field intent: `derives_from` = the source-of-truth this doc paraphrases (anchor-checked); `api_files` = committed public-API surface backing the APIs used; `rules` = which of Rules A–H the guide enforces; `assembles_into` = downstream consumers (single-source map); `last_verified` = the revision the citations were checked against.
+
+## feature-slice.md structure
+
+A feature author's walkthrough. Opens with a one-paragraph "what is a feature slice here" (package-by-feature; one dir `feature/<name>/`; what lives in the slice vs. the shared `core` kernel / `infra` / `app` / `ui`). Then **the seven elements**, each as: *what it is · where it lives · which Rule it honors · `path → symbol` citation* (boardlist spine; board callout where the boardlist case is too simple):
+
+1. **Models** — feature slot model in `feature/<name>/`; domain entities in the `core` kernel. Cite `feature/boardlist → BoardListModel`, `core/BoardEntities.kt → BoardSummary`.
+2. **Actions** — feature actions in the slice; card-mutation / sync-contract actions + `InverseOp` in `core`; **why `Action`/`Undoable` are plain marker interfaces, not `sealed`** (Kotlin same-package rule; the Phase-0a finding). Cite `feature/boardlist → BoardListActions`, `core/Action.kt`, `core/CardActions.kt → InverseOp`.
+3. **Reducer** — the hand-written `model<M> { on<T> { … } }` routing DSL; pure; **Rule G** (mint ids/timestamps at the dispatch edge, never in the reducer). Cite `feature/boardlist → boardListReducer`.
+4. **Effects** — **Rule E** (effects originate only in middleware, never reducers/UI); the feature's effect handler is **composed into** `effectsMiddleware`, runs off-main. boardlist's load is handled there → board callout. Cite `feature/board/EffectsMiddleware.kt → effectsMiddleware`.
+5. **Screen** — Compose; **Rule C** render isolation (bind the narrowest slice via `selectorState`/`fieldState`, never read a whole model wholesale). Cite `feature/boardlist → BoardListScreen`; board callout for richer binding.
+6. **Selectors** — pure derivation functions for rendering. Cite `feature/board/BoardSelectors.kt` (board callout; boardlist's derivation is inline).
+7. **Tests** — `commonTest` is the default home; `jvmTest` for jvm-only concerns. Cite a boardlist/board reducer test.
+
+Then:
+- **Store wiring** — register the feature's model slot (declaration order matters) and compose its effect handler (middleware order `activityLogger → undo → effects` matters). Cite `app/AccountStore.kt → declareAccountModels`, `app/AppStore.kt`.
+- **Verify loop** (L3 fold-in, brief) — `compile <target> → commonTest/jvmTest → detektAll → apiCheck`; how to read a failure; iOS-simulator host-gating caveat (trust CI). Full treatment deferred to the `testing` guide.
+- **Codegen note** (L2 fold-in, brief) — KSP `@Reduce` is packaging-agnostic (top-level annotated handlers discovered regardless of package). Full treatment deferred to feature/testing guides.
+- **"Where things live"** mini-map — `core` (kernel) · `infra` · `feature/<name>` · `app` (composition root) · `ui` — and forward cross-references to the other six guides (via `README.md`).
+
+Tone/length budget (a convention the template encodes): tight, scannable, citation-dense; target ~250–400 lines; prose explains the *why/rule*, citations carry the *where*.
+
+## Acceptance gate
+
+Docs-only sub-project — no Kotlin compile/test. The gate is **citation integrity**: every `path → symbol` in `feature-slice.md` (and the header `derives_from`) is verified to resolve — the cited path exists under the worktree AND the symbol appears in that file. Implemented as a grep sweep over the citation list; this is a manual dry-run of the Phase-3 anchor checker and validates the chosen anchor style end-to-end. Also confirm `api_files` paths exist.
+
+Secondary checks: no broken intra-`docs/agent/` markdown links (README ↔ guide ↔ template); `last_verified.commit` matches the worktree base.
+
+## Out of scope
+
+- The other six T1 guides, the API-map index, `AGENTS.md`, the Claude skill, the automated L4 anchor checker / CI (all later sub-projects).
+- Any change to `examples/taskflow` source or to `website/`.
+
+## Next
+
+After approval → writing-plans for the authoring steps, then execute with the citation-integrity gate, then PR. On completion, `0-rest` replicates the locked template across the remaining six guides.

--- a/docs/superpowers/specs/2026-06-03-knowledge-sync-agent-phase4-design.md
+++ b/docs/superpowers/specs/2026-06-03-knowledge-sync-agent-phase4-design.md
@@ -1,0 +1,51 @@
+# Phase 4: knowledge-sync agent (semantic drift)
+
+**Date:** 2026-06-03
+**Phase:** 4 (final) of the redux-kotlin AI integration strategy.
+**Branch:** `knowledge-sync-phase4` (stacked on `l4-ci-phase3`).
+**Type:** CI + docs. Adds one GitHub Actions workflow + a setup doc. No source changes.
+
+## Why
+
+Phase 3 catches *structural* drift deterministically (broken anchors, API changes). It cannot see *semantic* drift — when a code change makes a guide's prose/pattern subtly wrong while every cited path still resolves. Phase 4 adds the LLM catch: on a PR that touches library source, `.api` dumps, or the canonical `examples/taskflow`, an agent diffs the change against the knowledge refs (which carry `derives_from` provenance) and comments which refs likely need updating. Advisory, not blocking — it complements, doesn't gate.
+
+## Decisions (recommended, locked)
+
+- **Mechanism:** the official Claude GitHub Action (`anthropics/claude-code-action`) in headless/prompt mode, given a focused prompt + read access to the diff and `docs/agent/`. Avoids bespoke API plumbing.
+- **Trigger:** `pull_request` touching `redux-kotlin*/**/src/**`, `**/api/*.api`, or `examples/taskflow/**` (path-filtered). Optionally a weekly `schedule` as a safety net.
+- **Advisory:** the job posts a PR comment; it does **not** fail the build (`continue-on-error` / no required status). Drift is surfaced for a human, per the strategy.
+- **Secret:** requires repo secret `ANTHROPIC_API_KEY`. This **cannot be set unattended** — the workflow ships ready, and `docs/agent/knowledge-sync.md` documents enabling it. Until the secret exists the job no-ops/skips cleanly (guard on `secrets.ANTHROPIC_API_KEY != ''`).
+- **Provenance-targeted:** the prompt instructs the agent to use each ref's `derives_from` header to decide relevance — targeted, not whole-repo guesswork (matches the L4 "provenance discipline").
+
+## Deliverables
+
+1. **`.github/workflows/knowledge-sync.yml`** — `pull_request` (path-filtered) + `workflow_dispatch`; `permissions: contents: read, pull-requests: write`; a single job guarded by `if: ${{ secrets.ANTHROPIC_API_KEY != '' }}` that:
+   - checks out (fetch-depth 0),
+   - runs `anthropics/claude-code-action` with `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}` and a `prompt` that: reads the PR diff; for each changed library/source/api/taskflow path, consults `docs/agent/references/*.md` + `AGENTS.md` + `docs/agent/api-map.md` provenance (`derives_from`) to find refs that derive from the changed files; posts ONE PR comment listing each ref that likely needs updating and why (or "no knowledge drift detected"). Read-only to the repo besides the comment.
+   - `continue-on-error: true` (advisory).
+2. **`docs/agent/knowledge-sync.md`** — provenance-headed (`tier: T2`, concern `knowledge-sync`); explains: what the agent does, the required `ANTHROPIC_API_KEY` secret + how to add it, the trigger paths, that it's advisory (complements the deterministic Phase-3 checks), and how to pin/verify the action version before relying on it.
+
+## Constraints
+
+- Cannot run the LLM action locally; verification is limited to **YAML validity, trigger-path correctness, the secret-guard, and a sound prompt**. The doc must flag "verify/pin `anthropics/claude-code-action` to a release before enabling."
+- Must not block CI (advisory). Must not run (cleanly skip) when the secret is absent.
+- Single-source: the prompt points the agent at the canonical `docs/agent/` knowledge; it does not embed copies of the rules.
+
+## Acceptance gate
+
+- `knowledge-sync.yml` parses (`python3 -c "import yaml,…"`); `actionlint` clean if available.
+- Trigger `paths:` globs match real locations (`redux-kotlin*/.../src`, `**/api/*.api`, `examples/taskflow/**`).
+- Secret-guard present (`if: secrets.ANTHROPIC_API_KEY != ''`).
+- `permissions` minimal (`contents: read`, `pull-requests: write`).
+- `docs/agent/knowledge-sync.md` exists, names the secret, and is itself anchor-clean (passes `scripts/check-agent-refs.sh` if it adds anchors).
+- No `.kt`/`website/`/`examples/` source changes.
+
+## Out of scope
+
+- Setting the secret (manual, documented).
+- The parked "snippet compile-check" stretch from the strategy.
+- Authoring the six remaining T1 guides (Phase 0-rest).
+
+## Next (post-initiative)
+
+Phase 0-rest (the six remaining T1 guides), then the strategy's success-metric baselining. The deterministic (Phase 3) + semantic (Phase 4) drift controls now both exist.

--- a/docs/superpowers/specs/2026-06-03-l4-deterministic-ci-phase3-design.md
+++ b/docs/superpowers/specs/2026-06-03-l4-deterministic-ci-phase3-design.md
@@ -1,0 +1,47 @@
+# Phase 3: L4 deterministic CI (anchor check + API-change tripwire)
+
+**Date:** 2026-06-03
+**Phase:** 3 of the redux-kotlin AI integration strategy.
+**Branch:** `l4-ci-phase3` (stacked on `claude-skill-phase2`).
+**Type:** CI + scripts. Adds shell scripts under `scripts/` (detekt-excluded) + one GitHub Actions workflow. No library source changes.
+
+## Why
+
+L4 keeps the knowledge refs honest *deterministically* (no LLM), closing the cheap half of the drift surface before the Phase-4 semantic agent. Two checks:
+1. **Anchor check** — refs cite real things: every `path → symbol` anchor resolves (path exists + symbol present), every cited module name exists in `settings.gradle.kts`, every cited gradle task is real. This is the automated form of the manual sweep dry-run from Phases 0–1.
+2. **API-change tripwire** — any committed `*.api` change in a PR flags "public API changed — knowledge review required" and names the affected modules, so the API-map / refs get re-checked.
+
+## Decisions (recommended, locked)
+
+- **Scripts in `scripts/`** (`check-agent-refs.sh`, `check-api-tripwire.sh`) — bash, runnable locally and in CI; `scripts/` is detekt-excluded so no lint friction. Deterministic, fast (no gradle build needed for the anchor check).
+- **Command verification** is against a **static allowlist** of real root gradle tasks (`build`, `detektAll`, `apiCheck`, `apiDump`, `allTests`, `jvmTest`) rather than invoking gradle — keeps the check fast and hermetic. (Live `./gradlew tasks` verification is a documented stretch, not done here.)
+- **One workflow** `.github/workflows/agent-knowledge.yml`, `on: pull_request: branches: [master]` (matches `pr.yml`), two jobs: `anchor-check` (blocking) and `api-tripwire` (blocking when `*.api` changed unless the PR carries the bypass label `api-reviewed`).
+
+## Deliverables
+
+1. **`scripts/check-agent-refs.sh`** — scans `docs/agent/references/*.md`, `AGENTS.md`, `docs/agent/api-map.md`. For each file:
+   - Extract backtick anchors `` `path → Sym[, Sym]` `` and YAML `derives_from:` / `api_files:` entries.
+   - Verify: each `path` exists; each `Sym` appears in `path` (grep -r); each `api_files` path exists.
+   - Verify cited module tokens matching `:redux-kotlin[-a-z]*` exist in `settings.gradle.kts`.
+   - Verify cited `./gradlew <task>` `<task>` ∈ the static allowlist.
+   - Exit 0 if all resolve; non-zero listing each failure. Skip anchors explicitly marked `*(planned)*`.
+2. **`scripts/check-api-tripwire.sh`** — args: base ref (default `origin/master`). Lists changed `*.api` files vs base; if any, prints the affected module dirs + remediation ("update `docs/agent/api-map.md`; add label `api-reviewed` to ack") and exits non-zero unless `API_REVIEW_OK=1` (the CI job sets this when the bypass label is present).
+3. **`.github/workflows/agent-knowledge.yml`** — `pull_request: [master]`; `anchor-check` job runs script 1; `api-tripwire` job computes the PR base, checks for label `api-reviewed` (via `github` context), sets `API_REVIEW_OK` accordingly, runs script 2.
+
+## Acceptance gate (testable locally)
+
+- `bash scripts/check-agent-refs.sh` exits **0** against the committed refs (feature-slice.md, AGENTS.md, api-map.md). 
+- A **negative test**: temporarily appending a bogus anchor `` `docs/agent/nope.md → Ghost` `` makes it exit non-zero naming that anchor; revert.
+- `bash scripts/check-api-tripwire.sh origin/master` exits **0** on this branch (Phases 0–3 are docs/CI only — no `.api` changed); a negative test (touch a `.api`) trips it; revert.
+- `actionlint` clean if available, else YAML parses; workflow `on`/jobs/steps well-formed.
+- No library `.kt`/`website/`/`examples/` changes.
+
+## Out of scope
+
+- The Phase-4 LLM knowledge-sync agent.
+- Live gradle-task existence verification (static allowlist instead).
+- Wiring into `pr.yml` (standalone workflow; same trigger).
+
+## Next
+
+Phase 4 (knowledge-sync agent) adds the semantic-drift catch on top of these deterministic checks.

--- a/scripts/check-agent-refs.sh
+++ b/scripts/check-agent-refs.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 2
+fail=0
+note() { printf 'ANCHOR-FAIL: %s\n' "$*"; fail=1; }
+ALLOWED=" build detekt detektAll apiCheck apiDump allTests jvmTest test assemble assembleDebug "
+files=(AGENTS.md docs/agent/api-map.md)
+while IFS= read -r f; do files+=("$f"); done < <(find docs/agent/references -name '*.md' ! -name '_template.md' 2>/dev/null | sort)
+for F in "${files[@]}"; do
+  [ -f "$F" ] || { note "missing doc: $F"; continue; }
+  while IFS= read -r line; do
+    case "$line" in *'(planned'*) continue ;; esac
+    while IFS= read -r a; do
+      a="${a#\`}"; a="${a%\`}"; p="${a%% → *}"; syms="${a##* → }"
+      # Only treat as a source anchor if the path looks like a real repo path
+      # (contains a '/'); skip convention/example placeholders.
+      case "$p" in */*) ;; *) continue ;; esac
+      if [ ! -e "$p" ]; then note "$F: path not found: $p"; continue; fi
+      IFS=',' read -ra arr <<< "$syms"
+      for s in "${arr[@]}"; do s="$(printf '%s' "$s" | xargs)"; [ -n "$s" ] || continue
+        grep -rqF -- "$s" "$p" || note "$F: symbol '$s' not found in $p"; done
+    done < <(printf '%s\n' "$line" | grep -oE '`[^`]+ → [^`]+`' || true)
+    while IFS= read -r m; do grep -qF "\"$m\"" settings.gradle.kts || note "$F: module $m not in settings.gradle.kts"
+    done < <(printf '%s\n' "$line" | grep -oE ':redux-kotlin[a-z-]*' | sort -u || true)
+    while IFS= read -r t; do t="${t##*:}"; [ -n "$t" ] || continue; case "$ALLOWED" in *" $t "*) ;; *) note "$F: gradle task '$t' not in allowlist" ;; esac
+    done < <(printf '%s\n' "$line" | grep -oE '\./gradlew [:a-zA-Z-]+' | sed 's#\./gradlew ##' || true)
+  done < "$F"
+  while IFS= read -r p; do p="$(printf '%s' "$p" | xargs)"; [ -n "$p" ] || continue
+    [ -e "$p" ] || note "$F: api_file not found: $p"
+  done < <(awk '/^api_files:/{f=1;next} /^[a-zA-Z_]+:/{f=0} f && /^[[:space:]]*-/{sub(/^[[:space:]]*-[[:space:]]*/,"");print}' "$F")
+done
+[ "$fail" -ne 0 ] && { echo "ANCHOR CHECK FAILED"; exit 1; }
+echo "ANCHOR CHECK OK"

--- a/scripts/check-api-tripwire.sh
+++ b/scripts/check-api-tripwire.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 2
+BASE="${1:-origin/master}"
+changed="$(git diff --name-only "$BASE...HEAD" -- '*.api' 2>/dev/null || true)"
+[ -z "$changed" ] && changed="$(git diff --name-only "$BASE" -- '*.api' 2>/dev/null || true)"
+if [ -z "$changed" ]; then echo "api-tripwire: no .api changes vs $BASE ✓"; exit 0; fi
+echo "api-tripwire: public API changed — knowledge review required."
+printf '%s\n' "$changed" | sed 's#/api/.*##' | sort -u | sed 's/^/  module: /'
+echo "Action: update docs/agent/api-map.md if the surface summary changed, then add PR label 'api-reviewed' to acknowledge."
+[ "${API_REVIEW_OK:-0}" = "1" ] && { echo "api-tripwire: acknowledged (api-reviewed) — passing."; exit 0; }
+exit 1


### PR DESCRIPTION
## What
**Phase 4 (final)** — the semantic half of L4 drift control. An **advisory** GitHub Action that, on PRs touching library `*/src/**`, a committed `**/api/*.api`, or `examples/taskflow/**`, runs Claude to diff the change against the provenance-headed knowledge under `docs/agent/` (using each doc's `derives_from` header to target the review) and posts ONE PR comment naming refs that likely need updating — catching prose/pattern drift the deterministic Phase-3 checks can't see.

- **`.github/workflows/knowledge-sync.yml`** — path-filtered `pull_request` + `workflow_dispatch`; `permissions: contents:read, pull-requests:write`; **secret-guarded** (cleanly skips when `ANTHROPIC_API_KEY` is absent) and **non-blocking** (`continue-on-error`).
- **`docs/agent/knowledge-sync.md`** — what it does, how to enable (add the `ANTHROPIC_API_KEY` secret; pin the action), and how it complements the deterministic checks.

## Verification
- YAML valid; trigger globs resolve (`*/src`, `*/api/*.api`, `examples/taskflow`); secret-guard present; minimal permissions; advisory.
- `scripts/check-agent-refs.sh` → `ANCHOR CHECK OK` (the new doc adds no anchors).
- Not runtime-tested (LLM action) — by design; the doc flags "verify/pin `anthropics/claude-code-action` before relying on it."
- No `.kt`/`website/`/`examples/` source changes.

## Requires (manual, documented)
Repo secret `ANTHROPIC_API_KEY` — cannot be set from a PR. Until added, the job no-ops.

## Stacking
Stacked on `l4-ci-phase3` (#316) → merge #313 → #314 → #315 → #316 → this. Completes the strategy's drift-control pair (deterministic Phase 3 + semantic Phase 4).

Spec: `docs/superpowers/specs/2026-06-03-knowledge-sync-agent-phase4-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
