### PR TITLE
feat(agent): knowledge-sync agent + single-source assembler (Phases 4 + review)

### DIFF
--- a/.claude/skills/redux-kotlin/SKILL.md
+++ b/.claude/skills/redux-kotlin/SKILL.md
@@ -11,12 +11,14 @@ companion modules on one `Store<S>` contract. Recommended app organization is **
 
 ## Always-apply rules (full text → `../../../examples/taskflow/ARCHITECTURE.md` §17)
 
-- **Rule C — Render isolation.** No composable reads a model wholesale; bind the narrowest slice via `selectorState`/`fieldStateOf`, wrapped in `key(...)`. Derivation lives in pure functions/reducers.
-- **Rule D — Identity split.** A profile edit fans to the root account directory, per-account `CollaboratorsModel`, and `SessionModel` — never duplicate identity inconsistently.
-- **Rule E — Off-main effects.** Effects originate only in middleware and run off-main; dispatch marshals back to main via `NotificationContext`. Per-feature handlers compose into one `effectsMiddleware`.
-- **Rule F — Delta-only status.** Emit status only on a real change.
-- **Rule G — Mint at the edge.** Ids/timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
-- **Rule H — Single inset point.** Window insets applied once at the shell root.
+<!-- assemble:rules:start -->
+- **Rule C — Render isolation.** No composable reads a model (board/cards/columns) wholesale; every leaf binds the narrowest slice via `selectorState`/`fieldStateOf` and is wrapped in `key(...)`; list derivation lives in pure functions/reducers.
+- **Rule D — Identity split.** A profile edit fans `EditProfile` to the root account directory, the per-account `CollaboratorsModel`, and `SessionModel` (bio) — identity is never duplicated inconsistently.
+- **Rule E — Off-main effects.** Effects originate only in middleware and run off-main; dispatch marshals back to main via `NotificationContext` (no explicit main hop). Per-feature handlers compose into one `effectsMiddleware`.
+- **Rule F — Delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
+- **Rule G — Mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
+- **Rule H — Single inset point.** Window insets are applied once at the shell root.
+<!-- assemble:rules:end -->
 
 ## Decision routing
 

--- a/.github/workflows/assemble-check.yml
+++ b/.github/workflows/assemble-check.yml
@@ -1,0 +1,18 @@
+name: Assemble check
+on:
+  pull_request:
+    branches: [master]
+permissions:
+  contents: read
+concurrency:
+  cancel-in-progress: true
+  group: assemble-check-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+jobs:
+  assemble-check:
+    name: Agent knowledge is assembled from fragments
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify assembled regions match fragments
+        run: bash scripts/assemble-agent-knowledge.sh --check

--- a/.github/workflows/knowledge-sync.yml
+++ b/.github/workflows/knowledge-sync.yml
@@ -1,0 +1,53 @@
+name: Knowledge sync
+on:
+  pull_request:
+    paths:
+      - 'redux-kotlin*/**/src/**'
+      - '**/api/*.api'
+      - 'examples/taskflow/**'
+  workflow_dispatch:
+permissions:
+  contents: read
+  pull-requests: write
+concurrency:
+  cancel-in-progress: true
+  group: knowledge-sync-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+jobs:
+  sync:
+    name: Knowledge drift review
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Gate on API key presence
+        id: gate
+        run: echo "enabled=${{ secrets.ANTHROPIC_API_KEY != '' }}" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Claude knowledge-drift review
+        if: steps.gate.outputs.enabled == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are the redux-kotlin knowledge-sync reviewer. This PR changed library source, a committed
+            `.api` dump, and/or `examples/taskflow` (the canonical reference app).
+
+            The agent knowledge lives under `docs/agent/`:
+            - `docs/agent/references/*.md` — T1 per-concern guides; each has a YAML `derives_from:` header
+              listing the `path → Symbol` sources it paraphrases.
+            - `AGENTS.md` — the T0 index (modules, commands, Rules C–H, layout).
+            - `docs/agent/api-map.md` — module → `.api` map.
+
+            Do this:
+            1. Read the PR diff (changed files).
+            2. For each knowledge doc, read its `derives_from` provenance; a doc is IN SCOPE if any changed
+               file matches one of its `derives_from` paths (or it documents a changed module / Rule).
+            3. For each in-scope doc, judge whether the change makes its prose, patterns, citations, or rule
+               statements stale — focus on SEMANTIC drift (deterministic anchor/API checks run separately).
+            4. Post ONE concise PR comment: a bullet per doc needing an update with the specific reason, or
+               exactly "No knowledge drift detected." Do not modify files. Do not restate the rules.
+            Keep it short and high-signal. Cite `path → Symbol` for any claim.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,15 +15,17 @@ same single `Store<S>` contract. Take the core, add only the companions you need
 
 The nine published core modules (each "use for X"):
 
+<!-- assemble:modules:start -->
 - `redux-kotlin` — core contract: `Store`/`TypedStore`, `Reducer`, `Middleware`, `createStore`, `applyMiddleware`, `combineReducers`, `compose`.
 - `redux-kotlin-threadsafe` — `createThreadSafeStore` (atomicfu-locked store wrapper).
-- `redux-kotlin-concurrent` — `createConcurrentStore` (lock-free reads + reentrant-lock-serialized writes).
+- `redux-kotlin-concurrent` — `createConcurrentStore` (lock-free reads + reentrant-lock-serialized writes; the CallerSerialized strategy).
 - `redux-kotlin-granular` — `subscribeTo` / `subscribeFields` field-level subscriptions.
-- `redux-kotlin-registry` — `StoreRegistry<K,S>` / `TypedStoreRegistry` keyed multi-store container.
+- `redux-kotlin-registry` — `StoreRegistry` / `TypedStoreRegistry` keyed multi-store container.
 - `redux-kotlin-multimodel` — `ModelState` typesafe heterogeneous model bag.
 - `redux-kotlin-multimodel-granular` — granular subscriptions for `ModelState`.
 - `redux-kotlin-compose` — Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`).
 - `redux-kotlin-compose-multimodel` — Compose bindings for `ModelState`.
+<!-- assemble:modules:end -->
 
 More modules exist (routing/bundle/bom/devtools/codegen) → see `docs/agent/api-map.md`.
 
@@ -45,12 +47,14 @@ does not auto-correct. Full gate detail → `CLAUDE.md`.
 (There are no named Rules A or B.) Faithful one-liners from
 `examples/taskflow/ARCHITECTURE.md` §17:
 
-- **Rule C — render isolation.** No composable reads a slot wholesale; each leaf binds the narrowest slice via `selectorState`/`fieldStateOf`; list derivation lives in pure functions/reducers.
-- **Rule D — identity split.** A profile edit fans to the root account directory, the per-account model, and the session model so identity is never duplicated inconsistently.
-- **Rule E — off-main effects.** All repository/sync work runs off-main; dispatch marshals notifications back to main via `NotificationContext` (no explicit main hop in effects).
-- **Rule F — delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
-- **Rule G — mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
-- **Rule H — single inset point.** Window insets are applied once at the shell root.
+<!-- assemble:rules:start -->
+- **Rule C — Render isolation.** No composable reads a model (board/cards/columns) wholesale; every leaf binds the narrowest slice via `selectorState`/`fieldStateOf` and is wrapped in `key(...)`; list derivation lives in pure functions/reducers.
+- **Rule D — Identity split.** A profile edit fans `EditProfile` to the root account directory, the per-account `CollaboratorsModel`, and `SessionModel` (bio) — identity is never duplicated inconsistently.
+- **Rule E — Off-main effects.** Effects originate only in middleware and run off-main; dispatch marshals back to main via `NotificationContext` (no explicit main hop). Per-feature handlers compose into one `effectsMiddleware`.
+- **Rule F — Delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
+- **Rule G — Mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
+- **Rule H — Single inset point.** Window insets are applied once at the shell root.
+<!-- assemble:rules:end -->
 
 Full text → `examples/taskflow/ARCHITECTURE.md`.
 
@@ -65,4 +69,5 @@ Canonical example: `examples/taskflow`.
 ## Deeper knowledge
 
 - **T1** per-concern guides → `docs/agent/references/` (`feature-slice.md` is live; the other six are planned — see `docs/agent/references/README.md`).
+- Task → guide routing (decision table) → `docs/agent/references/README.md`.
 - **T2** → `examples/taskflow/ARCHITECTURE.md` (full architecture + design rules) and `docs/agent/api-map.md` (module → `.api` index).

--- a/docs/agent/_fragments/modules.md
+++ b/docs/agent/_fragments/modules.md
@@ -1,0 +1,9 @@
+- `redux-kotlin` — core contract: `Store`/`TypedStore`, `Reducer`, `Middleware`, `createStore`, `applyMiddleware`, `combineReducers`, `compose`.
+- `redux-kotlin-threadsafe` — `createThreadSafeStore` (atomicfu-locked store wrapper).
+- `redux-kotlin-concurrent` — `createConcurrentStore` (lock-free reads + reentrant-lock-serialized writes; the CallerSerialized strategy).
+- `redux-kotlin-granular` — `subscribeTo` / `subscribeFields` field-level subscriptions.
+- `redux-kotlin-registry` — `StoreRegistry` / `TypedStoreRegistry` keyed multi-store container.
+- `redux-kotlin-multimodel` — `ModelState` typesafe heterogeneous model bag.
+- `redux-kotlin-multimodel-granular` — granular subscriptions for `ModelState`.
+- `redux-kotlin-compose` — Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`).
+- `redux-kotlin-compose-multimodel` — Compose bindings for `ModelState`.

--- a/docs/agent/_fragments/rules.md
+++ b/docs/agent/_fragments/rules.md
@@ -1,0 +1,6 @@
+- **Rule C — Render isolation.** No composable reads a model (board/cards/columns) wholesale; every leaf binds the narrowest slice via `selectorState`/`fieldStateOf` and is wrapped in `key(...)`; list derivation lives in pure functions/reducers.
+- **Rule D — Identity split.** A profile edit fans `EditProfile` to the root account directory, the per-account `CollaboratorsModel`, and `SessionModel` (bio) — identity is never duplicated inconsistently.
+- **Rule E — Off-main effects.** Effects originate only in middleware and run off-main; dispatch marshals back to main via `NotificationContext` (no explicit main hop). Per-feature handlers compose into one `effectsMiddleware`.
+- **Rule F — Delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
+- **Rule G — Mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
+- **Rule H — Single inset point.** Window insets are applied once at the shell root.

--- a/docs/agent/api-map.md
+++ b/docs/agent/api-map.md
@@ -6,7 +6,7 @@ derives_from:
 api_files: []
 rules: []
 assembles_into: [AGENTS.md, claude-skill]
-last_verified: { commit: d388b46, date: 2026-06-03 }
+last_verified: { commit: 06214a9, date: 2026-06-03 }
 ---
 
 # API map
@@ -34,5 +34,9 @@ Read the committed `.api` dump for a module's public surface; regenerate with `.
 | `:redux-kotlin-devtools-inapp` | `redux-kotlin-devtools-inapp/api/redux-kotlin-devtools-inapp.klib.api` | In-app DevTools overlay: triggers/config (`DevToolsTrigger`, `InAppConfig`, `DevToolsTab`). |
 | `:redux-kotlin-devtools-inapp-noop` | `redux-kotlin-devtools-inapp-noop/api/redux-kotlin-devtools-inapp-noop.klib.api` | No-op in-app DevTools (same config types, stripped for release builds). |
 | `:redux-kotlin-devtools-ui` | `redux-kotlin-devtools-ui/api/redux-kotlin-devtools-ui.klib.api` | Compose DevTools UI panels (tabs, theme). |
+
+`redux-kotlin-bom` (BOM platform), `redux-kotlin-routing-codegen` (KSP processor), and
+`redux-kotlin-devtools-standalone` (sample app) are published/built but carry no `.api` dump, so
+they're not listed.
 
 `examples/*` are `convention.control` (not published, no `.api`).

--- a/docs/agent/knowledge-sync.md
+++ b/docs/agent/knowledge-sync.md
@@ -1,0 +1,38 @@
+---
+tier: T2
+concern: knowledge-sync
+derives_from: []
+api_files: []
+rules: []
+assembles_into: []
+last_verified: { commit: 06214a9, date: 2026-06-03 }
+---
+
+# Knowledge-sync agent
+
+An advisory GitHub Action (`.github/workflows/knowledge-sync.yml`) that catches **semantic** drift the
+deterministic L4 checks (`scripts/check-agent-refs.sh`, `scripts/check-api-tripwire.sh`) cannot see:
+when a code change makes a guide's prose or patterns subtly wrong while every cited path still resolves.
+
+## What it does
+
+On a PR touching library `*/src/**`, a committed `**/api/*.api`, or `examples/taskflow/**`, it runs Claude
+to diff the change against the provenance-headed knowledge under `docs/agent/` and posts **one** PR comment
+listing which references likely need updating (using each doc's `derives_from` header to target the review),
+or "No knowledge drift detected." It is **advisory** — it never fails the build.
+
+## Enabling it
+
+1. Add a repository secret **`ANTHROPIC_API_KEY`** (Settings → Secrets and variables → Actions). Without it
+   the workflow's single job **cleanly skips** (the `gate` step yields `enabled=false`).
+2. **Pin the action.** Verify `anthropics/claude-code-action` inputs against its current README and pin to a
+   release tag or commit SHA before relying on it (this workflow uses `@v1`).
+3. (Optional) The workflow also supports `workflow_dispatch` for manual runs.
+
+## Relationship to the deterministic checks
+
+| Check | Catches | Blocking |
+|---|---|---|
+| `check-agent-refs.sh` (Phase 3) | broken `path → symbol` anchors, bad module/task names | yes |
+| `check-api-tripwire.sh` (Phase 3) | any committed `.api` change | yes (bypass label `api-reviewed`) |
+| knowledge-sync (this) | semantic / prose / pattern drift | no (advisory comment) |

--- a/docs/agent/references/_template.md
+++ b/docs/agent/references/_template.md
@@ -9,6 +9,8 @@ api_files:
   - <module>/api/<module>.klib.api
 rules: []          # subset of A–H this guide enforces
 assembles_into: [AGENTS.md, claude-skill]
+# last_verified.commit: the commit the cited `derives_from` sources were verified against
+# (use the repo base commit if this doc derives from nothing).
 last_verified: { commit: <short-sha>, date: <YYYY-MM-DD> }
 ---
 
@@ -20,6 +22,15 @@ last_verified: { commit: <short-sha>, date: <YYYY-MM-DD> }
 
 Prose explains the *why* and the *rule*. Every source reference uses the anchor form
 `path → Symbol` wrapped in backticks — repo-relative path, a literal " → ", then the symbol(s).
+
+## Anchor rules (enforced by `scripts/check-agent-refs.sh`)
+
+- A source citation is `` `path → Symbol` `` where **path must contain `/`** — bare names are not
+  validated (they're treated as convention/example placeholders).
+- The checker also verifies cited `:redux-kotlin*` **module names** exist in `settings.gradle.kts`
+  and that cited `./gradlew <task>` names are in its allowlist.
+- Lines containing `(planned` are skipped (so you can point at not-yet-written guides).
+- Shared blocks (Rules C–H, module map) are single-sourced in `docs/agent/_fragments/` and injected into `AGENTS.md`/`SKILL.md` by `scripts/assemble-agent-knowledge.sh` — edit the fragment, then re-run the assembler (CI `assemble-check` enforces it).
 
 ## See also
 

--- a/docs/agent/references/feature-slice.md
+++ b/docs/agent/references/feature-slice.md
@@ -106,7 +106,8 @@ Boardlist spine:
 Board callout:
 `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardScreen.kt → BoardScreen`.
 The screen wraps its store once via `rememberStableStore(store).value`, then binds slices with
-`fieldStateOf` (a whole field, value-equal) or `selectorState` (a derived snapshot). Child composables
+`fieldStateOf` (a whole field, value-equal) or `selectorState` (a derived snapshot); per ARCHITECTURE
+§17, each narrowly-bound leaf is wrapped in `key(...)` so it recomposes independently. Child composables
 receive finished immutable data plus a remembered callback — the store never reaches a child. Editor
 text and dialog-open flags stay in transient local `remember`, never the store. Rule G lives at the
 *mint* side here: ids/clock for `CreateBoard` come from `LocalIdGenerator` / `LocalClock` at the
@@ -150,7 +151,7 @@ Tight inner loop, fast to slow: `compile <target>`, then `commonTest` / `jvmTest
 then `apiCheck`.
 `apiCheck` matters only when you touch a library module's public API (taskflow itself has none);
 the backing `.api` dumps are listed in `api_files`. iOS-sim targets are host-gated — run them
-locally only on macOS; trust CI otherwise. Full treatment → testing.md.
+locally only on macOS; trust CI otherwise. Full treatment → `testing.md` *(planned)*.
 
 `detektAll` is the gate that bites first: `explicitApi()` is on, so every new `public` declaration in a
 slice (models, actions, reducer, screen, selectors) needs an explicit visibility modifier **and** a KDoc
@@ -159,9 +160,10 @@ not. Document public symbols as you write them, and never bypass the hook with `
 
 ## Codegen note
 
-KSP `@Reduce` codegen is packaging-agnostic: a `@Reduce`-annotated reducer can live in any
-`feature/*` package and the generated routing wiring follows it — package-by-feature does not change
-how codegen resolves it. Full treatment → the feature / testing guides.
+KSP `@Reduce` / `@ReduxInitial` codegen is packaging-agnostic: a `@Reduce`-annotated reducer can live
+in any `feature/*` package and the generated routing wiring follows it — package-by-feature does not
+change how codegen resolves it. Full codegen treatment is deferred to a planned guide
+*(planned — 0-rest)*.
 
 ## See also
 

--- a/docs/superpowers/plans/2026-06-03-knowledge-sync-agent-phase4.md
+++ b/docs/superpowers/plans/2026-06-03-knowledge-sync-agent-phase4.md
@@ -1,0 +1,150 @@
+# Phase 4 — Knowledge-Sync Agent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Add an advisory LLM workflow that, on PRs touching library source / `.api` / `examples/taskflow`, diffs the change against the provenance-headed knowledge refs and comments which refs likely need updating. Ships ready; requires the `ANTHROPIC_API_KEY` secret (documented; cleanly skips without it).
+
+**Architecture:** One `.github/workflows/knowledge-sync.yml` (path-filtered `pull_request` + `workflow_dispatch`, advisory/non-blocking, secret-guarded) + `docs/agent/knowledge-sync.md` setup doc. No source changes. Not locally runnable (LLM action) — verified by YAML validity + structure.
+
+**Tech Stack:** GitHub Actions YAML, `anthropics/claude-code-action`.
+
+---
+
+## Task 1: `.github/workflows/knowledge-sync.yml`
+
+**Files:** Create `.github/workflows/knowledge-sync.yml`
+
+- [ ] **Step 1:** Write:
+```yaml
+name: Knowledge sync
+on:
+  pull_request:
+    paths:
+      - 'redux-kotlin*/**/src/**'
+      - '**/api/*.api'
+      - 'examples/taskflow/**'
+  workflow_dispatch:
+permissions:
+  contents: read
+  pull-requests: write
+concurrency:
+  cancel-in-progress: true
+  group: knowledge-sync-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+jobs:
+  sync:
+    name: Knowledge drift review
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Gate on API key presence
+        id: gate
+        run: echo "enabled=${{ secrets.ANTHROPIC_API_KEY != '' }}" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Claude knowledge-drift review
+        if: steps.gate.outputs.enabled == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are the redux-kotlin knowledge-sync reviewer. This PR changed library source, a committed
+            `.api` dump, and/or `examples/taskflow` (the canonical reference app).
+
+            The agent knowledge lives under `docs/agent/`:
+            - `docs/agent/references/*.md` — T1 per-concern guides; each has a YAML `derives_from:` header
+              listing the `path → Symbol` sources it paraphrases.
+            - `AGENTS.md` — the T0 index (modules, commands, Rules C–H, layout).
+            - `docs/agent/api-map.md` — module → `.api` map.
+
+            Do this:
+            1. Read the PR diff (changed files).
+            2. For each knowledge doc, read its `derives_from` provenance; a doc is IN SCOPE if any changed
+               file matches one of its `derives_from` paths (or it documents a changed module / Rule).
+            3. For each in-scope doc, judge whether the change makes its prose, patterns, citations, or rule
+               statements stale — focus on SEMANTIC drift (deterministic anchor/API checks run separately).
+            4. Post ONE concise PR comment: a bullet per doc needing an update with the specific reason, or
+               exactly "No knowledge drift detected." Do not modify files. Do not restate the rules.
+            Keep it short and high-signal. Cite `path → Symbol` for any claim.
+```
+- [ ] **Step 2:** Validate: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/knowledge-sync.yml')); print('yaml ok')"`. If `actionlint` is installed, run it.
+- [ ] **Step 3:** Sanity-check trigger globs resolve to real locations:
+```bash
+ls -d redux-kotlin*/src >/dev/null 2>&1 && echo "src glob ok"
+ls */api/*.api >/dev/null 2>&1 && echo "api glob ok"
+ls -d examples/taskflow >/dev/null 2>&1 && echo "taskflow ok"
+```
+Expected: all three echo. (Note: the workflow uses `redux-kotlin*/**/src/**` which covers `<module>/src/...`.)
+- [ ] **Step 4:** Commit: `git add .github/workflows/knowledge-sync.yml && git commit -m "ci(agent): add knowledge-sync drift-review workflow"`
+
+---
+
+## Task 2: `docs/agent/knowledge-sync.md`
+
+**Files:** Create `docs/agent/knowledge-sync.md`
+
+- [ ] **Step 1:** Write:
+```markdown
+---
+tier: T2
+concern: knowledge-sync
+derives_from: []
+api_files: []
+rules: []
+assembles_into: []
+last_verified: { commit: <short-sha>, date: 2026-06-03 }
+---
+
+# Knowledge-sync agent
+
+An advisory GitHub Action (`.github/workflows/knowledge-sync.yml`) that catches **semantic** drift the
+deterministic L4 checks (`scripts/check-agent-refs.sh`, `scripts/check-api-tripwire.sh`) cannot see:
+when a code change makes a guide's prose or patterns subtly wrong while every cited path still resolves.
+
+## What it does
+
+On a PR touching library `*/src/**`, a committed `**/api/*.api`, or `examples/taskflow/**`, it runs Claude
+to diff the change against the provenance-headed knowledge under `docs/agent/` and posts **one** PR comment
+listing which references likely need updating (using each doc's `derives_from` header to target the review),
+or "No knowledge drift detected." It is **advisory** — it never fails the build.
+
+## Enabling it
+
+1. Add a repository secret **`ANTHROPIC_API_KEY`** (Settings → Secrets and variables → Actions). Without it
+   the workflow's single job **cleanly skips** (the `gate` step yields `enabled=false`).
+2. **Pin the action.** Verify `anthropics/claude-code-action` inputs against its current README and pin to a
+   release tag or commit SHA before relying on it (this workflow uses `@v1`).
+3. (Optional) The workflow also supports `workflow_dispatch` for manual runs.
+
+## Relationship to the deterministic checks
+
+| Check | Catches | Blocking |
+|---|---|---|
+| `check-agent-refs.sh` (Phase 3) | broken `path → symbol` anchors, bad module/task names | yes |
+| `check-api-tripwire.sh` (Phase 3) | any committed `.api` change | yes (bypass label `api-reviewed`) |
+| knowledge-sync (this) | semantic / prose / pattern drift | no (advisory comment) |
+```
+Replace `<short-sha>` with `git rev-parse --short HEAD`.
+- [ ] **Step 2:** If `scripts/check-agent-refs.sh` exists on this branch, run it — `docs/agent/knowledge-sync.md` must not break it (it adds no `path → symbol` anchors, so it should pass). Expected `ANCHOR CHECK OK`.
+- [ ] **Step 3:** Commit: `git add docs/agent/knowledge-sync.md && git commit -m "docs(agent): document the knowledge-sync agent + required secret"`
+
+---
+
+## Task 3: Acceptance + PR
+
+- [ ] **Step 1:** YAML valid; trigger globs resolve; secret-guard present (`grep -q "ANTHROPIC_API_KEY != ''" .github/workflows/knowledge-sync.yml`); `permissions` minimal; `bash scripts/check-agent-refs.sh` → `ANCHOR CHECK OK`.
+- [ ] **Step 2:** No-collateral: `git diff --name-only l4-ci-phase3...HEAD` → only `.github/workflows/knowledge-sync.yml`, `docs/agent/knowledge-sync.md`, `docs/superpowers/`. No `.kt`/`website/`/`examples/`.
+- [ ] **Step 3:** `git push -u origin knowledge-sync-phase4`
+- [ ] **Step 4:** `gh pr create --base l4-ci-phase3 --head knowledge-sync-phase4` — title `ci(agent): knowledge-sync drift-review agent (Phase 4)`; body: what it does, advisory + secret-guarded (skips without `ANTHROPIC_API_KEY`), pin-the-action caveat, completes the L4 drift-control pair (deterministic + semantic), stacked merge-order note, link the spec.
+
+---
+
+## Self-review notes
+- Spec coverage: workflow (T1), doc (T2), acceptance+PR (T3).
+- Not locally runnable (LLM) — verification is YAML/structure/secret-guard, explicitly per spec.
+- Secret-guard uses a `run`-step boolean output (`secrets` usable in `${{ }}`, not in job `if:`) — the robust pattern.
+- Advisory: `continue-on-error: true`, no required status.
+- Single-source: prompt points at `docs/agent/`; embeds no rule copies.

--- a/docs/superpowers/plans/2026-06-03-single-source-assembler.md
+++ b/docs/superpowers/plans/2026-06-03-single-source-assembler.md
@@ -1,0 +1,185 @@
+# Single-Source Assembler — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Single-source the duplicated Rules C–H + module map into `docs/agent/_fragments/`, assemble them into `AGENTS.md`/`SKILL.md` via marker injection, and gate drift in CI — implementing the strategy's "author once, assemble" and fixing the existing Rule-C drift.
+
+**Architecture:** Two fragment files + a bash assembler with `--check` + marker regions in the two consumer docs + a new `assemble-check.yml` workflow. No library/source changes. TDD: positive (assemble is idempotent; `--check` clean) + negative (diverge → `--check` fails).
+
+**Tech Stack:** bash + awk, GitHub Actions YAML, markdown.
+
+---
+
+## Task 1: Author the fragments
+
+**Files:** Create `docs/agent/_fragments/rules.md`, `docs/agent/_fragments/modules.md`
+
+- [ ] **Step 1:** `docs/agent/_fragments/rules.md` — canonical Rules C–H (faithful to `examples/taskflow/ARCHITECTURE.md` §17; **Rule C includes `key(...)`**). Bullets only, no header (drops into each doc's existing section):
+```markdown
+- **Rule C — Render isolation.** No composable reads a model (board/cards/columns) wholesale; every leaf binds the narrowest slice via `selectorState`/`fieldStateOf` and is wrapped in `key(...)`; list derivation lives in pure functions/reducers.
+- **Rule D — Identity split.** A profile edit fans `EditProfile` to the root account directory, the per-account `CollaboratorsModel`, and `SessionModel` (bio) — identity is never duplicated inconsistently.
+- **Rule E — Off-main effects.** Effects originate only in middleware and run off-main; dispatch marshals back to main via `NotificationContext` (no explicit main hop). Per-feature handlers compose into one `effectsMiddleware`.
+- **Rule F — Delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
+- **Rule G — Mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
+- **Rule H — Single inset point.** Window insets are applied once at the shell root.
+```
+- [ ] **Step 2:** `docs/agent/_fragments/modules.md` — canonical 9-core-module map (bullets only):
+```markdown
+- `redux-kotlin` — core contract: `Store`/`TypedStore`, `Reducer`, `Middleware`, `createStore`, `applyMiddleware`, `combineReducers`, `compose`.
+- `redux-kotlin-threadsafe` — `createThreadSafeStore` (atomicfu-locked store wrapper).
+- `redux-kotlin-concurrent` — `createConcurrentStore` (lock-free reads + reentrant-lock-serialized writes; the CallerSerialized strategy).
+- `redux-kotlin-granular` — `subscribeTo` / `subscribeFields` field-level subscriptions.
+- `redux-kotlin-registry` — `StoreRegistry` / `TypedStoreRegistry` keyed multi-store container.
+- `redux-kotlin-multimodel` — `ModelState` typesafe heterogeneous model bag.
+- `redux-kotlin-multimodel-granular` — granular subscriptions for `ModelState`.
+- `redux-kotlin-compose` — Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`).
+- `redux-kotlin-compose-multimodel` — Compose bindings for `ModelState`.
+```
+- [ ] **Step 3:** Commit: `git add docs/agent/_fragments && git commit -m "docs(agent): add single-source fragments (rules, module map)"`
+
+---
+
+## Task 2: The assembler script
+
+**Files:** Create `scripts/assemble-agent-knowledge.sh` (chmod +x)
+
+- [ ] **Step 1:** Write:
+```bash
+#!/usr/bin/env bash
+# Single-source assembler: inject docs/agent/_fragments/* into marker regions of the agent surfaces.
+# Default: rewrite in place. --check: fail (non-zero) if any region is out of sync with its fragment.
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 2
+CHECK=0; [ "${1:-}" = "--check" ] && CHECK=1
+FRAG="docs/agent/_fragments"
+# target|marker|fragment
+MAP=(
+  "AGENTS.md|rules|$FRAG/rules.md"
+  ".claude/skills/redux-kotlin/SKILL.md|rules|$FRAG/rules.md"
+  "AGENTS.md|modules|$FRAG/modules.md"
+)
+inject() { # stdin=content, $1=marker, $2=fragfile -> stdout
+  awk -v s="<!-- assemble:$1:start -->" -v e="<!-- assemble:$1:end -->" -v f="$2" '
+    $0==s { print; while ((getline l < f) > 0) print l; close(f); skip=1; next }
+    $0==e { skip=0 }
+    !skip { print }
+  '
+}
+targets=$(printf '%s\n' "${MAP[@]}" | cut -d'|' -f1 | sort -u)
+rc=0
+for t in $targets; do
+  [ -f "$t" ] || { echo "ASSEMBLE-FAIL: missing target $t"; rc=1; continue; }
+  rendered="$(cat "$t")"
+  for entry in "${MAP[@]}"; do
+    IFS='|' read -r mt mk mf <<< "$entry"
+    [ "$mt" = "$t" ] || continue
+    [ -f "$mf" ] || { echo "ASSEMBLE-FAIL: missing fragment $mf"; rc=1; continue; }
+    grep -qF "<!-- assemble:$mk:start -->" "$t" || { echo "ASSEMBLE-FAIL: $t missing marker '$mk'"; rc=1; continue; }
+    rendered="$(printf '%s\n' "$rendered" | inject "$mk" "$mf")"
+  done
+  if [ "$CHECK" -eq 1 ]; then
+    if ! diff -q <(printf '%s\n' "$rendered") "$t" >/dev/null; then
+      echo "ASSEMBLE-FAIL: $t is out of sync with its fragment(s) — run scripts/assemble-agent-knowledge.sh"; rc=1
+    fi
+  else
+    printf '%s\n' "$rendered" > "$t"
+  fi
+done
+[ "$rc" -eq 0 ] && { [ "$CHECK" -eq 1 ] && echo "ASSEMBLE CHECK OK" || echo "ASSEMBLED"; } || echo "ASSEMBLE FAILED"
+exit "$rc"
+```
+- [ ] **Step 2:** `chmod +x scripts/assemble-agent-knowledge.sh`
+- [ ] **Step 3:** Commit: `git add scripts/assemble-agent-knowledge.sh && git commit -m "build(agent): add single-source assembler (--check)"`
+
+---
+
+## Task 3: Retrofit AGENTS.md + SKILL.md with markers
+
+**Files:** Modify `AGENTS.md`, `.claude/skills/redux-kotlin/SKILL.md`
+
+- [ ] **Step 1:** In `AGENTS.md`, replace the **Design rules** bullet list (the `- **Rule C …**` … `- **Rule H …**` lines under `## Design rules`) with marker lines:
+```
+<!-- assemble:rules:start -->
+<!-- assemble:rules:end -->
+```
+Keep the surrounding `## Design rules` heading and any pointer line ("full text → …ARCHITECTURE.md §17").
+- [ ] **Step 2:** In `AGENTS.md`, replace the **Module map** bullet list (the 9 `- \`redux-kotlin…\`` lines under `## Module map`) with:
+```
+<!-- assemble:modules:start -->
+<!-- assemble:modules:end -->
+```
+Keep the heading + any "more modules exist → api-map" pointer line.
+- [ ] **Step 3:** In `SKILL.md`, replace the **Always-apply rules** bullet list (the `- **Rule C …**`…`- **Rule H …**` lines) with:
+```
+<!-- assemble:rules:start -->
+<!-- assemble:rules:end -->
+```
+Keep the `## Always-apply rules (full text → …)` heading.
+- [ ] **Step 4:** Run the assembler to fill the regions: `bash scripts/assemble-agent-knowledge.sh` → prints `ASSEMBLED`. Then `git diff` to confirm the regions now hold the fragment content (and AGENTS.md Rule C now includes `key(...)`, fixing the drift).
+- [ ] **Step 5 (idempotency + anchor):** `bash scripts/assemble-agent-knowledge.sh` again → no further diff; `bash scripts/assemble-agent-knowledge.sh --check` → `ASSEMBLE CHECK OK`; `bash scripts/check-agent-refs.sh` → `ANCHOR CHECK OK`; `wc -l AGENTS.md` still tight (≤ ~180).
+- [ ] **Step 6:** Commit: `git add AGENTS.md .claude/skills/redux-kotlin/SKILL.md && git commit -m "docs(agent): assemble rules + module map from fragments (single-source)"`
+
+---
+
+## Task 4: CI check + template note
+
+**Files:** Create `.github/workflows/assemble-check.yml`; modify `docs/agent/references/_template.md`
+
+- [ ] **Step 1:** Write `.github/workflows/assemble-check.yml`:
+```yaml
+name: Assemble check
+on:
+  pull_request:
+    branches: [master]
+permissions:
+  contents: read
+concurrency:
+  cancel-in-progress: true
+  group: assemble-check-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+jobs:
+  assemble-check:
+    name: Agent knowledge is assembled from fragments
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify assembled regions match fragments
+        run: bash scripts/assemble-agent-knowledge.sh --check
+```
+- [ ] **Step 2:** Validate: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/assemble-check.yml')); print('yaml ok')"`.
+- [ ] **Step 3:** In `docs/agent/references/_template.md`, add one line (near the anchor-rules note): "Shared blocks (Rules C–H, module map) are single-sourced in `docs/agent/_fragments/` and injected into `AGENTS.md`/`SKILL.md` by `scripts/assemble-agent-knowledge.sh` — edit the fragment, then re-run the assembler (CI `assemble-check` enforces it)."
+- [ ] **Step 4:** Commit: `git add .github/workflows/assemble-check.yml docs/agent/references/_template.md && git commit -m "ci(agent): enforce assembled-from-fragments + document it"`
+
+---
+
+## Task 5: Acceptance (TDD negative test) + PR
+
+- [ ] **Step 1 (positive):** `bash scripts/assemble-agent-knowledge.sh --check` → `ASSEMBLE CHECK OK` (exit 0); `bash scripts/check-agent-refs.sh` → `ANCHOR CHECK OK`.
+- [ ] **Step 2 (negative):** prove `--check` catches drift:
+```bash
+printf '\n- **Rule Z — bogus.**\n' >> docs/agent/_fragments/rules.md
+bash scripts/assemble-agent-knowledge.sh --check; echo "exit=$?"   # expect ASSEMBLE-FAIL (AGENTS.md + SKILL.md) + exit=1
+git checkout -- docs/agent/_fragments/rules.md
+bash scripts/assemble-agent-knowledge.sh --check                   # expect ASSEMBLE CHECK OK
+```
+Also confirm editing a generated region trips it:
+```bash
+sed -i.bak 's/Rule H — Single inset point/Rule H — TAMPERED/' AGENTS.md && rm -f AGENTS.md.bak
+bash scripts/assemble-agent-knowledge.sh --check; echo "exit=$?"   # expect fail
+bash scripts/assemble-agent-knowledge.sh                           # re-sync
+bash scripts/assemble-agent-knowledge.sh --check                   # OK
+git diff --stat
+```
+- [ ] **Step 3:** Verify drift fixed: `grep -c 'key(' AGENTS.md` ≥ 1 (Rule C now has `key(...)`); the rules region in AGENTS.md and SKILL.md are byte-identical (extract between markers and `diff`).
+- [ ] **Step 4:** No-collateral: `git diff --name-only knowledge-sync-phase4...HEAD` → only `docs/agent/_fragments/*`, `scripts/assemble-agent-knowledge.sh`, `AGENTS.md`, `.claude/skills/redux-kotlin/SKILL.md`, `.github/workflows/assemble-check.yml`, `docs/agent/references/_template.md`, `docs/superpowers/`. No `.kt`/`website/`/`examples/`/`agent-knowledge.yml`.
+- [ ] **Step 5:** `git push -u origin single-source-assembler`
+- [ ] **Step 6:** `gh pr create --base knowledge-sync-phase4 --head single-source-assembler` — title `build(agent): single-source assembler for shared knowledge blocks`; body: implements §5 "author once, assemble", resolves Q6, fixes the Rule-C `key(...)` drift, the `--check` CI gate + negative test, stacked merge-order note, link the spec.
+
+---
+
+## Self-review notes
+- Spec coverage: fragments (T1), assembler (T2), retrofit (T3), CI+template (T4), acceptance+PR (T5).
+- Separate `assemble-check.yml` (not `agent-knowledge.yml`) → no collision with the #7 fix on that file.
+- Idempotent injection; `--check` is the drift gate; negative tests prove it fires for both fragment edits and region tampering.
+- Scope limited to rules + module map (the always-loaded duplicates); api-map retrofit documented as future.
+- Anchor checker still passes (fragments live in `_fragments/`, not scanned; injected text has no `path → symbol` anchors).

--- a/docs/superpowers/specs/2026-06-03-knowledge-sync-agent-phase4-design.md
+++ b/docs/superpowers/specs/2026-06-03-knowledge-sync-agent-phase4-design.md
@@ -1,0 +1,51 @@
+# Phase 4: knowledge-sync agent (semantic drift)
+
+**Date:** 2026-06-03
+**Phase:** 4 (final) of the redux-kotlin AI integration strategy.
+**Branch:** `knowledge-sync-phase4` (stacked on `l4-ci-phase3`).
+**Type:** CI + docs. Adds one GitHub Actions workflow + a setup doc. No source changes.
+
+## Why
+
+Phase 3 catches *structural* drift deterministically (broken anchors, API changes). It cannot see *semantic* drift — when a code change makes a guide's prose/pattern subtly wrong while every cited path still resolves. Phase 4 adds the LLM catch: on a PR that touches library source, `.api` dumps, or the canonical `examples/taskflow`, an agent diffs the change against the knowledge refs (which carry `derives_from` provenance) and comments which refs likely need updating. Advisory, not blocking — it complements, doesn't gate.
+
+## Decisions (recommended, locked)
+
+- **Mechanism:** the official Claude GitHub Action (`anthropics/claude-code-action`) in headless/prompt mode, given a focused prompt + read access to the diff and `docs/agent/`. Avoids bespoke API plumbing.
+- **Trigger:** `pull_request` touching `redux-kotlin*/**/src/**`, `**/api/*.api`, or `examples/taskflow/**` (path-filtered). Optionally a weekly `schedule` as a safety net.
+- **Advisory:** the job posts a PR comment; it does **not** fail the build (`continue-on-error` / no required status). Drift is surfaced for a human, per the strategy.
+- **Secret:** requires repo secret `ANTHROPIC_API_KEY`. This **cannot be set unattended** — the workflow ships ready, and `docs/agent/knowledge-sync.md` documents enabling it. Until the secret exists the job no-ops/skips cleanly (guard on `secrets.ANTHROPIC_API_KEY != ''`).
+- **Provenance-targeted:** the prompt instructs the agent to use each ref's `derives_from` header to decide relevance — targeted, not whole-repo guesswork (matches the L4 "provenance discipline").
+
+## Deliverables
+
+1. **`.github/workflows/knowledge-sync.yml`** — `pull_request` (path-filtered) + `workflow_dispatch`; `permissions: contents: read, pull-requests: write`; a single job guarded by `if: ${{ secrets.ANTHROPIC_API_KEY != '' }}` that:
+   - checks out (fetch-depth 0),
+   - runs `anthropics/claude-code-action` with `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}` and a `prompt` that: reads the PR diff; for each changed library/source/api/taskflow path, consults `docs/agent/references/*.md` + `AGENTS.md` + `docs/agent/api-map.md` provenance (`derives_from`) to find refs that derive from the changed files; posts ONE PR comment listing each ref that likely needs updating and why (or "no knowledge drift detected"). Read-only to the repo besides the comment.
+   - `continue-on-error: true` (advisory).
+2. **`docs/agent/knowledge-sync.md`** — provenance-headed (`tier: T2`, concern `knowledge-sync`); explains: what the agent does, the required `ANTHROPIC_API_KEY` secret + how to add it, the trigger paths, that it's advisory (complements the deterministic Phase-3 checks), and how to pin/verify the action version before relying on it.
+
+## Constraints
+
+- Cannot run the LLM action locally; verification is limited to **YAML validity, trigger-path correctness, the secret-guard, and a sound prompt**. The doc must flag "verify/pin `anthropics/claude-code-action` to a release before enabling."
+- Must not block CI (advisory). Must not run (cleanly skip) when the secret is absent.
+- Single-source: the prompt points the agent at the canonical `docs/agent/` knowledge; it does not embed copies of the rules.
+
+## Acceptance gate
+
+- `knowledge-sync.yml` parses (`python3 -c "import yaml,…"`); `actionlint` clean if available.
+- Trigger `paths:` globs match real locations (`redux-kotlin*/.../src`, `**/api/*.api`, `examples/taskflow/**`).
+- Secret-guard present (`if: secrets.ANTHROPIC_API_KEY != ''`).
+- `permissions` minimal (`contents: read`, `pull-requests: write`).
+- `docs/agent/knowledge-sync.md` exists, names the secret, and is itself anchor-clean (passes `scripts/check-agent-refs.sh` if it adds anchors).
+- No `.kt`/`website/`/`examples/` source changes.
+
+## Out of scope
+
+- Setting the secret (manual, documented).
+- The parked "snippet compile-check" stretch from the strategy.
+- Authoring the six remaining T1 guides (Phase 0-rest).
+
+## Next (post-initiative)
+
+Phase 0-rest (the six remaining T1 guides), then the strategy's success-metric baselining. The deterministic (Phase 3) + semantic (Phase 4) drift controls now both exist.

--- a/docs/superpowers/specs/2026-06-03-single-source-assembler-design.md
+++ b/docs/superpowers/specs/2026-06-03-single-source-assembler-design.md
@@ -1,0 +1,57 @@
+# Single-source assembler for agent knowledge
+
+**Date:** 2026-06-03
+**Sub-project:** Post-review #1 (resolves strategy open-question Q6 + the §5 L1 "author once, assemble" principle).
+**Branch:** `single-source-assembler` (stacked on `knowledge-sync-phase4`).
+**Type:** Scripts + CI + doc retrofit. No library source changes.
+
+## Why
+
+The review found the strategy's central single-source discipline was dropped: the **Rules card (C–H)** is hand-copied into both `AGENTS.md` and `SKILL.md`, and the **module map** lives in `AGENTS.md`. They have **already drifted** (AGENTS.md's Rule C omits the `key(...)` requirement that SKILL.md and ARCHITECTURE §17 state; wordings differ). The deterministic anchor checker validates paths/symbols, not prose, so this drift is unguarded. Fix: author each shared block **once** as a fragment and *assemble* it into the consuming surfaces, with a CI check that fails on drift.
+
+## Decisions (recommended, locked)
+
+- **Mechanism: marker-injection into checked-in files.** `AGENTS.md`/`SKILL.md` stay human-readable and directly committed (tools read them as-is); only the shared regions are generated, delimited by HTML-comment markers. Preferred over full-file generation (keeps files editable/reviewable) and over include-directives (agents/tools don't process includes).
+- **Fragments** in `docs/agent/_fragments/` (leading `_` groups them; the anchor checker already only scans `references/*.md`+`AGENTS.md`+`api-map.md`, not `_fragments/`).
+- **Scope (focused):** single-source the two genuinely-duplicated, always-loaded surfaces — **Rules C–H** (→ `AGENTS.md` + `SKILL.md`) and the **module map** (→ `AGENTS.md`). `api-map.md` stays the `.api` index (T2, on-demand) and is documented as a future fragment-consumer, not retrofitted now (its table format + non-core rows make injection low-value). `CLAUDE.md` is the maintainer doc — untouched.
+- **Canonical content:** the Rules fragment is the corrected, faithful-to-ARCHITECTURE-§17 version (Rule C **includes** `key(...)`), ending the existing drift.
+- **CI: a new workflow** `.github/workflows/assemble-check.yml` (separate from `agent-knowledge.yml` to avoid colliding with the in-flight #7 fix on that file). Runs the assembler in `--check` mode.
+
+## Deliverables
+
+1. **`docs/agent/_fragments/rules.md`** — the canonical Rules C–H bullet list (faithful to `examples/taskflow/ARCHITECTURE.md` §17; C includes `key(...)`). Just the bullets (no header) so it drops into each surface's existing section.
+2. **`docs/agent/_fragments/modules.md`** — the canonical 9-core-module map (one `- \`module\` — use for X` line each).
+3. **`scripts/assemble-agent-knowledge.sh`** — injects each fragment into marker-delimited regions of its target(s):
+   - `rules` → `AGENTS.md` + `.claude/skills/redux-kotlin/SKILL.md`
+   - `modules` → `AGENTS.md`
+   - Default mode rewrites the regions in place; `--check` mode regenerates to a temp copy and `diff`s — exit non-zero (listing the stale file) if any target's region differs from its fragment. Idempotent (running twice = no change).
+4. **Marker retrofit** of `AGENTS.md` (Design-rules region + Module-map region) and `SKILL.md` (Always-apply-rules region) with `<!-- assemble:rules:start -->`…`<!-- assemble:rules:end -->` / `:modules:` markers; the region bodies become the fragment content (removing the hand-copied duplicates).
+5. **`.github/workflows/assemble-check.yml`** — `pull_request: [master]`; `permissions: contents: read`; runs `bash scripts/assemble-agent-knowledge.sh --check`.
+6. Brief note in `docs/agent/references/_template.md` (or a one-line README mention): shared blocks (rules, module map) are single-sourced in `docs/agent/_fragments/`; edit there, then run `scripts/assemble-agent-knowledge.sh`.
+
+## Constraints / invariants
+
+- After assembly, `scripts/check-agent-refs.sh` must still pass (`ANCHOR CHECK OK`) — the injected rules/module text contains no `path → symbol` anchors that would newly fail.
+- `AGENTS.md` stays token-tight (the change removes duplication, doesn't add prose).
+- The assembler must be deterministic + idempotent; `--check` is clean immediately after a default run.
+- Markers must not break markdown rendering (HTML comments are invisible).
+- No change to `.github/workflows/agent-knowledge.yml` (avoid the #7-fix collision).
+
+## Acceptance gate (testable locally)
+
+- `bash scripts/assemble-agent-knowledge.sh` then `git diff` — regions match fragments; running again is a no-op.
+- `bash scripts/assemble-agent-knowledge.sh --check` exits **0** on the committed state.
+- **Negative test:** edit a fragment (or a generated region) so they diverge → `--check` exits non-zero naming the stale file; revert.
+- `bash scripts/check-agent-refs.sh` → `ANCHOR CHECK OK`.
+- Rules C–H in the assembled `AGENTS.md` now include `key(...)` (drift fixed); `AGENTS.md` and `SKILL.md` rules are byte-identical in the generated region.
+- YAML valid; no `.kt`/`website/`/`examples/`/`agent-knowledge.yml` changes.
+
+## Out of scope
+
+- Retrofitting `api-map.md` to consume `modules.md` (documented as future).
+- Any change to `CLAUDE.md`.
+- The six planned T1 guides (0-rest).
+
+## Resolves
+
+Strategy open-question **Q6** (AGENTS.md ↔ CLAUDE.md / single-source): recorded resolution — `CLAUDE.md` stays the maintainer doc; agent surfaces are single-sourced from `docs/agent/_fragments/` and assembled. The §5 L1 "author once, assemble; do not maintain parallel copies" discipline is now implemented for the shared blocks.

--- a/scripts/assemble-agent-knowledge.sh
+++ b/scripts/assemble-agent-knowledge.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 2
+CHECK=0; [ "${1:-}" = "--check" ] && CHECK=1
+FRAG="docs/agent/_fragments"
+MAP=(
+  "AGENTS.md|rules|$FRAG/rules.md"
+  ".claude/skills/redux-kotlin/SKILL.md|rules|$FRAG/rules.md"
+  "AGENTS.md|modules|$FRAG/modules.md"
+)
+inject() { # stdin=content, $1=marker, $2=fragfile -> stdout
+  awk -v s="<!-- assemble:$1:start -->" -v e="<!-- assemble:$1:end -->" -v f="$2" '
+    $0==s { print; while ((getline l < f) > 0) print l; close(f); skip=1; next }
+    $0==e { skip=0 }
+    !skip { print }
+  '
+}
+targets=$(printf '%s\n' "${MAP[@]}" | cut -d'|' -f1 | sort -u)
+rc=0
+for t in $targets; do
+  [ -f "$t" ] || { echo "ASSEMBLE-FAIL: missing target $t"; rc=1; continue; }
+  rendered="$(cat "$t")"
+  for entry in "${MAP[@]}"; do
+    IFS='|' read -r mt mk mf <<< "$entry"
+    [ "$mt" = "$t" ] || continue
+    [ -f "$mf" ] || { echo "ASSEMBLE-FAIL: missing fragment $mf"; rc=1; continue; }
+    grep -qF "<!-- assemble:$mk:start -->" "$t" || { echo "ASSEMBLE-FAIL: $t missing marker '$mk'"; rc=1; continue; }
+    rendered="$(printf '%s\n' "$rendered" | inject "$mk" "$mf")"
+  done
+  if [ "$CHECK" -eq 1 ]; then
+    if ! diff -q <(printf '%s\n' "$rendered") "$t" >/dev/null; then
+      echo "ASSEMBLE-FAIL: $t out of sync with fragment(s) — run scripts/assemble-agent-knowledge.sh"; rc=1
+    fi
+  else
+    printf '%s\n' "$rendered" > "$t"
+  fi
+done
+[ "$rc" -eq 0 ] && { [ "$CHECK" -eq 1 ] && echo "ASSEMBLE CHECK OK" || echo "ASSEMBLED"; } || echo "ASSEMBLE FAILED"
+exit "$rc"


### PR DESCRIPTION
Consolidates the final two stacked PRs — **#317** (Phase-4 knowledge-sync) and **#318** (single-source assembler) — onto current `master`. The repo is rebase-only, which made the deep stacked branches unmergeable (add/add conflicts after the earlier PRs rebased with new SHAs); this is their exact net delta as one clean branch, so it merges cleanly.

## Contents
- **Phase 4 — knowledge-sync agent:** `.github/workflows/knowledge-sync.yml` (advisory, secret-gated LLM drift review) + `docs/agent/knowledge-sync.md`.
- **Single-source assembler:** `docs/agent/_fragments/{rules,modules}.md` + `scripts/assemble-agent-knowledge.sh` (`--check`) + `.github/workflows/assemble-check.yml`; `AGENTS.md`/`SKILL.md` rules + module map are now **assembled from the fragments** — resolves the Rule-C `key(...)` drift (the two surfaces are byte-identical).
- **Review cheap-batch:** Rule C `key(...)`, planned-marks, honest codegen note, `last_verified` semantics + `_template` anchor-rules note, api-map dump-less-module note, AGENTS routing link.

## Verified locally
- `scripts/assemble-agent-knowledge.sh --check` → ASSEMBLE CHECK OK
- `scripts/check-agent-refs.sh` → ANCHOR CHECK OK
- `agent-knowledge.yml` untouched (keeps the #7 unshallow fix already merged via #316).

Supersedes #317 and #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)