### PR TITLE
build(agent): single-source assembler for shared knowledge blocks

### DIFF
--- a/.claude/skills/redux-kotlin/SKILL.md
+++ b/.claude/skills/redux-kotlin/SKILL.md
@@ -11,12 +11,14 @@ companion modules on one `Store<S>` contract. Recommended app organization is **
 
 ## Always-apply rules (full text → `../../../examples/taskflow/ARCHITECTURE.md` §17)
 
-- **Rule C — Render isolation.** No composable reads a model wholesale; bind the narrowest slice via `selectorState`/`fieldStateOf`, wrapped in `key(...)`. Derivation lives in pure functions/reducers.
-- **Rule D — Identity split.** A profile edit fans to the root account directory, per-account `CollaboratorsModel`, and `SessionModel` — never duplicate identity inconsistently.
-- **Rule E — Off-main effects.** Effects originate only in middleware and run off-main; dispatch marshals back to main via `NotificationContext`. Per-feature handlers compose into one `effectsMiddleware`.
-- **Rule F — Delta-only status.** Emit status only on a real change.
-- **Rule G — Mint at the edge.** Ids/timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
-- **Rule H — Single inset point.** Window insets applied once at the shell root.
+<!-- assemble:rules:start -->
+- **Rule C — Render isolation.** No composable reads a model (board/cards/columns) wholesale; every leaf binds the narrowest slice via `selectorState`/`fieldStateOf` and is wrapped in `key(...)`; list derivation lives in pure functions/reducers.
+- **Rule D — Identity split.** A profile edit fans `EditProfile` to the root account directory, the per-account `CollaboratorsModel`, and `SessionModel` (bio) — identity is never duplicated inconsistently.
+- **Rule E — Off-main effects.** Effects originate only in middleware and run off-main; dispatch marshals back to main via `NotificationContext` (no explicit main hop). Per-feature handlers compose into one `effectsMiddleware`.
+- **Rule F — Delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
+- **Rule G — Mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
+- **Rule H — Single inset point.** Window insets are applied once at the shell root.
+<!-- assemble:rules:end -->
 
 ## Decision routing
 

--- a/.github/workflows/assemble-check.yml
+++ b/.github/workflows/assemble-check.yml
@@ -1,0 +1,18 @@
+name: Assemble check
+on:
+  pull_request:
+    branches: [master]
+permissions:
+  contents: read
+concurrency:
+  cancel-in-progress: true
+  group: assemble-check-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+jobs:
+  assemble-check:
+    name: Agent knowledge is assembled from fragments
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify assembled regions match fragments
+        run: bash scripts/assemble-agent-knowledge.sh --check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,15 +15,17 @@ same single `Store<S>` contract. Take the core, add only the companions you need
 
 The nine published core modules (each "use for X"):
 
+<!-- assemble:modules:start -->
 - `redux-kotlin` — core contract: `Store`/`TypedStore`, `Reducer`, `Middleware`, `createStore`, `applyMiddleware`, `combineReducers`, `compose`.
 - `redux-kotlin-threadsafe` — `createThreadSafeStore` (atomicfu-locked store wrapper).
-- `redux-kotlin-concurrent` — `createConcurrentStore` (lock-free reads + reentrant-lock-serialized writes).
+- `redux-kotlin-concurrent` — `createConcurrentStore` (lock-free reads + reentrant-lock-serialized writes; the CallerSerialized strategy).
 - `redux-kotlin-granular` — `subscribeTo` / `subscribeFields` field-level subscriptions.
-- `redux-kotlin-registry` — `StoreRegistry<K,S>` / `TypedStoreRegistry` keyed multi-store container.
+- `redux-kotlin-registry` — `StoreRegistry` / `TypedStoreRegistry` keyed multi-store container.
 - `redux-kotlin-multimodel` — `ModelState` typesafe heterogeneous model bag.
 - `redux-kotlin-multimodel-granular` — granular subscriptions for `ModelState`.
 - `redux-kotlin-compose` — Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`).
 - `redux-kotlin-compose-multimodel` — Compose bindings for `ModelState`.
+<!-- assemble:modules:end -->
 
 More modules exist (routing/bundle/bom/devtools/codegen) → see `docs/agent/api-map.md`.
 
@@ -45,12 +47,14 @@ does not auto-correct. Full gate detail → `CLAUDE.md`.
 (There are no named Rules A or B.) Faithful one-liners from
 `examples/taskflow/ARCHITECTURE.md` §17:
 
-- **Rule C — render isolation.** No composable reads a slot wholesale; each leaf binds the narrowest slice via `selectorState`/`fieldStateOf`; list derivation lives in pure functions/reducers.
-- **Rule D — identity split.** A profile edit fans to the root account directory, the per-account model, and the session model so identity is never duplicated inconsistently.
-- **Rule E — off-main effects.** All repository/sync work runs off-main; dispatch marshals notifications back to main via `NotificationContext` (no explicit main hop in effects).
-- **Rule F — delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
-- **Rule G — mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
-- **Rule H — single inset point.** Window insets are applied once at the shell root.
+<!-- assemble:rules:start -->
+- **Rule C — Render isolation.** No composable reads a model (board/cards/columns) wholesale; every leaf binds the narrowest slice via `selectorState`/`fieldStateOf` and is wrapped in `key(...)`; list derivation lives in pure functions/reducers.
+- **Rule D — Identity split.** A profile edit fans `EditProfile` to the root account directory, the per-account `CollaboratorsModel`, and `SessionModel` (bio) — identity is never duplicated inconsistently.
+- **Rule E — Off-main effects.** Effects originate only in middleware and run off-main; dispatch marshals back to main via `NotificationContext` (no explicit main hop). Per-feature handlers compose into one `effectsMiddleware`.
+- **Rule F — Delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
+- **Rule G — Mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
+- **Rule H — Single inset point.** Window insets are applied once at the shell root.
+<!-- assemble:rules:end -->
 
 Full text → `examples/taskflow/ARCHITECTURE.md`.
 

--- a/docs/agent/_fragments/modules.md
+++ b/docs/agent/_fragments/modules.md
@@ -1,0 +1,9 @@
+- `redux-kotlin` — core contract: `Store`/`TypedStore`, `Reducer`, `Middleware`, `createStore`, `applyMiddleware`, `combineReducers`, `compose`.
+- `redux-kotlin-threadsafe` — `createThreadSafeStore` (atomicfu-locked store wrapper).
+- `redux-kotlin-concurrent` — `createConcurrentStore` (lock-free reads + reentrant-lock-serialized writes; the CallerSerialized strategy).
+- `redux-kotlin-granular` — `subscribeTo` / `subscribeFields` field-level subscriptions.
+- `redux-kotlin-registry` — `StoreRegistry` / `TypedStoreRegistry` keyed multi-store container.
+- `redux-kotlin-multimodel` — `ModelState` typesafe heterogeneous model bag.
+- `redux-kotlin-multimodel-granular` — granular subscriptions for `ModelState`.
+- `redux-kotlin-compose` — Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`).
+- `redux-kotlin-compose-multimodel` — Compose bindings for `ModelState`.

--- a/docs/agent/_fragments/rules.md
+++ b/docs/agent/_fragments/rules.md
@@ -1,0 +1,6 @@
+- **Rule C — Render isolation.** No composable reads a model (board/cards/columns) wholesale; every leaf binds the narrowest slice via `selectorState`/`fieldStateOf` and is wrapped in `key(...)`; list derivation lives in pure functions/reducers.
+- **Rule D — Identity split.** A profile edit fans `EditProfile` to the root account directory, the per-account `CollaboratorsModel`, and `SessionModel` (bio) — identity is never duplicated inconsistently.
+- **Rule E — Off-main effects.** Effects originate only in middleware and run off-main; dispatch marshals back to main via `NotificationContext` (no explicit main hop). Per-feature handlers compose into one `effectsMiddleware`.
+- **Rule F — Delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
+- **Rule G — Mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
+- **Rule H — Single inset point.** Window insets are applied once at the shell root.

--- a/docs/agent/references/_template.md
+++ b/docs/agent/references/_template.md
@@ -30,6 +30,7 @@ Prose explains the *why* and the *rule*. Every source reference uses the anchor 
 - The checker also verifies cited `:redux-kotlin*` **module names** exist in `settings.gradle.kts`
   and that cited `./gradlew <task>` names are in its allowlist.
 - Lines containing `(planned` are skipped (so you can point at not-yet-written guides).
+- Shared blocks (Rules C–H, module map) are single-sourced in `docs/agent/_fragments/` and injected into `AGENTS.md`/`SKILL.md` by `scripts/assemble-agent-knowledge.sh` — edit the fragment, then re-run the assembler (CI `assemble-check` enforces it).
 
 ## See also
 

--- a/docs/superpowers/plans/2026-06-03-single-source-assembler.md
+++ b/docs/superpowers/plans/2026-06-03-single-source-assembler.md
@@ -1,0 +1,185 @@
+# Single-Source Assembler — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Single-source the duplicated Rules C–H + module map into `docs/agent/_fragments/`, assemble them into `AGENTS.md`/`SKILL.md` via marker injection, and gate drift in CI — implementing the strategy's "author once, assemble" and fixing the existing Rule-C drift.
+
+**Architecture:** Two fragment files + a bash assembler with `--check` + marker regions in the two consumer docs + a new `assemble-check.yml` workflow. No library/source changes. TDD: positive (assemble is idempotent; `--check` clean) + negative (diverge → `--check` fails).
+
+**Tech Stack:** bash + awk, GitHub Actions YAML, markdown.
+
+---
+
+## Task 1: Author the fragments
+
+**Files:** Create `docs/agent/_fragments/rules.md`, `docs/agent/_fragments/modules.md`
+
+- [ ] **Step 1:** `docs/agent/_fragments/rules.md` — canonical Rules C–H (faithful to `examples/taskflow/ARCHITECTURE.md` §17; **Rule C includes `key(...)`**). Bullets only, no header (drops into each doc's existing section):
+```markdown
+- **Rule C — Render isolation.** No composable reads a model (board/cards/columns) wholesale; every leaf binds the narrowest slice via `selectorState`/`fieldStateOf` and is wrapped in `key(...)`; list derivation lives in pure functions/reducers.
+- **Rule D — Identity split.** A profile edit fans `EditProfile` to the root account directory, the per-account `CollaboratorsModel`, and `SessionModel` (bio) — identity is never duplicated inconsistently.
+- **Rule E — Off-main effects.** Effects originate only in middleware and run off-main; dispatch marshals back to main via `NotificationContext` (no explicit main hop). Per-feature handlers compose into one `effectsMiddleware`.
+- **Rule F — Delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
+- **Rule G — Mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
+- **Rule H — Single inset point.** Window insets are applied once at the shell root.
+```
+- [ ] **Step 2:** `docs/agent/_fragments/modules.md` — canonical 9-core-module map (bullets only):
+```markdown
+- `redux-kotlin` — core contract: `Store`/`TypedStore`, `Reducer`, `Middleware`, `createStore`, `applyMiddleware`, `combineReducers`, `compose`.
+- `redux-kotlin-threadsafe` — `createThreadSafeStore` (atomicfu-locked store wrapper).
+- `redux-kotlin-concurrent` — `createConcurrentStore` (lock-free reads + reentrant-lock-serialized writes; the CallerSerialized strategy).
+- `redux-kotlin-granular` — `subscribeTo` / `subscribeFields` field-level subscriptions.
+- `redux-kotlin-registry` — `StoreRegistry` / `TypedStoreRegistry` keyed multi-store container.
+- `redux-kotlin-multimodel` — `ModelState` typesafe heterogeneous model bag.
+- `redux-kotlin-multimodel-granular` — granular subscriptions for `ModelState`.
+- `redux-kotlin-compose` — Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`).
+- `redux-kotlin-compose-multimodel` — Compose bindings for `ModelState`.
+```
+- [ ] **Step 3:** Commit: `git add docs/agent/_fragments && git commit -m "docs(agent): add single-source fragments (rules, module map)"`
+
+---
+
+## Task 2: The assembler script
+
+**Files:** Create `scripts/assemble-agent-knowledge.sh` (chmod +x)
+
+- [ ] **Step 1:** Write:
+```bash
+#!/usr/bin/env bash
+# Single-source assembler: inject docs/agent/_fragments/* into marker regions of the agent surfaces.
+# Default: rewrite in place. --check: fail (non-zero) if any region is out of sync with its fragment.
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 2
+CHECK=0; [ "${1:-}" = "--check" ] && CHECK=1
+FRAG="docs/agent/_fragments"
+# target|marker|fragment
+MAP=(
+  "AGENTS.md|rules|$FRAG/rules.md"
+  ".claude/skills/redux-kotlin/SKILL.md|rules|$FRAG/rules.md"
+  "AGENTS.md|modules|$FRAG/modules.md"
+)
+inject() { # stdin=content, $1=marker, $2=fragfile -> stdout
+  awk -v s="<!-- assemble:$1:start -->" -v e="<!-- assemble:$1:end -->" -v f="$2" '
+    $0==s { print; while ((getline l < f) > 0) print l; close(f); skip=1; next }
+    $0==e { skip=0 }
+    !skip { print }
+  '
+}
+targets=$(printf '%s\n' "${MAP[@]}" | cut -d'|' -f1 | sort -u)
+rc=0
+for t in $targets; do
+  [ -f "$t" ] || { echo "ASSEMBLE-FAIL: missing target $t"; rc=1; continue; }
+  rendered="$(cat "$t")"
+  for entry in "${MAP[@]}"; do
+    IFS='|' read -r mt mk mf <<< "$entry"
+    [ "$mt" = "$t" ] || continue
+    [ -f "$mf" ] || { echo "ASSEMBLE-FAIL: missing fragment $mf"; rc=1; continue; }
+    grep -qF "<!-- assemble:$mk:start -->" "$t" || { echo "ASSEMBLE-FAIL: $t missing marker '$mk'"; rc=1; continue; }
+    rendered="$(printf '%s\n' "$rendered" | inject "$mk" "$mf")"
+  done
+  if [ "$CHECK" -eq 1 ]; then
+    if ! diff -q <(printf '%s\n' "$rendered") "$t" >/dev/null; then
+      echo "ASSEMBLE-FAIL: $t is out of sync with its fragment(s) — run scripts/assemble-agent-knowledge.sh"; rc=1
+    fi
+  else
+    printf '%s\n' "$rendered" > "$t"
+  fi
+done
+[ "$rc" -eq 0 ] && { [ "$CHECK" -eq 1 ] && echo "ASSEMBLE CHECK OK" || echo "ASSEMBLED"; } || echo "ASSEMBLE FAILED"
+exit "$rc"
+```
+- [ ] **Step 2:** `chmod +x scripts/assemble-agent-knowledge.sh`
+- [ ] **Step 3:** Commit: `git add scripts/assemble-agent-knowledge.sh && git commit -m "build(agent): add single-source assembler (--check)"`
+
+---
+
+## Task 3: Retrofit AGENTS.md + SKILL.md with markers
+
+**Files:** Modify `AGENTS.md`, `.claude/skills/redux-kotlin/SKILL.md`
+
+- [ ] **Step 1:** In `AGENTS.md`, replace the **Design rules** bullet list (the `- **Rule C …**` … `- **Rule H …**` lines under `## Design rules`) with marker lines:
+```
+<!-- assemble:rules:start -->
+<!-- assemble:rules:end -->
+```
+Keep the surrounding `## Design rules` heading and any pointer line ("full text → …ARCHITECTURE.md §17").
+- [ ] **Step 2:** In `AGENTS.md`, replace the **Module map** bullet list (the 9 `- \`redux-kotlin…\`` lines under `## Module map`) with:
+```
+<!-- assemble:modules:start -->
+<!-- assemble:modules:end -->
+```
+Keep the heading + any "more modules exist → api-map" pointer line.
+- [ ] **Step 3:** In `SKILL.md`, replace the **Always-apply rules** bullet list (the `- **Rule C …**`…`- **Rule H …**` lines) with:
+```
+<!-- assemble:rules:start -->
+<!-- assemble:rules:end -->
+```
+Keep the `## Always-apply rules (full text → …)` heading.
+- [ ] **Step 4:** Run the assembler to fill the regions: `bash scripts/assemble-agent-knowledge.sh` → prints `ASSEMBLED`. Then `git diff` to confirm the regions now hold the fragment content (and AGENTS.md Rule C now includes `key(...)`, fixing the drift).
+- [ ] **Step 5 (idempotency + anchor):** `bash scripts/assemble-agent-knowledge.sh` again → no further diff; `bash scripts/assemble-agent-knowledge.sh --check` → `ASSEMBLE CHECK OK`; `bash scripts/check-agent-refs.sh` → `ANCHOR CHECK OK`; `wc -l AGENTS.md` still tight (≤ ~180).
+- [ ] **Step 6:** Commit: `git add AGENTS.md .claude/skills/redux-kotlin/SKILL.md && git commit -m "docs(agent): assemble rules + module map from fragments (single-source)"`
+
+---
+
+## Task 4: CI check + template note
+
+**Files:** Create `.github/workflows/assemble-check.yml`; modify `docs/agent/references/_template.md`
+
+- [ ] **Step 1:** Write `.github/workflows/assemble-check.yml`:
+```yaml
+name: Assemble check
+on:
+  pull_request:
+    branches: [master]
+permissions:
+  contents: read
+concurrency:
+  cancel-in-progress: true
+  group: assemble-check-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+jobs:
+  assemble-check:
+    name: Agent knowledge is assembled from fragments
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify assembled regions match fragments
+        run: bash scripts/assemble-agent-knowledge.sh --check
+```
+- [ ] **Step 2:** Validate: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/assemble-check.yml')); print('yaml ok')"`.
+- [ ] **Step 3:** In `docs/agent/references/_template.md`, add one line (near the anchor-rules note): "Shared blocks (Rules C–H, module map) are single-sourced in `docs/agent/_fragments/` and injected into `AGENTS.md`/`SKILL.md` by `scripts/assemble-agent-knowledge.sh` — edit the fragment, then re-run the assembler (CI `assemble-check` enforces it)."
+- [ ] **Step 4:** Commit: `git add .github/workflows/assemble-check.yml docs/agent/references/_template.md && git commit -m "ci(agent): enforce assembled-from-fragments + document it"`
+
+---
+
+## Task 5: Acceptance (TDD negative test) + PR
+
+- [ ] **Step 1 (positive):** `bash scripts/assemble-agent-knowledge.sh --check` → `ASSEMBLE CHECK OK` (exit 0); `bash scripts/check-agent-refs.sh` → `ANCHOR CHECK OK`.
+- [ ] **Step 2 (negative):** prove `--check` catches drift:
+```bash
+printf '\n- **Rule Z — bogus.**\n' >> docs/agent/_fragments/rules.md
+bash scripts/assemble-agent-knowledge.sh --check; echo "exit=$?"   # expect ASSEMBLE-FAIL (AGENTS.md + SKILL.md) + exit=1
+git checkout -- docs/agent/_fragments/rules.md
+bash scripts/assemble-agent-knowledge.sh --check                   # expect ASSEMBLE CHECK OK
+```
+Also confirm editing a generated region trips it:
+```bash
+sed -i.bak 's/Rule H — Single inset point/Rule H — TAMPERED/' AGENTS.md && rm -f AGENTS.md.bak
+bash scripts/assemble-agent-knowledge.sh --check; echo "exit=$?"   # expect fail
+bash scripts/assemble-agent-knowledge.sh                           # re-sync
+bash scripts/assemble-agent-knowledge.sh --check                   # OK
+git diff --stat
+```
+- [ ] **Step 3:** Verify drift fixed: `grep -c 'key(' AGENTS.md` ≥ 1 (Rule C now has `key(...)`); the rules region in AGENTS.md and SKILL.md are byte-identical (extract between markers and `diff`).
+- [ ] **Step 4:** No-collateral: `git diff --name-only knowledge-sync-phase4...HEAD` → only `docs/agent/_fragments/*`, `scripts/assemble-agent-knowledge.sh`, `AGENTS.md`, `.claude/skills/redux-kotlin/SKILL.md`, `.github/workflows/assemble-check.yml`, `docs/agent/references/_template.md`, `docs/superpowers/`. No `.kt`/`website/`/`examples/`/`agent-knowledge.yml`.
+- [ ] **Step 5:** `git push -u origin single-source-assembler`
+- [ ] **Step 6:** `gh pr create --base knowledge-sync-phase4 --head single-source-assembler` — title `build(agent): single-source assembler for shared knowledge blocks`; body: implements §5 "author once, assemble", resolves Q6, fixes the Rule-C `key(...)` drift, the `--check` CI gate + negative test, stacked merge-order note, link the spec.
+
+---
+
+## Self-review notes
+- Spec coverage: fragments (T1), assembler (T2), retrofit (T3), CI+template (T4), acceptance+PR (T5).
+- Separate `assemble-check.yml` (not `agent-knowledge.yml`) → no collision with the #7 fix on that file.
+- Idempotent injection; `--check` is the drift gate; negative tests prove it fires for both fragment edits and region tampering.
+- Scope limited to rules + module map (the always-loaded duplicates); api-map retrofit documented as future.
+- Anchor checker still passes (fragments live in `_fragments/`, not scanned; injected text has no `path → symbol` anchors).

--- a/docs/superpowers/specs/2026-06-03-single-source-assembler-design.md
+++ b/docs/superpowers/specs/2026-06-03-single-source-assembler-design.md
@@ -1,0 +1,57 @@
+# Single-source assembler for agent knowledge
+
+**Date:** 2026-06-03
+**Sub-project:** Post-review #1 (resolves strategy open-question Q6 + the §5 L1 "author once, assemble" principle).
+**Branch:** `single-source-assembler` (stacked on `knowledge-sync-phase4`).
+**Type:** Scripts + CI + doc retrofit. No library source changes.
+
+## Why
+
+The review found the strategy's central single-source discipline was dropped: the **Rules card (C–H)** is hand-copied into both `AGENTS.md` and `SKILL.md`, and the **module map** lives in `AGENTS.md`. They have **already drifted** (AGENTS.md's Rule C omits the `key(...)` requirement that SKILL.md and ARCHITECTURE §17 state; wordings differ). The deterministic anchor checker validates paths/symbols, not prose, so this drift is unguarded. Fix: author each shared block **once** as a fragment and *assemble* it into the consuming surfaces, with a CI check that fails on drift.
+
+## Decisions (recommended, locked)
+
+- **Mechanism: marker-injection into checked-in files.** `AGENTS.md`/`SKILL.md` stay human-readable and directly committed (tools read them as-is); only the shared regions are generated, delimited by HTML-comment markers. Preferred over full-file generation (keeps files editable/reviewable) and over include-directives (agents/tools don't process includes).
+- **Fragments** in `docs/agent/_fragments/` (leading `_` groups them; the anchor checker already only scans `references/*.md`+`AGENTS.md`+`api-map.md`, not `_fragments/`).
+- **Scope (focused):** single-source the two genuinely-duplicated, always-loaded surfaces — **Rules C–H** (→ `AGENTS.md` + `SKILL.md`) and the **module map** (→ `AGENTS.md`). `api-map.md` stays the `.api` index (T2, on-demand) and is documented as a future fragment-consumer, not retrofitted now (its table format + non-core rows make injection low-value). `CLAUDE.md` is the maintainer doc — untouched.
+- **Canonical content:** the Rules fragment is the corrected, faithful-to-ARCHITECTURE-§17 version (Rule C **includes** `key(...)`), ending the existing drift.
+- **CI: a new workflow** `.github/workflows/assemble-check.yml` (separate from `agent-knowledge.yml` to avoid colliding with the in-flight #7 fix on that file). Runs the assembler in `--check` mode.
+
+## Deliverables
+
+1. **`docs/agent/_fragments/rules.md`** — the canonical Rules C–H bullet list (faithful to `examples/taskflow/ARCHITECTURE.md` §17; C includes `key(...)`). Just the bullets (no header) so it drops into each surface's existing section.
+2. **`docs/agent/_fragments/modules.md`** — the canonical 9-core-module map (one `- \`module\` — use for X` line each).
+3. **`scripts/assemble-agent-knowledge.sh`** — injects each fragment into marker-delimited regions of its target(s):
+   - `rules` → `AGENTS.md` + `.claude/skills/redux-kotlin/SKILL.md`
+   - `modules` → `AGENTS.md`
+   - Default mode rewrites the regions in place; `--check` mode regenerates to a temp copy and `diff`s — exit non-zero (listing the stale file) if any target's region differs from its fragment. Idempotent (running twice = no change).
+4. **Marker retrofit** of `AGENTS.md` (Design-rules region + Module-map region) and `SKILL.md` (Always-apply-rules region) with `<!-- assemble:rules:start -->`…`<!-- assemble:rules:end -->` / `:modules:` markers; the region bodies become the fragment content (removing the hand-copied duplicates).
+5. **`.github/workflows/assemble-check.yml`** — `pull_request: [master]`; `permissions: contents: read`; runs `bash scripts/assemble-agent-knowledge.sh --check`.
+6. Brief note in `docs/agent/references/_template.md` (or a one-line README mention): shared blocks (rules, module map) are single-sourced in `docs/agent/_fragments/`; edit there, then run `scripts/assemble-agent-knowledge.sh`.
+
+## Constraints / invariants
+
+- After assembly, `scripts/check-agent-refs.sh` must still pass (`ANCHOR CHECK OK`) — the injected rules/module text contains no `path → symbol` anchors that would newly fail.
+- `AGENTS.md` stays token-tight (the change removes duplication, doesn't add prose).
+- The assembler must be deterministic + idempotent; `--check` is clean immediately after a default run.
+- Markers must not break markdown rendering (HTML comments are invisible).
+- No change to `.github/workflows/agent-knowledge.yml` (avoid the #7-fix collision).
+
+## Acceptance gate (testable locally)
+
+- `bash scripts/assemble-agent-knowledge.sh` then `git diff` — regions match fragments; running again is a no-op.
+- `bash scripts/assemble-agent-knowledge.sh --check` exits **0** on the committed state.
+- **Negative test:** edit a fragment (or a generated region) so they diverge → `--check` exits non-zero naming the stale file; revert.
+- `bash scripts/check-agent-refs.sh` → `ANCHOR CHECK OK`.
+- Rules C–H in the assembled `AGENTS.md` now include `key(...)` (drift fixed); `AGENTS.md` and `SKILL.md` rules are byte-identical in the generated region.
+- YAML valid; no `.kt`/`website/`/`examples/`/`agent-knowledge.yml` changes.
+
+## Out of scope
+
+- Retrofitting `api-map.md` to consume `modules.md` (documented as future).
+- Any change to `CLAUDE.md`.
+- The six planned T1 guides (0-rest).
+
+## Resolves
+
+Strategy open-question **Q6** (AGENTS.md ↔ CLAUDE.md / single-source): recorded resolution — `CLAUDE.md` stays the maintainer doc; agent surfaces are single-sourced from `docs/agent/_fragments/` and assembled. The §5 L1 "author once, assemble; do not maintain parallel copies" discipline is now implemented for the shared blocks.

--- a/scripts/assemble-agent-knowledge.sh
+++ b/scripts/assemble-agent-knowledge.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 2
+CHECK=0; [ "${1:-}" = "--check" ] && CHECK=1
+FRAG="docs/agent/_fragments"
+MAP=(
+  "AGENTS.md|rules|$FRAG/rules.md"
+  ".claude/skills/redux-kotlin/SKILL.md|rules|$FRAG/rules.md"
+  "AGENTS.md|modules|$FRAG/modules.md"
+)
+inject() { # stdin=content, $1=marker, $2=fragfile -> stdout
+  awk -v s="<!-- assemble:$1:start -->" -v e="<!-- assemble:$1:end -->" -v f="$2" '
+    $0==s { print; while ((getline l < f) > 0) print l; close(f); skip=1; next }
+    $0==e { skip=0 }
+    !skip { print }
+  '
+}
+targets=$(printf '%s\n' "${MAP[@]}" | cut -d'|' -f1 | sort -u)
+rc=0
+for t in $targets; do
+  [ -f "$t" ] || { echo "ASSEMBLE-FAIL: missing target $t"; rc=1; continue; }
+  rendered="$(cat "$t")"
+  for entry in "${MAP[@]}"; do
+    IFS='|' read -r mt mk mf <<< "$entry"
+    [ "$mt" = "$t" ] || continue
+    [ -f "$mf" ] || { echo "ASSEMBLE-FAIL: missing fragment $mf"; rc=1; continue; }
+    grep -qF "<!-- assemble:$mk:start -->" "$t" || { echo "ASSEMBLE-FAIL: $t missing marker '$mk'"; rc=1; continue; }
+    rendered="$(printf '%s\n' "$rendered" | inject "$mk" "$mf")"
+  done
+  if [ "$CHECK" -eq 1 ]; then
+    if ! diff -q <(printf '%s\n' "$rendered") "$t" >/dev/null; then
+      echo "ASSEMBLE-FAIL: $t out of sync with fragment(s) — run scripts/assemble-agent-knowledge.sh"; rc=1
+    fi
+  else
+    printf '%s\n' "$rendered" > "$t"
+  fi
+done
+[ "$rc" -eq 0 ] && { [ "$CHECK" -eq 1 ] && echo "ASSEMBLE CHECK OK" || echo "ASSEMBLED"; } || echo "ASSEMBLE FAILED"
+exit "$rc"


### PR DESCRIPTION
## What
Implements the strategy's §5 L1 **"author once, assemble"** discipline (and formally resolves open-question **Q6**), which the review found had been dropped — the Rules card (C–H) and module map were hand-copied into `AGENTS.md` + `SKILL.md` and had **already drifted** (AGENTS.md's Rule C was missing the `key(...)` requirement).

- **`docs/agent/_fragments/{rules.md,modules.md}`** — the single source for the shared blocks.
- **`scripts/assemble-agent-knowledge.sh`** — marker-injects fragments into `AGENTS.md` + `SKILL.md`; `--check` mode fails on drift; idempotent.
- **`AGENTS.md` / `SKILL.md`** — shared regions now generated between `<!-- assemble:… -->` markers (no more hand-copies); the Rule-C `key(...)` drift is fixed and the two surfaces' rules are now byte-identical.
- **`.github/workflows/assemble-check.yml`** — CI gate (`--check`); separate from `agent-knowledge.yml` to avoid colliding with the in-flight #7 fix.

## Verification (TDD)
- positive: `assemble --check` → `ASSEMBLE CHECK OK`; `check-agent-refs.sh` → `ANCHOR CHECK OK`.
- negative (fragment edit): `--check` flags both AGENTS.md + SKILL.md, exit 1.
- negative (region tamper): `--check` flags it; re-assemble re-syncs.
- Rule C now includes `key(...)`; AGENTS.md/SKILL.md rules regions byte-identical; AGENTS.md 73 lines; idempotent.
- Scope: rules + module map only; `api-map.md` documented as a future fragment-consumer. `CLAUDE.md`/`agent-knowledge.yml` untouched.

## Stacking
Top of the stack — based on `knowledge-sync-phase4` (#317). Merge order #313→#314→#315→#316→#317→this.

Spec: `docs/superpowers/specs/2026-06-03-single-source-assembler-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
