### PR TITLE
docs(agent): complete Phase 0 reference set + merge umbrella strategy spec

### DIFF
--- a/.claude/skills/redux-kotlin/SKILL.md
+++ b/.claude/skills/redux-kotlin/SKILL.md
@@ -25,12 +25,12 @@ companion modules on one `Store<S>` contract. Recommended app organization is **
 | If you are… | Read |
 |---|---|
 | Adding or editing a **feature** | [`feature-slice.md`](../../../docs/agent/references/feature-slice.md) |
-| Setting up the **store / topology** | `../../../docs/agent/references/store-setup.md` *(planned — see README)* |
-| **Compose** state binding (Rule C) | `../../../docs/agent/references/compose-binding.md` *(planned)* |
-| **Effects + sync** (Rule E) | `../../../docs/agent/references/effects-sync.md` *(planned)* |
-| **Testing** + the verify loop | `../../../docs/agent/references/testing.md` *(planned)* |
-| The 6 **platform shims** | `../../../docs/agent/references/platform-shims.md` *(planned)* |
-| **Modularization** | `../../../docs/agent/references/modularization.md` *(planned)* |
+| Setting up the **store / topology** | [`store-setup.md`](../../../docs/agent/references/store-setup.md) |
+| **Compose** state binding (Rule C) | [`compose-binding.md`](../../../docs/agent/references/compose-binding.md) |
+| **Effects + sync** (Rule E) | [`effects-sync.md`](../../../docs/agent/references/effects-sync.md) |
+| **Testing** + the verify loop | [`testing.md`](../../../docs/agent/references/testing.md) |
+| The 5 **platform shims** | [`platform-shims.md`](../../../docs/agent/references/platform-shims.md) |
+| **Modularization** | [`modularization.md`](../../../docs/agent/references/modularization.md) |
 
 ## Pointers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,6 @@ Canonical example: `examples/taskflow`.
 
 ## Deeper knowledge
 
-- **T1** per-concern guides → `docs/agent/references/` (`feature-slice.md` is live; the other six are planned — see `docs/agent/references/README.md`).
+- **T1** per-concern guides → `docs/agent/references/` (all seven live: feature-slice, store-setup, compose-binding, effects-sync, testing, platform-shims, modularization — see `docs/agent/references/README.md`).
 - Task → guide routing (decision table) → `docs/agent/references/README.md`.
 - **T2** → `examples/taskflow/ARCHITECTURE.md` (full architecture + design rules) and `docs/agent/api-map.md` (module → `.api` index).

--- a/docs/agent/references/README.md
+++ b/docs/agent/references/README.md
@@ -9,12 +9,12 @@ checked to resolve (path exists, symbol present). See [_template.md](./_template
 | Concern | Guide | Status |
 |---|---|---|
 | Add a feature slice | [feature-slice.md](./feature-slice.md) | ✅ |
-| Store setup & topology | `store-setup.md` | planned (0-rest) |
-| Compose binding (Rule C) | `compose-binding.md` | planned (0-rest) |
-| Effects + sync (Rule E) | `effects-sync.md` | planned (0-rest) |
-| Testing & the verify loop | `testing.md` | planned (0-rest) |
-| The 6 platform shims | `platform-shims.md` | planned (0-rest) |
-| Modularization | `modularization.md` | planned (0-rest) |
+| Store setup & topology | [store-setup.md](./store-setup.md) | ✅ |
+| Compose binding (Rule C) | [compose-binding.md](./compose-binding.md) | ✅ |
+| Effects + sync (Rule E) | [effects-sync.md](./effects-sync.md) | ✅ |
+| Testing & the verify loop | [testing.md](./testing.md) | ✅ |
+| The 5 platform shims | [platform-shims.md](./platform-shims.md) | ✅ |
+| Modularization | [modularization.md](./modularization.md) | ✅ |
 
 Tiers: **T0** = rules card + module map + commands (assembled into `AGENTS.md`). **T1** = these guides.
 **T2** = [`examples/taskflow/ARCHITECTURE.md`](../../../examples/taskflow/ARCHITECTURE.md) + committed `.api` dumps.

--- a/docs/agent/references/compose-binding.md
+++ b/docs/agent/references/compose-binding.md
@@ -1,0 +1,115 @@
+---
+tier: T1
+concern: compose-binding
+derives_from:
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardScreen.kt → BoardScreen
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/KanbanCard.kt → KanbanCard
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/ColumnHeader.kt → ColumnHeader
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardSelectors.kt → deriveVisibleCardIds
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/ui/Locals.kt → LocalIdGenerator, LocalClock
+  - examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/feature/board/RenderIsolationTest.kt → RenderIsolationTest
+api_files:
+  - redux-kotlin-compose-multimodel/api/redux-kotlin-compose-multimodel.klib.api
+  - redux-kotlin-compose/api/redux-kotlin-compose.klib.api
+rules: [C, G]
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: 3c1cd67, date: 2026-06-04 }
+---
+
+# Compose binding (Rule C)
+
+> How a screen binds the narrowest slice of the store so one card move recomposes only the two
+> affected columns — and how ids/timestamps are minted at the dispatch site, never in a reducer.
+
+## Rule C — render isolation
+
+**No composable reads a model wholesale.** Every leaf binds the smallest slice it needs and is wrapped
+in `key(...)` so it recomposes independently. `BoardScreen` is the worked example:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardScreen.kt → BoardScreen`.
+It is deliberately split into per-column and per-card composables — moving one card changes only the
+two affected columns' slices, and every other column stays frozen.
+
+## The binding API
+
+From `redux-kotlin-compose` and `redux-kotlin-compose-multimodel` (`api_files` above):
+
+- **`rememberStableStore(store).value`** — wrap the incoming `Store<ModelState>` once per screen. The
+  `StableStore` value class memoizes the wrapper so it is stable across recompositions.
+- **`fieldStateOf(Model::class) { slice }`** — bind a single-model slice as Compose `State<T>`. Fires
+  only when the selected value changes identity. Because reducers reuse unchanged instances (structural
+  sharing), a sibling edit leaves an untouched card's reference identical → no recomposition.
+- **`selectorState { ms -> derived }`** — bind a value derived across models. Recomposes only when the
+  value-equal result genuinely changes. This is the home for all list/filter work that Rule C bans
+  from composable bodies.
+
+### The pattern
+
+```
+val s = rememberStableStore(store).value
+// per column, keyed so each is tracked independently:
+key(colId) {
+    val cardIds by s.selectorState { ms -> deriveVisibleCardIds(ms.get<BoardModel>(), ms.get<FilterModel>(), colId) }
+    // per card, keyed:
+    key(cardId) {
+        val card by s.fieldStateOf(BoardModel::class) { it.board?.cards?.get(cardId) }
+        KanbanCard(card = card, onClick = onCardClick)   // store never reaches the child
+    }
+}
+```
+
+Two non-negotiables visible here:
+
+- **`key(...)` per leaf.** `key(colId)` / `key(cardId)` give Compose a stable identity per item, so an
+  unchanged item is never recomposed when a sibling changes. Reference:
+  `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardScreen.kt → BoardScreen`.
+- **List derivation lives in pure functions, not composable bodies.** No `.filter`/`.count`/`.sortedBy`
+  in a `@Composable`; call a selector:
+  `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardSelectors.kt → deriveVisibleCardIds`.
+
+## Leaves are pure
+
+A child composable never receives the store — only finished immutable data plus a remembered callback
+minted at the binding point (`remember(store) { { id -> store.dispatch(OpenCard(id)) } }`). Editor text
+and dialog-open flags stay in transient local `remember`, never the store.
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/KanbanCard.kt → KanbanCard`
+and `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/ColumnHeader.kt → ColumnHeader`
+take plain data + an `onClick`, read no store, and run no business logic. The one allowed exception is an
+O(1) lookup (resolving an assignee from a collaborators map).
+
+## Rule G — mint at the dispatch site
+
+Ids and timestamps are created where the action is dispatched, never inside a reducer. The screen reads
+two CompositionLocals:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/ui/Locals.kt → LocalIdGenerator, LocalClock`,
+then dispatches with the minted values, e.g. `dispatch(CreateBoard(idGen.newBoardId(), name, clock()))`.
+Injecting these via locals lets tests supply a deterministic id sequence and a fixed clock without
+threading constructor parameters. The reducer just stamps the finished id/timestamp into state. (Detail
+on the platform `newUuid()` backing → [platform-shims.md](./platform-shims.md).)
+
+## Proof it works
+
+`examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/feature/board/RenderIsolationTest.kt → RenderIsolationTest`
+binds three columns through `key(colId)` + `fieldStateOf`, counts recompositions in a plain (non-snapshot)
+map held in `remember`, dispatches a card move A→B, and asserts: A and B recompose (their `cardIds` slice
+changed), **C does not** (its slice is untouched), and an unrelated `SetFilterQuery` leaves C flat too.
+
+## Verify loop
+
+`./gradlew :examples:taskflow:composeApp:jvmTest` runs `RenderIsolationTest` (the Compose UI tests are
+JVM-hosted), then `./gradlew detektAll`. `explicitApi()` requires a KDoc on every public composable.
+Full treatment → [testing.md](./testing.md).
+
+## Pitfalls
+
+- Reading a whole model (`val board by s.fieldStateOf(BoardModel::class) { it }`) then indexing in the
+  body re-recomposes the leaf on every board change — defeats Rule C.
+- Forgetting `key(...)` makes Compose track items positionally, so a move recomposes everything after
+  the insertion point.
+- Calling `Clock.System.now()` or generating an id inside a reducer breaks Rule G and makes the reducer
+  non-deterministic to test.
+
+## See also
+
+- [feature-slice.md](./feature-slice.md) — the screen as one of the seven slice elements.
+- [store-setup.md](./store-setup.md) — where the bound `Store<ModelState>` comes from.
+- [README](./README.md)

--- a/docs/agent/references/effects-sync.md
+++ b/docs/agent/references/effects-sync.md
@@ -1,0 +1,120 @@
+---
+tier: T1
+concern: effects-sync
+derives_from:
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/EffectsMiddleware.kt → effectsMiddleware
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/sync/SyncEngine.kt → SyncEngine, SyncStatus
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/sync/SyncRepository.kt → SyncRepository
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/remote/RemoteApi.kt → RemoteApi
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/remote/PushResult.kt → PushResult
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/local/LocalStore.kt → LocalStore
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/CardActions.kt → InverseOp, CardOpFailed, CardOpSucceeded
+  - examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/infra/data/OfflineSyncE2ETest.kt → OfflineSyncE2ETest
+api_files:
+  - redux-kotlin-bundle/api/redux-kotlin-bundle.klib.api
+rules: [E, F, G]
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: 3c1cd67, date: 2026-06-04 }
+---
+
+# Effects + sync (Rule E)
+
+> Where intent becomes IO: the single effects middleware, the optimistic-then-revert dance, and the
+> offline-first queue that drains on reconnect.
+
+## Rule E — effects originate only in middleware
+
+The **only** place a dispatched action turns into IO is a middleware:
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/EffectsMiddleware.kt → effectsMiddleware`.
+Reducers and composables stay pure. Each feature that performs IO ships its own
+`Middleware<ModelState>` and they compose into the per-account pipeline (`activityLogger → undo →
+effects`, see [store-setup.md](./store-setup.md)) — "Rule E" is this discipline, not a single file.
+
+All repository work runs on the per-account background `CoroutineScope` (off-main, `Dispatchers.Default`).
+Dispatches that follow marshal back to main through the store's `NotificationContext`, so the effect
+code does **no explicit main hop**.
+
+## The optimistic dance
+
+For a mutating action the handler:
+
+1. **Captures the inverse from the pre-update state** —
+   `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/CardActions.kt → InverseOp`
+   (`MoveBack`, `DeleteAdded`, `RestoreEdited`, `ReAddDeleted`). This must happen **before** `next(action)`
+   while the old state is still visible.
+2. **Runs the reducer optimistically** via `next(action)` (synchronous, under the write lock) so the UI
+   updates instantly.
+3. **Launches the repository call** on the background scope, carrying that captured inverse.
+
+On a backend rejection the engine emits
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/CardActions.kt → CardOpFailed`
+carrying the inverse, and the reducer reverts **exactly that op** — not a whole-board snapshot. On
+acceptance it emits `CardOpSucceeded`, which clears the card from the in-flight ("Saving…") set.
+
+## Offline-first — local-first write, queue, drain
+
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/sync/SyncRepository.kt → SyncRepository`
+is the gateway. Every mutation does three things:
+
+1. Write `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/local/LocalStore.kt → LocalStore`
+   immediately (durable, works offline).
+2. Enqueue a sync op carrying its per-op inverse.
+3. Kick `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/sync/SyncEngine.kt → SyncEngine`
+   to attempt a drain.
+
+`SyncEngine.drain` walks the pending-op queue against the remote and handles each outcome:
+
+| Outcome | Action |
+|---|---|
+| Accepted | mark synced; emit `CardOpSucceeded` (clears in-flight) |
+| Rejected | emit `CardOpFailed` with the inverse; drop the op (never retried) |
+| Offline | stop the drain, **leave the queue intact**, retry on reconnect |
+| Transient network error | increment the attempt counter, keep the op queued |
+
+After a successful push it pulls remote changes since the last cursor and merges them. The queue is
+durable, so going offline never reverts an optimistic change — offline is not a rejection.
+
+## Rule F — delta-only status
+
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/sync/SyncEngine.kt → SyncStatus`
+(online · pendingCount · inFlight · lastSyncedAt · lastError) is emitted **only when it actually
+changes** — no notification churn on a no-op drain. The status flows to a reducer slot the
+`SyncIndicator`/`SyncToast` bind narrowly (Rule C).
+
+## The remote seam
+
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/remote/RemoteApi.kt → RemoteApi`
+is the interface (`push(ops) → PushResult`, `pull(since) → page`). The demo backs it with a
+`FakeRemoteApi` that simulates latency, a configurable failure rate, an offline gate, and deterministic
+WIP-limit rejections — all seeded for reproducibility. `push` returns
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/remote/PushResult.kt → PushResult`
+(`Accepted` | `Rejected(opId, reason)`); connectivity failures are thrown, not modelled as results.
+Swap this interface for a real HTTP client (via the `HttpEngine` shim, [platform-shims.md](./platform-shims.md))
+without touching the middleware.
+
+## Proof it works
+
+`examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/infra/data/OfflineSyncE2ETest.kt → OfflineSyncE2ETest`
+drives the real store + middleware + sync + SQLDelight under virtual time: an offline move persists and
+queues without reverting; reconnect drains the queue and advances the cursor; a WIP-limit rejection
+reverts via the per-op `MoveBack` inverse; an accepted move clears the in-flight set. The middleware in
+isolation is covered by `EffectsMiddlewareTest`.
+
+## Verify loop
+
+`./gradlew :examples:taskflow:composeApp:jvmTest` (the sync E2E + middleware tests are JVM-hosted under
+virtual time), then `./gradlew detektAll`. Full treatment → [testing.md](./testing.md).
+
+## Pitfalls
+
+- Capturing the inverse **after** `next(action)` reads post-mutation state — the revert will be wrong.
+- Doing IO in a reducer or a composable instead of the middleware breaks Rule E and makes the write
+  untestable as a pure function.
+- Emitting status unconditionally floods subscribers — keep the Rule F delta check.
+- Treating an offline error as a rejection wrongly reverts the optimistic change.
+
+## See also
+
+- [store-setup.md](./store-setup.md) — the middleware pipeline order this composes into.
+- [feature-slice.md](./feature-slice.md) — a feature ships its effect handler only if it does IO.
+- [README](./README.md)

--- a/docs/agent/references/feature-slice.md
+++ b/docs/agent/references/feature-slice.md
@@ -151,7 +151,7 @@ Tight inner loop, fast to slow: `compile <target>`, then `commonTest` / `jvmTest
 then `apiCheck`.
 `apiCheck` matters only when you touch a library module's public API (taskflow itself has none);
 the backing `.api` dumps are listed in `api_files`. iOS-sim targets are host-gated — run them
-locally only on macOS; trust CI otherwise. Full treatment → `testing.md` *(planned)*.
+locally only on macOS; trust CI otherwise. Full treatment → [testing.md](./testing.md).
 
 `detektAll` is the gate that bites first: `explicitApi()` is on, so every new `public` declaration in a
 slice (models, actions, reducer, screen, selectors) needs an explicit visibility modifier **and** a KDoc

--- a/docs/agent/references/modularization.md
+++ b/docs/agent/references/modularization.md
@@ -1,0 +1,104 @@
+---
+tier: T1
+concern: modularization
+derives_from:
+  - settings.gradle.kts → published module list
+  - examples/taskflow/composeApp/build.gradle.kts → redux-kotlin-bundle-compose
+  - redux-kotlin-bundle-compose/build.gradle.kts → redux-kotlin-bundle, redux-kotlin-compose-multimodel
+  - redux-kotlin-bundle/build.gradle.kts → redux-kotlin-concurrent, redux-kotlin-registry, redux-kotlin-routing, redux-kotlin-multimodel-granular
+api_files:
+  - redux-kotlin/api/redux-kotlin.klib.api
+  - redux-kotlin-concurrent/api/redux-kotlin-concurrent.klib.api
+  - redux-kotlin-threadsafe/api/redux-kotlin-threadsafe.klib.api
+  - redux-kotlin-registry/api/redux-kotlin-registry.klib.api
+  - redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api
+  - redux-kotlin-multimodel-granular/api/redux-kotlin-multimodel-granular.klib.api
+  - redux-kotlin-granular/api/redux-kotlin-granular.klib.api
+  - redux-kotlin-compose/api/redux-kotlin-compose.klib.api
+  - redux-kotlin-compose-multimodel/api/redux-kotlin-compose-multimodel.klib.api
+  - redux-kotlin-bundle/api/redux-kotlin-bundle.klib.api
+  - redux-kotlin-bundle-compose/api/redux-kotlin-bundle-compose.klib.api
+rules: []
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: 3c1cd67, date: 2026-06-04 }
+---
+
+# Modularization
+
+> Which redux-kotlin library module to depend on for which job, and the package-by-feature dependency
+> direction inside an app module.
+
+## Library module selection
+
+The core is one module; everything else layers onto the same `Store<S>` contract. Pick the smallest set
+that does the job. Full per-module API lives in the `api_files` above.
+
+| Module | Use it when |
+|---|---|
+| `:redux-kotlin` | always — the `Store`/`Reducer`/`Middleware` contract, `createStore`, `applyMiddleware`, `compose`. |
+| `:redux-kotlin-concurrent` | the store is touched from multiple threads and you want lock-free reads + serialized writes (the production default; taskflow uses this via the bundle). |
+| `:redux-kotlin-threadsafe` | you want a simpler atomicfu-locked wrapper instead of the concurrent strategy. |
+| `:redux-kotlin-granular` | field-level subscriptions (`subscribeTo` / `subscribeFields`) to avoid waking subscribers on unrelated changes. |
+| `:redux-kotlin-registry` | a dynamic, keyed set of stores with one lifecycle each (taskflow's per-account stores). |
+| `:redux-kotlin-multimodel` | one store holds several unrelated model types in a typesafe `ModelState` bag. |
+| `:redux-kotlin-multimodel-granular` | granular subscriptions over a `ModelState` bag. |
+| `:redux-kotlin-compose` | Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`) for a single-model store. |
+| `:redux-kotlin-compose-multimodel` | Compose bindings for a `ModelState` bag (`fieldStateOf`). |
+
+### Decision rules
+
+- **Threading:** single-threaded → bare `:redux-kotlin`; multi-threaded → `:redux-kotlin-concurrent`
+  (preferred) or `:redux-kotlin-threadsafe`.
+- **One store vs many:** several unrelated models in one store → `:redux-kotlin-multimodel`; a dynamic
+  keyed family of stores → `:redux-kotlin-registry`. (When to actually split → [store-setup.md](./store-setup.md).)
+- **Subscriptions:** add `:redux-kotlin-granular` / `:redux-kotlin-multimodel-granular` only when
+  whole-store notification is a measured cost; Compose's `fieldStateOf`/`selectorState` already isolate
+  renders ([compose-binding.md](./compose-binding.md)).
+- **Compose:** match the binding module to the store shape — `compose` for single-model, `compose-multimodel`
+  for a `ModelState` bag.
+
+## The bundles
+
+Two aggregate modules save you wiring the common stacks; depend on one instead of six:
+
+- `examples/taskflow/composeApp/build.gradle.kts → redux-kotlin-bundle-compose` is taskflow's single
+  redux dependency.
+- It re-exports (`api`) `redux-kotlin-bundle-compose/build.gradle.kts → redux-kotlin-bundle, redux-kotlin-compose-multimodel`,
+  and the bundle in turn re-exports
+  `redux-kotlin-bundle/build.gradle.kts → redux-kotlin-concurrent, redux-kotlin-registry, redux-kotlin-routing, redux-kotlin-multimodel-granular`.
+
+So a Compose KMP app gets the concurrent store + registry + routing DSL + multimodel + Compose bindings
+from one line. Drop to individual modules only under a size/minimal-deps constraint.
+
+## App-internal modularization — package-by-feature
+
+Inside an app module, organize by feature, not by layer (the recommended default — see the strategy
+spec's §5.1). taskflow's `commonMain` is: `feature/<name>/` slices over a shared `core` kernel, with
+`infra`, `app`, and `ui` as the shared homes. The dependency direction is one-way:
+
+```
+core  ←  infra
+core / infra / ui  ←  feature/*
+everything  ←  app
+```
+
+`core` never imports a `feature`. A `feature` may use `core`/`infra`/`ui` and may reference another
+feature's public leaf actions, but features do not reach into each other's internals. This keeps a
+feature's files context-local (fewer files for an agent to load) and the kernel reusable. Full element
+breakdown → [feature-slice.md](./feature-slice.md).
+
+When an app grows large enough that features need separate build units, the same direction maps onto
+Gradle modules (`:feature:board` depending on `:core`), but the package-level split is the first step and
+is usually sufficient.
+
+## Verify loop
+
+`./gradlew build` resolves the dependency graph and runs `apiCheck` for every library module; a wrong or
+missing module dependency fails compilation. `./gradlew apiDump` regenerates the `api_files` after an
+intentional public-API change.
+
+## See also
+
+- [store-setup.md](./store-setup.md) — the factories these modules supply.
+- [feature-slice.md](./feature-slice.md) — the package-by-feature layout in detail.
+- [README](./README.md)

--- a/docs/agent/references/platform-shims.md
+++ b/docs/agent/references/platform-shims.md
@@ -1,0 +1,84 @@
+---
+tier: T1
+concern: platform-shims
+derives_from:
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/DriverFactory.kt → DriverFactory, createDriver
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/DynamicColor.kt → dynamicColorScheme
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/HttpEngine.kt → ktorEngineOrNull
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/Ids.kt → newUuid
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/Notification.kt → mainNotificationContext
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/util/IdGenerator.kt → IdGenerator, DefaultIdGenerator
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/Ids.kt → OpId, BoardId, CardId, ColumnId
+rules: [E, G]
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: 3c1cd67, date: 2026-06-04 }
+---
+
+# Platform shims (expect/actual)
+
+> The five seams taskflow declares once in `commonMain/infra/platform/` and implements per target —
+> what each one abstracts and how the app injects it.
+
+## The discipline
+
+Each shim is an `expect` declaration in
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/`
+with one `actual` per target under `androidMain` / `iosMain` / `jvmMain` / `wasmJsMain`. Common code
+depends on the `expect` only; the composition root injects the result. Keep the seam **small and
+behind a domain-meaningful name** — `ktorEngineOrNull()`, not a leaked platform type — so common code
+reads the same on every platform.
+
+## The five shims
+
+| Shim (commonMain expect) | Abstracts | android / ios / jvm / wasmJs backing |
+|---|---|---|
+| `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/DriverFactory.kt → DriverFactory` | the SQLDelight `SqlDriver` | Android `AndroidSqliteDriver` · iOS `NativeSqliteDriver` · JVM `JdbcSqliteDriver` · wasmJs `WebWorkerDriver` (async init) |
+| `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/DynamicColor.kt → dynamicColorScheme` | Material You color | Android Material You on API 31+, else `null` · iOS/JVM/wasmJs `null` |
+| `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/HttpEngine.kt → ktorEngineOrNull` | the Ktor client engine | Android `Android` · iOS `Darwin` · JVM `Java` · wasmJs `null` (browser fetch) |
+| `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/Ids.kt → newUuid` | a fresh UUID string | Android/JVM `java.util.UUID` · iOS `NSUUID` · wasmJs `crypto.randomUUID()` |
+| `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/Notification.kt → mainNotificationContext` | UI-thread marshalling | Android `Handler(mainLooper)` · iOS `dispatch_get_main_queue` · JVM Swing EDT · wasmJs inline |
+
+## How each is wired
+
+- **DriverFactory** → its `createDriver()` feeds the SQLDelight database that backs `SqlDelightLocalStore`
+  (the durable side of [effects-sync.md](./effects-sync.md)). It is `suspend` so the async wasmJs Web
+  Worker driver fits the same signature as the synchronous ones.
+- **DynamicColor** → the theme calls `dynamicColorScheme(dark) ?: fallbackColors`; a `null` actual simply
+  falls back to the bundled palette.
+- **HttpEngine** → builds the Ktor client for image loading; a `null` actual lets the platform default
+  apply. The same seam is where a real `RemoteApi` would get its client.
+- **Notification** → `mainNotificationContext()` is the default notification context passed to both store
+  factories ([store-setup.md](./store-setup.md)); it is what makes Rule E's off-main effects safe without
+  an explicit main hop.
+
+## Ids and Rule G
+
+The id chain ties three files together. The platform `newUuid()` is wrapped by
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/util/IdGenerator.kt → IdGenerator, DefaultIdGenerator`
+into typed factories (`newCardId()`, `newBoardId()`, …) that mint the value classes in
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/core/Ids.kt → OpId, BoardId, CardId, ColumnId`.
+The UI reads the generator from a CompositionLocal and mints at the dispatch site (Rule G,
+[compose-binding.md](./compose-binding.md)); a `FakeIdGenerator` injected in tests yields a deterministic
+sequence. Android additionally needs an `AndroidContextHolder` set early (from the activity) because two
+actuals require a `Context`.
+
+## Verify loop
+
+`./gradlew :examples:taskflow:composeApp:jvmTest` compiles and runs the jvm actuals; native actuals are
+host-gated (iOS sim needs a Mac with the Xcode SDK — trust CI). Then `./gradlew detektAll`. A new shim
+must keep `explicitApi()` happy on the `expect` (KDoc on the public declaration).
+
+## Pitfalls
+
+- Leaking a platform type through the `expect` signature forces common code to know the platform —
+  return a common/abstract type or `null` instead.
+- Forgetting one target's `actual` fails compilation only on that host; compile `allTests` or trust CI to
+  catch native gaps.
+- Generating ids in a reducer instead of via the injected generator breaks Rule G and determinism.
+
+## See also
+
+- [store-setup.md](./store-setup.md) — `mainNotificationContext` as the store's default context.
+- [effects-sync.md](./effects-sync.md) — `DriverFactory`/`HttpEngine` behind the data layer.
+- [compose-binding.md](./compose-binding.md) — the id generator injected for Rule G.
+- [README](./README.md)

--- a/docs/agent/references/store-setup.md
+++ b/docs/agent/references/store-setup.md
@@ -1,0 +1,112 @@
+---
+tier: T1
+concern: store-setup
+derives_from:
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AppStore.kt → createAppStore
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt → createAccountStore, AccountStoreHandle, declareAccountModels
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountRegistry.kt → AccountRegistry
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/StoreExt.kt → getModel
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/Notification.kt → mainNotificationContext
+api_files:
+  - redux-kotlin-bundle/api/redux-kotlin-bundle.klib.api
+  - redux-kotlin-concurrent/api/redux-kotlin-concurrent.klib.api
+  - redux-kotlin-registry/api/redux-kotlin-registry.klib.api
+  - redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api
+  - redux-kotlin-routing/api/redux-kotlin-routing.klib.api
+rules: [E]
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: 3c1cd67, date: 2026-06-04 }
+---
+
+# Store setup & topology
+
+> How taskflow builds its stores: when one store is enough, when to split into a root + per-account
+> topology, how the routing DSL declares model slots, and how `NotificationContext` keeps subscriber
+> callbacks on the UI thread.
+
+## The store factory
+
+Taskflow uses the concurrent multimodel store from the bundle — `createConcurrentModelStore` (the
+`CallerSerialized` strategy: lock-free reads, reentrant-lock-serialized writes), holding a
+`ModelState` heterogeneous model bag. Both factories build the same kind of store:
+
+- Root: `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AppStore.kt → createAppStore`
+- Per account: `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt → createAccountStore`
+
+A single `createConcurrentModelStore(...) { declare slots }` call with one slot is the floor; you do
+not need any of the topology below for a one-screen app. The module that supplies it is the bundle —
+see [modularization.md](./modularization.md).
+
+## One store vs. two
+
+Taskflow runs **N+1 stores**: one root store plus one store per logged-in account.
+
+- **Root store** (`createAppStore`) holds cross-account state only: the account directory, app
+  settings (theme + the demo's fake-backend knobs), and the login flow. It carries **no middleware**.
+- **Per-account store** (`createAccountStore`) holds one account's board state behind the
+  `activityLogger → undo → effects` middleware pipeline, and owns that account's background
+  `CoroutineScope`, sync repository, and bot.
+
+**Decision rule — split when isolation has a lifetime.** Reach for a second store (or a registry of
+them) when a sub-domain has (a) independent state that must not leak across instances, and (b) a
+lifecycle you tear down as a unit. Each account here gets its own `CoroutineScope(SupervisorJob() +
+Dispatchers.Default)`; removing an account cancels that scope and every effect/sync/bot coroutine
+under it in one move. If your sub-domains share one lifetime and never need isolation, stay with one
+store and more slots. Cross-store reads go one way: per-account effects read the root store's settings
+via `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/StoreExt.kt → getModel`;
+the root never reaches into an account store.
+
+## The routing DSL — declaring slots
+
+A `ModelState` store is built by declaring each slot up front and routing action classes to reducers.
+The DSL is `model(InitialValue()) { on<ActionType> { state, action -> reducer(state, action) } }`.
+
+- Root slots: `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AppStore.kt → createAppStore`
+  declares `AccountsModel`, `AppSettingsModel`, `AuthFlowModel`.
+- Per-account slots: `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt → declareAccountModels`
+  declares nine — `SessionModel`, `NavModel`, `BoardListModel`, `CollaboratorsModel`, `BoardModel`,
+  `FilterModel`, `UndoModel`, `SyncModel`, `ActivityModel`.
+
+Two routing facts that shape how you write reducers:
+
+- **Declare every slot up front.** `ModelState.get` fails for an undeclared model, so the slot set is
+  fixed at construction; you cannot add a slot at runtime.
+- **Routing matches the exact leaf class** and returns the same model instance for unhandled actions,
+  so a reducer's own `when` only handles the leaves it registered, ending in `else -> model`. The same
+  shared action (e.g. `BoardClosed`) can be registered on several slots; each registered handler fires
+  and untouched slots are left alone. Multi-slot reducers that need identity take a captured `selfId`
+  from the wiring rather than reading it at runtime (Rule G — see [effects-sync.md](./effects-sync.md)).
+
+## Threading — NotificationContext (Rule E)
+
+Both factories default their notification context to
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/Notification.kt → mainNotificationContext`,
+a platform shim (see [platform-shims.md](./platform-shims.md)) that marshals subscriber callbacks to
+the UI main thread. This is what lets effects dispatch from a background scope with **no explicit main
+hop**: the write runs serialized, and the store notifies subscribers through the context, which posts
+them to main. Tests override it with an inline context to dispatch synchronously on the caller thread.
+
+## Per-account lifecycle — the registry
+
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountRegistry.kt → AccountRegistry`
+owns the per-account stores. It keeps two parallel structures: a `StoreRegistry<AccountId, ModelState>`
+(from `redux-kotlin-registry`) for lock-free store lookup, and a map of
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt → AccountStoreHandle`
+for the disposable resources (scope, sync repo, bot job). `getOrCreate` builds-or-returns; `remove`
+cancels the scope and forgets both entries. Use a registry whenever the number of stores is dynamic and
+keyed; a fixed pair of stores does not need one.
+
+## Verify loop
+
+`./gradlew :examples:taskflow:composeApp:jvmTest` (compiles the jvm target and runs
+`commonTest` + `jvmTest`, including the store-topology tests `AppStoreTest` and `AccountRegistryTest`),
+then `./gradlew detektAll`, then `./gradlew apiCheck` if you touched a library module's public API
+(taskflow itself has none; the backing surfaces are the `api_files` above). Full treatment →
+[testing.md](./testing.md).
+
+## See also
+
+- [feature-slice.md](./feature-slice.md) — what a slot/reducer/screen looks like inside one feature.
+- [effects-sync.md](./effects-sync.md) — the middleware pipeline this wires.
+- [modularization.md](./modularization.md) — which module supplies each factory.
+- [README](./README.md)

--- a/docs/agent/references/testing.md
+++ b/docs/agent/references/testing.md
@@ -1,0 +1,88 @@
+---
+tier: T1
+concern: testing
+derives_from:
+  - examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardReducersTest.kt → BoardReducersTest
+  - examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/AppStoreTest.kt → AppStoreTest
+  - examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/feature/board/RenderIsolationTest.kt → RenderIsolationTest
+  - examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/feature/account/AccountSwitchTest.kt → AccountSwitchTest
+  - examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/infra/data/OfflineSyncE2ETest.kt → OfflineSyncE2ETest
+  - examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/app/AccountRegistryTest.kt → AccountRegistryTest
+assembles_into: [AGENTS.md, claude-skill]
+rules: [C]
+last_verified: { commit: 3c1cd67, date: 2026-06-04 }
+---
+
+# Testing & the verify loop
+
+> Where each kind of test lives, what to assert at each layer, and the fast→slow command sequence an
+> agent runs after writing code.
+
+## Source-set layout — where a test goes
+
+- **`commonTest`** (default): platform-uniform correctness that runs on every target. Pure reducers,
+  selectors, action shape, codecs, the fake backend. A new feature's reducer test starts here:
+  `examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/feature/board/BoardReducersTest.kt → BoardReducersTest`,
+  and store-level routing tests too:
+  `examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/AppStoreTest.kt → AppStoreTest`.
+- **`jvmTest`**: JVM-only because it needs the JVM SQLite driver, coroutine virtual time, or the Compose
+  UI test harness — none of which run uniformly across native/JS. The Compose render and account-switch
+  tests, the offline-sync E2E, the SQLDelight round-trip, and the registry lifecycle test live here:
+  `examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/feature/board/RenderIsolationTest.kt → RenderIsolationTest`,
+  `examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/infra/data/OfflineSyncE2ETest.kt → OfflineSyncE2ETest`,
+  `examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/app/AccountRegistryTest.kt → AccountRegistryTest`.
+- **`jvmCommonTest`**: shared parent feeding both `jvmTest` and `androidUnitTest`; put shared JVM-side
+  test deps there. taskflow does not need it.
+
+`kotlin-test` is wired by the convention plugins — never add a test framework dependency by hand.
+
+## What to assert at each layer
+
+- **Pure reducer / selector — no store.** Call the function with a known model + action and assert the
+  next model. `BoardReducersTest` checks the board integrity invariant (every card id appears in exactly
+  one column) and that an unhandled action returns the *same* instance. Reducers and selectors are pure,
+  so this is fast and deterministic — the bulk of your tests.
+- **Store-level — full dispatch.** Wire a real store with an inline `NotificationContext` (synchronous
+  on the caller thread), dispatch, and read a model back via `getModel`. `AppStoreTest` asserts a
+  dispatched action routes to the right slot.
+- **Effects + sync — virtual time.** Wire the real store + middleware + `FakeRemoteApi` + SQLDelight and
+  drive coroutines under virtual time; assert queue draining, per-op revert, and in-flight transitions
+  (`OfflineSyncE2ETest`). See [effects-sync.md](./effects-sync.md).
+- **Render isolation — recomposition counts.** `RenderIsolationTest` (Rule C) counts per-column
+  recompositions in a plain `remember`-held map and asserts an untouched column does not recompose on a
+  card move.
+- **Account switching — store binding.**
+  `examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/feature/account/AccountSwitchTest.kt → AccountSwitchTest`
+  drives two per-account stores and asserts each account restores its own remembered screen.
+
+## The verify loop (fast → slow)
+
+1. **Compile + unit/reducer tests:** `./gradlew :examples:taskflow:composeApp:jvmTest` — compiles the
+   jvm target and runs `commonTest` + `jvmTest`. This is the tight inner loop.
+2. **All host-runnable targets:** `./gradlew :examples:taskflow:composeApp:allTests` — every target this
+   host can run (jvm/js/wasmJs; native is host-gated).
+3. **Lint gate:** `./gradlew detektAll` — `explicitApi()` is on, so every public declaration needs an
+   explicit modifier **and** a KDoc (including nested `data class`es and their properties). Formatting
+   auto-corrects; missing KDoc does not. Never `--no-verify`.
+4. **API surface:** `./gradlew apiCheck` (and `./gradlew apiDump` to regenerate) — only relevant when you
+   change a library module's public API; taskflow itself has none.
+
+**Host-gating:** iOS-simulator tests need a Mac with the Xcode iOS SDK; if `iosSimulatorArm64Test` fails
+locally with an SDK error that is environmental — trust CI for cross-platform. jvm/js/android compile on
+every host.
+
+## Pitfalls
+
+- Putting a SQLDelight or coroutine-virtual-time test in `commonTest` — it will fail to run on
+  native/JS. Keep it in `jvmTest`.
+- Asserting on a board snapshot after a rejected op instead of asserting the single reverted op — masks
+  whether the per-op inverse is correct.
+- Writing recomposition-count state into a snapshot-backed `mutableStateOf` — it perturbs the very
+  recomposition you are measuring; use a plain map.
+
+## See also
+
+- [feature-slice.md](./feature-slice.md) — the reducer/selector tests each slice ships.
+- [effects-sync.md](./effects-sync.md) — the virtual-time sync E2E.
+- [compose-binding.md](./compose-binding.md) — the render-isolation proof.
+- [README](./README.md)

--- a/docs/superpowers/specs/2026-06-03-redux-kotlin-ai-integration-strategy-design.md
+++ b/docs/superpowers/specs/2026-06-03-redux-kotlin-ai-integration-strategy-design.md
@@ -1,0 +1,207 @@
+# Redux-Kotlin AI Integration Strategy — Umbrella Design
+
+**Date:** 2026-06-03
+**Status:** Umbrella strategy (decomposes into sub-projects, each with its own spec → plan → build)
+**Scope:** Strategy altitude. Defines components, dependencies, build order, success metrics, and the
+best-practice questions each sub-project must resolve. Does **not** design any single component to
+implementation depth — that happens per sub-project, starting with Phase 0.
+
+**Delivery status (2026-06-04):** Phases **0a, 0, 1, 2, 3, 4 shipped.** taskflow is refactored to
+package-by-feature; the full T1 reference set (all seven guides) is live under `docs/agent/references/`;
+`AGENTS.md` + API-map, the Claude skill, the L4 deterministic CI (anchor check + API tripwire), the
+knowledge-sync agent, and a single-source assembler are in place. Open best-practice questions (§8)
+remain deferred to their own sub-projects. The §6 sequencing table below is the original plan of record.
+
+---
+
+## 1. Why
+
+Software is increasingly written by agents, not humans, and increasingly autonomously. Everything that
+raises agent efficiency — fewer tokens, fewer write→build→verify cycles, more correct-by-default output —
+raises the value of redux-kotlin as a target an agent can build on. This initiative equips agents to build
+Android / iOS / Web (wasmJs) / Desktop (JVM) applications on redux-kotlin efficiently and correctly.
+
+**Primary consumer:** external adopters' agents (developers pulling redux-kotlin into their own apps),
+**external-first** — but redux-kotlin maintainers are the first users / dogfooders. Artifacts are designed
+to ship with the library and to be used in-repo.
+
+## 2. Organizing principle
+
+**`examples/taskflow` + Rules A–H are the canonical reference implementation.** Every knowledge artifact is
+*derived from* it and stays *verifiable against* it. Nothing is hand-asserted that the codebase does not
+demonstrate. This single discipline is what makes a knowledge-first strategy survivable: knowledge that
+drifts from implementation is worse than no knowledge.
+
+(Rules A–H and the full architecture live in `examples/taskflow/ARCHITECTURE.md` — render isolation,
+identity split, off-main effects, delta-only status, mint-at-edge, single inset point, plus store topology,
+the routing-DSL reducer model, and the offline-first sync layer.)
+
+## 3. Strategy shape (decision record)
+
+Three shapes were considered:
+
+- **A. Knowledge-first** — distill patterns into `AGENTS.md` + skill + reference; agent writes code by hand,
+  verifies with gradle. Cheap, fast; agent still writes boilerplate; docs can drift.
+- **B. CLI / codegen-first** — generators + CLI as keystone, correct-by-construction. Biggest token payoff;
+  heaviest build; rigid for novel app shapes.
+- **C. Layered** — knowledge + CLI + verify, sequenced by leverage.
+
+**Chosen: A (knowledge-first), enriched.**
+
+**Rationale for rejecting scaffold/bootstrap codegen:** project bootstrapping and scaffold codegen are too
+fragile against complex Gradle setups, drifting APIs, and per-app architecture/packaging divergence. A
+pattern-informed agent handles bootstrapping *better* and adapts to app-specific shape. So scaffold/bootstrap
+generation is **out of scope**. The existing compile-time KSP codegen (`@Reduce`/`@ReduxInitial` →
+`ReduxModule` wiring) **stays** — it is annotation-driven, regenerated every build, never committed, and
+therefore drift-proof, not fragile.
+
+**Key existing asset:** the committed `*.api` dumps (`./gradlew apiDump`) are a machine-readable public-API
+surface per module — token-cheap, accurate grounding an agent reads instead of grepping source.
+
+## 4. Architecture
+
+```
+L1 KNOWLEDGE (keystone)          L2 CODEGEN (existing)        L3 VERIFY (documented loop)
+─────────────────────────        ──────────────────────       ──────────────────────────
+AGENTS.md (universal, T0)        KSP @Reduce/@ReduxInitial     compile <target>
+Claude skill (premium)           (drift-proof wiring)          + commonTest / jvmTest
+tiered reference (T1/T2)         keep + document;              + detektAll
+API map (.api dumps)             extension = later sub-proj    + apiCheck
+   ▲ all derived from taskflow + Rules A–H ▲                   → structured pass/fail
+
+L4 DRIFT CONTROL — polices the one boundary: refs ↔ implementation
+  anchor check (CI) · API-change tripwire (CI) · knowledge-sync agent (LLM)
+```
+
+**Agent data flow when building an app:** load `AGENTS.md` (always) → on task, pull the relevant tiered
+reference section + the target module's `.api` dump → write code following patterns → run the L3 verify
+commands → self-correct on failure. KSP handles reducer wiring invisibly.
+
+## 5. Components
+
+### 5.1 — Packaging best-practice (cross-cutting decision)
+
+The reference set recommends **package-by-feature** as the default app organization, flexibly:
+
+- **Greenfield → package-by-feature** (default): co-locate a feature's `Models · Actions · Reducer ·
+  Effects · Screen · Selectors · Tests` under `feature/<name>/`. Better modularity, and **better agent
+  context-locality** (one directory per feature → fewer files loaded, fewer tokens hunting across layers).
+- **Existing app → match its existing convention** (don't impose).
+- **Tiny / single-screen → package-by-layer acceptable.**
+
+Correctness clarifications this forces (all improvements, must be stated in the guides):
+- **Rule E is a discipline, not one file.** Effects originate only from middleware (never reducers/UI); a
+  feature-based app splits per-feature effect handlers and *composes* them into the middleware.
+- **Sealed `Action` leaves may live across feature packages** within the same module (Kotlin 1.5+).
+- **KSP `@Reduce` is packaging-agnostic** — top-level annotated handlers are discovered regardless of
+  package, so per-feature co-location works naturally.
+
+Consequence: taskflow (currently package-by-layer) is refactored to package-by-feature in **Phase 0a** so
+the canon matches this recommendation and the Phase 0 exemplar can cite it for organization, not just for
+packaging-independent element patterns.
+
+### L1 — Knowledge (keystone)
+
+**Single-source discipline:** author the knowledge **once** as the per-concern reference set; *assemble*
+`AGENTS.md` and the Claude skill from it. Do not maintain parallel copies. This collapses the drift surface
+to a single boundary (refs ↔ implementation).
+
+- **(a) `AGENTS.md`** — universal, tool-agnostic (Cursor / Copilot / Codex / Claude). Always in context, so
+  token-tight. Contents = the irreducible index: what redux-kotlin is (1 para) · module map (which module
+  for which job) · build/test/lint-gate commands · Rules A–H as one-liners · "where things live" layout ·
+  pointers into T1/T2. The existing `CLAUDE.md` is approximately this but maintainer-scoped; see open
+  question 6 on unification.
+- **(b) Claude skill** — premium Claude Code path. `SKILL.md` = rules card + **decision routing** ("building
+  a feature? → `references/feature-slice.md`"; "wiring persistence? → `references/platform-shims.md`").
+  `references/` = the T1/T2 deep-dives. The skill *is* the progressive-disclosure reference for Claude users
+  — no separate artifact.
+- **(c) Tiered reference** (the markdown the skill points to; also serves non-Claude tools):
+  - **T0** (always, embedded in `AGENTS.md`): rules card + module map + commands.
+  - **T1** (on task): per-concern guides — *feature slice · store setup & topology · Compose binding
+    (Rule C) · effects + sync · testing · the 6 platform shims · modularization*.
+  - **T2** (on demand): `ARCHITECTURE.md` deep-dive + `.api` dumps.
+- **(d) API map** — an index mapping each module → its `.api` dump path, so an agent reads the committed
+  public-API surface instead of source.
+
+### L2 — Codegen (existing, keep)
+
+Document the KSP `@Reduce`/`@ReduxInitial` flow inside the T1 feature/testing guides. Extension (multi-model
+`onAction`, effect handlers) is flagged as a **separate later sub-project**, not in this initiative's scope.
+**No scaffolding, no bootstrap generation.**
+
+### L3 — Verify (documented loop, no binary)
+
+A T1 guide describing the tier-1 sequence an agent runs after writing code:
+`compile <target>` → `commonTest`/`jvmTest` → `detektAll` → `apiCheck`, with how to read failures and the
+host-gating caveats (iOS simulator needs a Mac with the Xcode SDK; trust CI for cross-platform).
+Higher verification tiers — headless screenshot, UI-behavior tests, state-machine assertions — are **open
+questions** (section 8.3), not designed here.
+
+### L4 — Drift control (refs ↔ implementation)
+
+Committed:
+
+- **Anchor check (CI, deterministic):** refs cite `path:line`, module names, and gradle commands. CI
+  verifies cited paths exist, module names match `settings.gradle.kts`, and cited commands are real tasks.
+- **API-change tripwire (CI, deterministic):** any `*.api` file changing in a PR flags "public API changed —
+  knowledge review required" and lists affected modules; blocks until the API-map index is regenerated / a
+  review label is set.
+- **knowledge-sync agent (LLM):** PR-gated (triggers on changes to `redux-kotlin*/src`, `*.api`, or
+  `examples/taskflow`) or scheduled. Diffs the change against the knowledge refs and comments which refs need
+  updating, or opens a follow-up. Catches the semantic / prose / pattern drift the deterministic checks
+  cannot see. Can phase in after the cheap checks.
+
+Parked (stretch): **snippet compile-check** — extract fenced Kotlin from refs and compile it in a test
+source set (kotlinx-knit style) so doc code cannot rot. Strongest guard, most setup.
+
+**Provenance discipline (enabler for all of L4):** every reference doc carries a header naming what it
+derives from (taskflow paths, specific `.api` files, which Rules). The anchor checker and sync agent diff
+against exactly those — detection is targeted, not whole-repo guesswork.
+
+## 6. Sequencing
+
+Each phase is its own sub-project (spec → plan → build). Ordered so value lands early:
+
+| Phase | Deliverable | Notes |
+|---|---|---|
+| **0a** *(prereq)* | **taskflow feature-based refactor** | Refactor `examples/taskflow` from package-by-layer to **package-by-feature** so the canon matches the recommended packaging (see §5.1). Blocks the clean Phase 0 exemplar (avoids re-anchoring churn). Behavior-preserving; build stays green; `ARCHITECTURE.md` updated. Own spec → plan → build. |
+| **0** | Reference set + provenance headers | Keystone-of-keystone. T1 per-concern guides derived from (post-refactor) taskflow / Rules / `.api`; folds in the L2 codegen doc + L3 verify guide. Unblocks everything. |
+| **1** | `AGENTS.md` (T0) + API-map index | Assembled from the refs. Immediately useful to any agent/tool. |
+| **2** | Claude skill | `SKILL.md` + decision routing + `references/` wired to the T1/T2 set. |
+| **3** | L4 deterministic CI | Anchor check + API-change tripwire (needs refs to exist first). |
+| **4** | knowledge-sync agent | Semantic drift catch. |
+
+**First sub-project to brainstorm next:** Phase 0.
+
+## 7. Success metrics (token + speed framing)
+
+- **Token:** tokens-to-correct-feature-slice — cold agent vs knowledge-equipped, baselined against a
+  taskflow-style slice.
+- **Speed:** write→verify cycles to green (fewer when patterns are preloaded).
+- **Correctness:** % Rules A–H adherence in agent output (render isolation, mint-at-edge, off-main) —
+  reviewable / lintable.
+- **Drift:** time-to-detect API/pattern drift (target: within the PR, via L4); count of stale refs caught.
+- **Adoption (external north star):** external repos consuming `AGENTS.md` / the skill.
+
+## 8. Open best-practice questions
+
+Resolved per sub-project, not here:
+
+1. **Store-topology decision rule** — when 1 store vs taskflow's 2-store + `AccountRegistry`?
+2. **Module-selection table** — concurrent vs threadsafe vs core; when granular / multimodel.
+3. **Verify-tier standardization** — which of headless-screenshot / UI-behavior / state-machine become
+   standard (overlap risk flagged; tier-1 is the only committed scope today).
+4. **KSP extension scope** — multi-model `onAction` / effect handlers: a separate later sub-project.
+5. **Skill granularity** — one skill vs several (feature / store / testing).
+6. **`AGENTS.md` ↔ `CLAUDE.md`** — unify (one generated source, maintainer + app-builder views) or split.
+7. **External distribution mechanics** — how `AGENTS.md` / the skill ship with the published library (docs
+   page? template repo? part of the artifact?).
+
+## 9. Explicitly out of scope
+
+- Scaffold / project-bootstrap codegen (too fragile; agents do this better when pattern-informed).
+- A standalone CLI binary (no `rk` binary; verify is documented commands, not tooling).
+- KSP extension beyond the current `@Reduce`/`@ReduxInitial` v1.
+- Designing verification tiers 2–4.
+
+These can be revisited if the knowledge-first approach proves insufficient on the success metrics.


### PR DESCRIPTION
Completes the redux-kotlin AI-integration strategy's two remaining gaps.

## What

**1. Phase 0 "0-rest" — the six remaining T1 reference guides.** Authored alongside the existing `feature-slice.md`:

- `store-setup.md` — store factories, 1-store vs 2-store topology, routing DSL, `NotificationContext`, the per-account registry.
- `compose-binding.md` — Rule C render isolation (`rememberStableStore`/`fieldStateOf`/`selectorState`/`key`), Rule G mint-at-dispatch.
- `effects-sync.md` — Rule E off-main effects, optimistic-then-revert, offline-first queue drain, Rule F delta-only status.
- `testing.md` — commonTest vs jvmTest source-set strategy, what to assert per layer, the fast→slow verify loop.
- `platform-shims.md` — the five `expect`/`actual` seams and per-target backing.
- `modularization.md` — library module-selection table + the package-by-feature dependency direction.

Each is derived from the package-by-feature taskflow and the committed `.api` dumps, with provenance front-matter and `path → Symbol` anchors. The README status table, `SKILL.md` decision routing, and `AGENTS.md` T1 pointer drop their `(planned)` markers.

**2. Umbrella strategy spec** — merged from the brainstorm branch so its already-merged child sub-specs have a parent of record. Carries a 2026-06-04 delivery-status note (Phases 0a/0/1/2/3/4 shipped).

## Verification

- `scripts/check-agent-refs.sh` → ANCHOR CHECK OK (every cited path + symbol resolves).
- `scripts/assemble-agent-knowledge.sh --check` → ASSEMBLE CHECK OK (AGENTS.md/SKILL.md still in sync with fragments).
- `detektAll` green on both commits (docs are lint-excluded; gate ran clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)