### PR TITLE
feat(devtools-cli): agent-facing DevTools CLI (serve + query loop)

### DIFF
--- a/docs/agent/api-map.md
+++ b/docs/agent/api-map.md
@@ -29,7 +29,7 @@ Read the committed `.api` dump for a module's public surface; regenerate with `.
 | `:redux-kotlin-bundle` | `redux-kotlin-bundle/api/redux-kotlin-bundle.klib.api` | One-call assembly of a concurrent `ModelState` store + registry + routing (`createConcurrentModelStore`, `getOrCreateConcurrentModelStore`). |
 | `:redux-kotlin-bundle-compose` | `redux-kotlin-bundle-compose/api/redux-kotlin-bundle-compose.klib.api` | Compose-side bundle conveniences (no published declarations). |
 | `:redux-kotlin-devtools-core` | `redux-kotlin-devtools-core/api/redux-kotlin-devtools-core.klib.api` | DevTools core model: state/action diffing (`DiffOp`, `DiffEntry`). |
-| `:redux-kotlin-devtools-bridge` | `redux-kotlin-devtools-bridge/api/redux-kotlin-devtools-bridge.klib.api` | Wire protocol between app and DevTools UI (`BridgeMessage`). |
+| `:redux-kotlin-devtools-bridge` | `redux-kotlin-devtools-bridge/api/redux-kotlin-devtools-bridge.klib.api` | Wire protocol between app and DevTools UI (`BridgeMessage`, `BridgeConfig`, `BridgeOutput`) plus the `.jsonl` recording codec (`RecordingHeader`, `encodeRecording`/`decodeRecording`). |
 | `:redux-kotlin-devtools-remote` | `redux-kotlin-devtools-remote/api/redux-kotlin-devtools-remote.klib.api` | Remote DevTools transport config (`RemoteConfig`). |
 | `:redux-kotlin-devtools-inapp` | `redux-kotlin-devtools-inapp/api/redux-kotlin-devtools-inapp.klib.api` | In-app DevTools overlay: triggers/config (`DevToolsTrigger`, `InAppConfig`, `DevToolsTab`). |
 | `:redux-kotlin-devtools-inapp-noop` | `redux-kotlin-devtools-inapp-noop/api/redux-kotlin-devtools-inapp-noop.klib.api` | No-op in-app DevTools (same config types, stripped for release builds). |

--- a/docs/agent/references/README.md
+++ b/docs/agent/references/README.md
@@ -9,6 +9,7 @@ checked to resolve (path exists, symbol present). See [_template.md](./_template
 | Concern | Guide | Status |
 |---|---|---|
 | Add a feature slice | [feature-slice.md](./feature-slice.md) | ✅ |
+| DevTools debugging loop | [devtools.md](./devtools.md) | ✅ |
 | Store setup & topology | [store-setup.md](./store-setup.md) | ✅ |
 | Compose binding (Rule C) | [compose-binding.md](./compose-binding.md) | ✅ |
 | Effects + sync (Rule E) | [effects-sync.md](./effects-sync.md) | ✅ |

--- a/docs/agent/references/devtools.md
+++ b/docs/agent/references/devtools.md
@@ -1,0 +1,180 @@
+---
+tier: T1
+concern: devtools
+derives_from:
+  - redux-kotlin-devtools-bridge/src/commonMain/kotlin/org/reduxkotlin/devtools/bridge/BridgeOutput.kt → BridgeOutput
+  - redux-kotlin-devtools-bridge/src/commonMain/kotlin/org/reduxkotlin/devtools/bridge/BridgeConfig.kt → BridgeConfig
+  - redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/ServeCommand.kt → ServeCommand
+  - redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureFormatter.kt → Format
+  - redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/QueryOptions.kt → QueryOptions
+  - redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureStore.kt → StoreRef
+  - redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/RootCommand.kt → RootCommand
+api_files: []
+rules: []
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: 300b1fbd, date: 2026-06-04 }
+---
+
+# DevTools debugging loop
+
+> How an agent observes a running redux-kotlin app's actions, state, and diffs to close a
+> write→run→observe→fix loop instead of debugging blind.
+
+## What it is
+
+The DevTools CLI (`rk-devtools`) gives agents and developers a read-only window into a live or
+recently-run redux-kotlin app. The app emits a structured event stream over a local bridge; the CLI
+receives it, writes per-store JSONL captures, and exposes query subcommands that agents can call at
+any point in a debugging session to answer questions like "what actions fired just before the crash?"
+or "which field changed between actions 40 and 50?"
+
+Without DevTools the loop is: guess → edit → run → read log. With DevTools:
+write → run → `rk-devtools diff --last 10` → targeted fix.
+
+## App opt-in (debug builds only)
+
+Wire the bridge in the app's debug variant. Production builds swap in `:redux-kotlin-devtools-inapp-noop`
+which compiles to no-ops; never ship the bridge in release.
+
+```kotlin
+// In debug DI / app init (debug source set)
+val store = createStore(reducer, initial, devTools(DevToolsConfig(name = "TaskFlow")))
+DevToolsHub.session("TaskFlow")?.let {
+    BridgeOutput(BridgeConfig(clientLabel = "TaskFlow", startEnabled = true)).start(it)
+}
+```
+
+Key types:
+
+- `redux-kotlin-devtools-bridge/src/commonMain/kotlin/org/reduxkotlin/devtools/bridge/BridgeOutput.kt → BridgeOutput`
+  — streams a store's `DevToolsSession` feed to the CLI server. One instance per store.
+  The explicit `BridgeOutput(config).start(session)` call connects the output to the running monitor.
+  `startEnabled` is a separate hint that an automated binder consults to decide whether to auto-start
+  the output at registration; with the explicit `start(...)` above it is moot but harmless to set.
+- `redux-kotlin-devtools-bridge/src/commonMain/kotlin/org/reduxkotlin/devtools/bridge/BridgeConfig.kt → BridgeConfig`
+  — connection settings: `host` (default `127.0.0.1`), `port` (default 9090), `clientLabel`
+  (human display name), optional `token` (required by the server for non-loopback connections).
+
+The bridge is localhost-bound by default. For a device-over-USB session set `host` to the forwarded
+address and supply a matching `--token` on both sides.
+
+## The CLI debugging loop
+
+### Step 1 — start the receiver (`serve`)
+
+```
+rk-devtools serve
+rk-devtools serve --ui          # also open the GUI monitor window
+rk-devtools serve --port 9091   # non-default port
+```
+
+`rk-devtools serve` (`redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/ServeCommand.kt → ServeCommand`)
+binds the bridge WebSocket receiver on `127.0.0.1:9090` (configurable) and writes one
+`<storeKey>.jsonl` capture file per connected store into `.rk-devtools/` in the working directory.
+Run it in a background terminal before launching the app; it persists captures across app restarts.
+`--ui` launches the Compose desktop GUI monitor on top of the same ingest layer.
+
+### Step 2 — discover connected stores (`stores`)
+
+```
+rk-devtools stores
+```
+
+Lists every store key present in `.rk-devtools/` with its human name. A key has the form
+`clientId::storeInstanceId` (e.g., `TaskFlow::root`). Pass it to `--store` in subsequent commands
+when more than one store is captured.
+
+Store discovery reads the JSONL header via
+`redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureStore.kt → StoreRef`.
+
+### Step 3 — query the capture
+
+All query subcommands share a common filter/format layer
+(`redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/QueryOptions.kt → QueryOptions`):
+
+| Flag | Meaning |
+|---|---|
+| `--store <key>` | target store (`clientId::storeInstanceId`); auto-resolved if only one |
+| `--type '*Card*'` | glob filter on action type (`*` = any substring) |
+| `--since <id>` / `--until <id>` | inclusive actionId range |
+| `--last <N>` | keep only the final N results after other filters |
+| `--format actions\|diff\|full` | output tier (see below) |
+| `--pretty` | pretty-print JSON |
+
+Output tiers
+(`redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureFormatter.kt → Format`):
+
+- `actions` — actionId, type, store, timestamp. Lightweight; the default.
+- `diff` — adds the JSON-diff array for each action.
+- `full` — also includes the full state snapshot after each action.
+
+#### `actions` — action log
+
+```
+rk-devtools actions --last 20
+rk-devtools actions --store taskflow::root --type '*Card*' --last 10
+```
+
+Prints the action stream (newest-last) at the `actions` tier. Good for "what happened?"
+
+#### `diff` — state changes
+
+```
+rk-devtools diff --store taskflow::root --type '*Card*' --last 10
+rk-devtools diff --last 5
+```
+
+Same filter options; defaults to the `diff` tier so each line includes the per-field change set.
+Good for "what changed and when?"
+
+#### `state` — snapshot at a point in time
+
+```
+rk-devtools state --at 42
+```
+
+Prints the full state snapshot recorded at actionId 42 (one JSON object). Good for "what was the
+store at the moment of the crash?"
+
+#### `tail` — live follow
+
+```
+rk-devtools tail --follow
+rk-devtools tail --follow --type '*Error*'
+```
+
+Prints current captures then polls for new actions. `--follow` keeps polling (300 ms interval) until
+interrupted; without it, `tail` is a one-shot snapshot of recent actions. Good for watching a
+session live without the GUI.
+
+## Format tiers in detail
+
+Each tier is a strict superset of the previous:
+
+```
+actions → { actionId, type, store, ts }
+diff    → + diff: [ { path, before, after } … ]
+full    → + state: { … full store snapshot … }
+```
+
+Use `actions` for agent filtering (low token cost), `diff` for targeted field investigation, `full`
+only when you need to reconstruct complete store state at a single point.
+
+## Typical agent workflow
+
+1. `rk-devtools serve` — start receiver in background before test run.
+2. Run/reproduce the scenario in the app.
+3. `rk-devtools stores` — confirm the store connected.
+4. `rk-devtools actions --last 30` — get the tail of the action log.
+5. `rk-devtools diff --type '*FailedAction*' --last 5` — isolate the diff around the failure.
+6. `rk-devtools state --at <id>` — inspect full state at the suspect action.
+7. Apply targeted fix; re-run from step 2 to confirm the diff changes as expected.
+
+## Design reference
+
+Full protocol, wire format, server internals, and module boundaries:
+`docs/superpowers/specs/2026-06-04-redux-kotlin-devtools-cli-design.md`
+
+## See also
+
+- [README](./README.md)

--- a/docs/superpowers/plans/2026-06-04-redux-kotlin-devtools-cli.md
+++ b/docs/superpowers/plans/2026-06-04-redux-kotlin-devtools-cli.md
@@ -1,0 +1,1281 @@
+# Redux-Kotlin DevTools CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a JVM CLI (`rk-devtools`) that hosts the DevTools bridge receiver, writes a per-store `.jsonl` capture, optionally launches the bundled GUI, and exposes Compose-free query subcommands (`actions`/`diff`/`state`/`tail`/`stores`) over the captured action+state+diff log.
+
+**Architecture:** New `redux-kotlin-devtools-cli` JVM module, three internal layers: a pure Compose-free `capture/` query library (reads the `.jsonl` recording format), a `server/` writer that snapshots the reused standalone `MonitorIngest` to disk, and a `command/` clikt frontend. `serve` reuses `redux-kotlin-devtools-standalone`'s `MonitorServer`/`MonitorIngest`/`MonitorApp` (Compose, runs once); query subcommands touch only `capture/`. The pure `.jsonl` codec is first moved from `-standalone` down into `-devtools-bridge` so `capture/` can share it Compose-free.
+
+**Tech Stack:** Kotlin/JVM, Clikt (arg parsing), Ktor CIO server + websockets (via the reused standalone server), kotlinx.serialization, kotlinx.coroutines, kotlin-test.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-04-redux-kotlin-devtools-cli-design.md`
+
+---
+
+## Conventions for this module
+
+- The CLI is **not a published library**, so it does not apply `explicitApi()`. But `detektAll` still scans it and `UndocumentedPublicClass/Function/Property` are active (excludes only `*Test`, `examples`, `build-conventions`). **Therefore: declare every class/function `internal` except `fun main`.** Internal symbols are not flagged; only `main` needs a KDoc line.
+- Tests live in `src/test/kotlin` (this is a `kotlin("jvm")` module, not multiplatform). Framework: `kotlin.test`.
+- Run the module's tests with `./gradlew :redux-kotlin-devtools-cli:test`. Lint with `./gradlew detektAll`. Never `--no-verify`.
+- Store key on the wire is `"${clientId}::${storeInstanceId}"` (formed in `MonitorIngest.Connection.accept`). Capture filenames sanitize it.
+
+---
+
+## File Structure
+
+**Refactor (existing modules):**
+- Move from `redux-kotlin-devtools-standalone/src/commonMain/kotlin/org/reduxkotlin/devtools/monitor/Recording.kt` → new `redux-kotlin-devtools-bridge/src/commonMain/kotlin/org/reduxkotlin/devtools/bridge/Recording.kt`: `RecordingHeader`, `encodeRecording`, `decodeRecording`. The `expect/actual saveRecording`/`loadRecording` stay in `-standalone`.
+
+**New module `redux-kotlin-devtools-cli`:**
+- `build.gradle.kts` — module build.
+- `src/main/kotlin/org/reduxkotlin/devtools/cli/Main.kt` — `fun main(args)`.
+- `capture/CaptureReader.kt` — read one capture file → `(RecordingHeader, List<BridgeMessage>)`; extract `Action`s.
+- `capture/CaptureStore.kt` — `safeKey()`, discover store files in a directory, read each header → `StoreRef`.
+- `capture/CaptureQuery.kt` — `QuerySpec` + `apply()` filter over `List<BridgeMessage.Action>`.
+- `capture/CaptureFormatter.kt` — `Format` enum + render records to JSON-lines / pretty.
+- `server/CaptureWriter.kt` — atomically write `(header, messages)` to a per-store `.jsonl`.
+- `server/CaptureFlusher.kt` — collect `ingest.registry.state`, flush each store via `CaptureWriter`.
+- `command/QueryOptions.kt` — shared clikt option group.
+- `command/{Root,Serve,Stores,Actions,Diff,State,Tail}Command.kt` — clikt commands.
+- `src/test/kotlin/.../capture/*Test.kt`, `.../server/*Test.kt` — tests.
+- `settings.gradle.kts` — add `:redux-kotlin-devtools-cli`.
+- `gradle/libs.versions.toml` — add `clikt`.
+
+---
+
+## Task 0: Move the recording codec from `-standalone` to `-devtools-bridge`
+
+**Files:**
+- Read: `redux-kotlin-devtools-standalone/src/commonMain/kotlin/org/reduxkotlin/devtools/monitor/Recording.kt`
+- Create: `redux-kotlin-devtools-bridge/src/commonMain/kotlin/org/reduxkotlin/devtools/bridge/Recording.kt`
+- Modify: `redux-kotlin-devtools-standalone/src/commonMain/kotlin/org/reduxkotlin/devtools/monitor/Recording.kt` (keep only the expect functions), and any importer of `RecordingHeader`/`encodeRecording`/`decodeRecording` in `-standalone`.
+
+- [ ] **Step 1: Create the codec in bridge**
+
+Create `redux-kotlin-devtools-bridge/src/commonMain/kotlin/org/reduxkotlin/devtools/bridge/Recording.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.bridge
+
+import kotlinx.serialization.Serializable
+
+/** Header line of a `.jsonl` DevTools recording — identifies the single store the recording captures. */
+@Serializable
+public data class RecordingHeader(
+    /** Discriminator constant identifying the file kind. */
+    public val kind: String = "rk-devtools-recording",
+    /** Bridge protocol version the recording was produced with. */
+    public val protocolVersion: Int,
+    /** Serializer tier that produced the JSON values. */
+    public val serializerTier: String,
+    /** Stable client (app instance) id. */
+    public val clientId: String,
+    /** Human label for the client. */
+    public val clientLabel: String,
+    /** Store display name. */
+    public val storeName: String,
+    /** Store instance id (unique within a client). */
+    public val storeInstanceId: String,
+)
+
+/** Encode a recording: header line followed by one [BridgeMessage] JSON per line. */
+public fun encodeRecording(header: RecordingHeader, messages: List<BridgeMessage>): String = buildString {
+    appendLine(bridgeJson.encodeToString(RecordingHeader.serializer(), header))
+    messages.forEach { appendLine(bridgeJson.encodeToString(BridgeMessage.serializer(), it)) }
+}
+
+/** Decode a recording produced by [encodeRecording] back into its header and messages. */
+public fun decodeRecording(text: String): Pair<RecordingHeader, List<BridgeMessage>> {
+    val lines = text.split("\n").filter { it.isNotBlank() }
+    require(lines.isNotEmpty()) { "empty recording" }
+    val header = bridgeJson.decodeFromString(RecordingHeader.serializer(), lines.first())
+    val messages = lines.drop(1).map { bridgeJson.decodeFromString(BridgeMessage.serializer(), it) }
+    return header to messages
+}
+```
+
+- [ ] **Step 2: Reduce the standalone Recording.kt to the platform pickers**
+
+Replace the body of `redux-kotlin-devtools-standalone/src/commonMain/kotlin/org/reduxkotlin/devtools/monitor/Recording.kt` so it keeps only the expect functions and re-imports the codec from bridge:
+
+```kotlin
+package org.reduxkotlin.devtools.monitor
+
+// RecordingHeader / encodeRecording / decodeRecording now live in :redux-kotlin-devtools-bridge
+// (org.reduxkotlin.devtools.bridge). Platform file pickers remain here.
+
+/** Persist [text] (an encoded recording) via the platform's save mechanism. */
+public expect fun saveRecording(suggestedName: String, text: String)
+
+/** Load a recording's text via the platform's open mechanism and pass it to [onLoaded]. */
+public expect fun loadRecording(onLoaded: (String) -> Unit)
+```
+
+- [ ] **Step 3: Fix imports in standalone**
+
+Run: `./gradlew :redux-kotlin-devtools-standalone:compileKotlinJvm`
+Expected: FAILs with unresolved `RecordingHeader`/`encodeRecording`/`decodeRecording` in files like `MonitorIngest.kt` and `Recording.jvm.kt`.
+For each failing file, add `import org.reduxkotlin.devtools.bridge.RecordingHeader` (and `encodeRecording`/`decodeRecording` where used). `-standalone` already depends on `:redux-kotlin-devtools-bridge`.
+
+- [ ] **Step 4: Recompile both modules**
+
+Run: `./gradlew :redux-kotlin-devtools-bridge:compileKotlinJvm :redux-kotlin-devtools-standalone:compileKotlinJvm`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Regenerate API dumps (public surface moved between modules)**
+
+Run: `./gradlew :redux-kotlin-devtools-bridge:apiDump :redux-kotlin-devtools-standalone:apiDump`
+Expected: `redux-kotlin-devtools-bridge/api/*.api` gains `RecordingHeader`/`encodeRecording`/`decodeRecording`; `redux-kotlin-devtools-standalone/api/*.api` loses them.
+
+- [ ] **Step 6: Run standalone tests + lint**
+
+Run: `./gradlew :redux-kotlin-devtools-standalone:jvmTest :redux-kotlin-devtools-bridge:jvmTest detektAll`
+Expected: BUILD SUCCESSFUL (the move is behavior-preserving).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add redux-kotlin-devtools-bridge redux-kotlin-devtools-standalone
+git commit -m "refactor(devtools): move .jsonl recording codec from standalone to bridge"
+```
+
+---
+
+## Task 1: Scaffold the `redux-kotlin-devtools-cli` module
+
+**Files:**
+- Modify: `settings.gradle.kts`
+- Modify: `gradle/libs.versions.toml`
+- Create: `redux-kotlin-devtools-cli/build.gradle.kts`
+- Create: `redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/Main.kt`
+
+- [ ] **Step 1: Add Clikt to the version catalog**
+
+In `gradle/libs.versions.toml`, under `[versions]` add `clikt = "4.4.0"`, and under `[libraries]` add:
+
+```toml
+clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
+```
+
+- [ ] **Step 2: Include the module**
+
+In `settings.gradle.kts`, add `":redux-kotlin-devtools-cli",` to the `include(...)` list immediately after `":redux-kotlin-devtools-standalone",`.
+
+- [ ] **Step 3: Create the build file**
+
+Create `redux-kotlin-devtools-cli/build.gradle.kts`:
+
+```kotlin
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id("convention.common")
+    kotlin("jvm")
+    application
+    alias(libs.plugins.kotlin.serialization)
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+application {
+    applicationName = "rk-devtools"
+    mainClass.set("org.reduxkotlin.devtools.cli.MainKt")
+}
+
+dependencies {
+    implementation(project(":redux-kotlin-devtools-core"))
+    implementation(project(":redux-kotlin-devtools-bridge"))
+    implementation(project(":redux-kotlin-devtools-standalone"))
+    implementation(libs.clikt)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.coroutines.core)
+    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlinx.coroutines.test)
+}
+```
+
+- [ ] **Step 4: Create a minimal Main**
+
+Create `redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/Main.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli
+
+/** CLI entry point for the redux-kotlin DevTools tool. */
+public fun main(args: Array<String>) {
+    println("rk-devtools (args: ${args.joinToString(" ")})")
+}
+```
+
+- [ ] **Step 5: Verify the module assembles and is wired**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:compileKotlin`
+Expected: BUILD SUCCESSFUL.
+Run: `./gradlew :redux-kotlin-devtools-cli:run --args="hello"`
+Expected: prints `rk-devtools (args: hello)`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add settings.gradle.kts gradle/libs.versions.toml redux-kotlin-devtools-cli
+git commit -m "build(devtools-cli): scaffold JVM CLI module"
+```
+
+---
+
+## Task 2: `capture/CaptureStore` — store key sanitization + discovery
+
+**Files:**
+- Create: `redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureStore.kt`
+- Test: `redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureStoreTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `CaptureStoreTest.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.capture
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CaptureStoreTest {
+    @Test
+    fun safeKey_sanitizes_separator_and_unsafe_chars() {
+        assertEquals("taskflow__TaskFlow-root", safeKey("taskflow::TaskFlow-root"))
+        assertEquals("a_b__c_d", safeKey("a/b::c d"))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:test --tests "*CaptureStoreTest"`
+Expected: FAIL — `safeKey` unresolved.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `CaptureStore.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.capture
+
+import org.reduxkotlin.devtools.bridge.RecordingHeader
+import org.reduxkotlin.devtools.bridge.decodeRecording
+import java.io.File
+
+/** A store discovered in a capture directory. */
+internal data class StoreRef(val key: String, val name: String, val file: File)
+
+/** Convert a wire store key (`clientId::storeInstanceId`) into a filesystem-safe base name. */
+internal fun safeKey(storeKey: String): String =
+    storeKey.replace("::", "__").replace(Regex("[^A-Za-z0-9_.-]"), "_")
+
+/** Capture file name for a store key. */
+internal fun captureFileName(storeKey: String): String = "${safeKey(storeKey)}.jsonl"
+
+/** List the store recordings present in [dir] by reading each file's header. */
+internal fun discoverStores(dir: File): List<StoreRef> {
+    if (!dir.isDirectory) return emptyList()
+    return dir.listFiles { f -> f.isFile && f.name.endsWith(".jsonl") }
+        ?.mapNotNull { f ->
+            runCatching {
+                val header: RecordingHeader = decodeRecording(f.readText()).first
+                StoreRef(key = "${header.clientId}::${header.storeInstanceId}", name = header.storeName, file = f)
+            }.getOrNull()
+        }
+        ?.sortedBy { it.key }
+        .orEmpty()
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:test --tests "*CaptureStoreTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-devtools-cli
+git commit -m "feat(devtools-cli): capture store key sanitization + discovery"
+```
+
+---
+
+## Task 3: `capture/CaptureReader` — read a file → Action records
+
+**Files:**
+- Create: `redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureReader.kt`
+- Test: `redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureReaderTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `CaptureReaderTest.kt`. It builds a recording with the real codec, including a trailing partial line, and asserts the reader returns the actions and tolerates the partial line:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.capture
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.PROTOCOL_VERSION
+import org.reduxkotlin.devtools.bridge.RecordingHeader
+import org.reduxkotlin.devtools.bridge.encodeRecording
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CaptureReaderTest {
+    private fun header() = RecordingHeader(
+        protocolVersion = PROTOCOL_VERSION, serializerTier = "json",
+        clientId = "taskflow", clientLabel = "TaskFlow", storeName = "TaskFlow", storeInstanceId = "root",
+    )
+
+    private fun action(id: Int, type: String) = BridgeMessage.Action(
+        actionId = id,
+        action = buildJsonObject { put("type", JsonPrimitive(type)) },
+        state = buildJsonObject { put("n", JsonPrimitive(id)) },
+        diff = emptyList(),
+        timestampMillis = id.toLong(),
+        isExcess = false,
+    )
+
+    @Test
+    fun reads_actions_and_tolerates_trailing_partial_line() {
+        val text = encodeRecording(header(), listOf(action(1, "A"), action(2, "B"))) + "{\"t\":\"acti"  // partial
+        val (h, actions) = parseCapture(text)
+        assertEquals("TaskFlow", h.storeName)
+        assertEquals(listOf(1, 2), actions.map { it.actionId })
+        assertEquals(listOf("A", "B"), actions.map { actionType(it.action) })
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:test --tests "*CaptureReaderTest"`
+Expected: FAIL — `parseCapture` / `actionType` unresolved.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `CaptureReader.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.capture
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.RecordingHeader
+import org.reduxkotlin.devtools.bridge.bridgeJson
+import java.io.File
+
+/** Parse capture [text]: first line is the header, subsequent lines are messages; a trailing partial line is skipped. */
+internal fun parseCapture(text: String): Pair<RecordingHeader, List<BridgeMessage.Action>> {
+    val lines = text.split("\n").filter { it.isNotBlank() }
+    require(lines.isNotEmpty()) { "empty capture" }
+    val header = bridgeJson.decodeFromString(RecordingHeader.serializer(), lines.first())
+    val actions = lines.drop(1).mapNotNull { line ->
+        runCatching { bridgeJson.decodeFromString(BridgeMessage.serializer(), line) }
+            .getOrNull() as? BridgeMessage.Action
+    }
+    return header to actions
+}
+
+/** Read a capture [file] from disk. */
+internal fun readCapture(file: File): Pair<RecordingHeader, List<BridgeMessage.Action>> = parseCapture(file.readText())
+
+/** Render the `type` discriminant of a serialized action for display/filtering. */
+internal fun actionType(action: JsonElement): String =
+    ((action as? JsonObject)?.get("type") as? JsonPrimitive)?.content ?: "?"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:test --tests "*CaptureReaderTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-devtools-cli
+git commit -m "feat(devtools-cli): capture reader (header + actions, partial-line tolerant)"
+```
+
+---
+
+## Task 4: `capture/CaptureQuery` — filtering
+
+**Files:**
+- Create: `redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureQuery.kt`
+- Test: `redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureQueryTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `CaptureQueryTest.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.capture
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CaptureQueryTest {
+    private fun a(id: Int, type: String, ts: Long = id.toLong()) = BridgeMessage.Action(
+        actionId = id, action = buildJsonObject { put("type", JsonPrimitive(type)) },
+        state = buildJsonObject {}, diff = emptyList(), timestampMillis = ts, isExcess = false,
+    )
+
+    private val data = listOf(a(1, "AddCard"), a(2, "MoveCard"), a(3, "AddColumn"), a(4, "CardOpFailed"))
+
+    @Test
+    fun filters_by_type_glob() {
+        val out = QuerySpec(type = "*Card*").apply(data)
+        assertEquals(listOf(1, 2), out.map { it.actionId })
+    }
+
+    @Test
+    fun filters_by_since_until_id_and_last() {
+        assertEquals(listOf(2, 3), QuerySpec(sinceId = 2, untilId = 3).apply(data).map { it.actionId })
+        assertEquals(listOf(3, 4), QuerySpec(last = 2).apply(data).map { it.actionId })
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:test --tests "*CaptureQueryTest"`
+Expected: FAIL — `QuerySpec` unresolved.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `CaptureQuery.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.capture
+
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+
+/** A filter over captured actions. `type` is a glob (`*` wildcard); id/time bounds are inclusive. */
+internal data class QuerySpec(
+    val type: String? = null,
+    val sinceId: Int? = null,
+    val untilId: Int? = null,
+    val sinceTs: Long? = null,
+    val untilTs: Long? = null,
+    val last: Int? = null,
+) {
+    /** Apply the filter, preserving capture order; `last` truncates to the final N after filtering. */
+    fun apply(actions: List<BridgeMessage.Action>): List<BridgeMessage.Action> {
+        val rx = type?.let { Regex("^" + Regex.escape(it).replace("\\*", ".*") + "$") }
+        val filtered = actions.filter { a ->
+            (rx == null || rx.matches(actionType(a.action))) &&
+                (sinceId == null || a.actionId >= sinceId) &&
+                (untilId == null || a.actionId <= untilId) &&
+                (sinceTs == null || a.timestampMillis >= sinceTs) &&
+                (untilTs == null || a.timestampMillis <= untilTs)
+        }
+        return if (last != null && last < filtered.size) filtered.takeLast(last) else filtered
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:test --tests "*CaptureQueryTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-devtools-cli
+git commit -m "feat(devtools-cli): capture query filtering (type glob, id/ts bounds, last-N)"
+```
+
+---
+
+## Task 5: `capture/CaptureFormatter` — the `--format` tiers
+
+**Files:**
+- Create: `redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureFormatter.kt`
+- Test: `redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureFormatterTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `CaptureFormatterTest.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.capture
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.core.DiffEntry
+import org.reduxkotlin.devtools.core.DiffOp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CaptureFormatterTest {
+    private val action = BridgeMessage.Action(
+        actionId = 7,
+        action = buildJsonObject { put("type", JsonPrimitive("AddCard")) },
+        state = buildJsonObject { put("count", JsonPrimitive(1)) },
+        diff = listOf(DiffEntry(DiffOp.CHANGED, "count", JsonPrimitive(0), JsonPrimitive(1))),
+        timestampMillis = 123L,
+        isExcess = false,
+    )
+
+    @Test
+    fun actions_tier_omits_diff_and_state() {
+        val line = formatRecord(action, Format.ACTIONS, store = "taskflow::root")
+        val obj = Json.parseToJsonElement(line).jsonObject
+        assertEquals(setOf("actionId", "type", "store", "ts"), obj.keys)
+    }
+
+    @Test
+    fun diff_tier_adds_diff_only() {
+        val obj = Json.parseToJsonElement(formatRecord(action, Format.DIFF, "s")).jsonObject
+        assertTrue("diff" in obj.keys && "state" !in obj.keys)
+    }
+
+    @Test
+    fun full_tier_adds_state() {
+        val obj = Json.parseToJsonElement(formatRecord(action, Format.FULL, "s")).jsonObject
+        assertTrue("diff" in obj.keys && "state" in obj.keys)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:test --tests "*CaptureFormatterTest"`
+Expected: FAIL — `Format`/`formatRecord` unresolved.
+
+> Note: confirm the `DiffEntry`/`DiffOp` package is `org.reduxkotlin.devtools.core` by checking `redux-kotlin-devtools-core/src/commonMain/kotlin/org/reduxkotlin/devtools/JsonDiff.kt`'s `package` line; adjust the import if it differs.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `CaptureFormatter.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.capture
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.bridgeJson
+
+/** Output granularity tiers; each is a strict superset of the previous. */
+internal enum class Format { ACTIONS, DIFF, FULL }
+
+private val prettyJson = Json(bridgeJson) { prettyPrint = true }
+
+/** Render one action record to a single JSON object string at the requested [format] tier. */
+internal fun formatRecord(action: BridgeMessage.Action, format: Format, store: String, pretty: Boolean = false): String {
+    val obj: JsonObject = buildJsonObject {
+        put("actionId", JsonPrimitive(action.actionId))
+        put("type", JsonPrimitive(actionType(action.action)))
+        put("store", JsonPrimitive(store))
+        put("ts", JsonPrimitive(action.timestampMillis))
+        if (action.isExcess) put("isExcess", JsonPrimitive(true))
+        if (format == Format.DIFF || format == Format.FULL) {
+            put("diff", bridgeJson.encodeToJsonElement(action.diff) as JsonElement)
+        }
+        if (format == Format.FULL) put("state", action.state)
+    }
+    val j = if (pretty) prettyJson else bridgeJson
+    return j.encodeToString(JsonObject.serializer(), obj)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:test --tests "*CaptureFormatterTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-devtools-cli
+git commit -m "feat(devtools-cli): capture formatter (actions/diff/full tiers, json-lines/pretty)"
+```
+
+---
+
+## Task 6: `server/CaptureWriter` — atomic per-store file write
+
+**Files:**
+- Create: `redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/server/CaptureWriter.kt`
+- Test: `redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/server/CaptureWriterTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `CaptureWriterTest.kt` (round-trips through the real reader):
+
+```kotlin
+package org.reduxkotlin.devtools.cli.server
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.PROTOCOL_VERSION
+import org.reduxkotlin.devtools.bridge.RecordingHeader
+import org.reduxkotlin.devtools.cli.capture.readCapture
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CaptureWriterTest {
+    @Test
+    fun writes_a_gui_loadable_recording_for_a_store() {
+        val dir = Files.createTempDirectory("rkcap").toFile()
+        val header = RecordingHeader(
+            protocolVersion = PROTOCOL_VERSION, serializerTier = "json",
+            clientId = "taskflow", clientLabel = "TaskFlow", storeName = "TaskFlow", storeInstanceId = "root",
+        )
+        val msgs = listOf(
+            BridgeMessage.Action(1, buildJsonObject { put("type", JsonPrimitive("A")) }, buildJsonObject {}, emptyList(), 1L, false),
+        )
+        val file: File = writeStoreCapture(dir, "taskflow::root", header, msgs)
+        assertTrue(file.name.endsWith(".jsonl"))
+        assertEquals(listOf(1), readCapture(file).second.map { it.actionId })
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:test --tests "*CaptureWriterTest"`
+Expected: FAIL — `writeStoreCapture` unresolved.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `CaptureWriter.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.server
+
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.RecordingHeader
+import org.reduxkotlin.devtools.bridge.encodeRecording
+import org.reduxkotlin.devtools.cli.capture.captureFileName
+import java.io.File
+
+/** Atomically write a store's recording into [dir] as `<safeKey>.jsonl`; returns the file. */
+internal fun writeStoreCapture(
+    dir: File,
+    storeKey: String,
+    header: RecordingHeader,
+    messages: List<BridgeMessage>,
+): File {
+    dir.mkdirs()
+    val target = File(dir, captureFileName(storeKey))
+    val tmp = File(dir, target.name + ".tmp")
+    tmp.writeText(encodeRecording(header, messages))
+    tmp.copyTo(target, overwrite = true)
+    tmp.delete()
+    return target
+}
+```
+
+> `copyTo` + delete is used rather than `renameTo` so an in-progress reader on Windows never observes a missing target. The reader (Task 3) already tolerates a partial trailing line.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:test --tests "*CaptureWriterTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-devtools-cli
+git commit -m "feat(devtools-cli): atomic per-store capture writer"
+```
+
+---
+
+## Task 7: `server/CaptureFlusher` — snapshot the ingest to disk
+
+**Files:**
+- Create: `redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/server/CaptureFlusher.kt`
+- Test: `redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/server/CaptureFlusherTest.kt`
+
+This wraps the reused `MonitorIngest`: it feeds wire messages into a `MonitorIngest.Connection`, then flushes every known store via `ingest.recordingFor(storeId)` → `writeStoreCapture`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `CaptureFlusherTest.kt`. It drives a real `MonitorIngest` with a Hello + an Action, flushes, and asserts a capture file exists with the action:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.server
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.PROTOCOL_VERSION
+import org.reduxkotlin.devtools.cli.capture.discoverStores
+import org.reduxkotlin.devtools.cli.capture.readCapture
+import org.reduxkotlin.devtools.monitor.MonitorIngest
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CaptureFlusherTest {
+    @Test
+    fun flushes_each_store_to_a_capture_file() {
+        val dir = Files.createTempDirectory("rkflush").toFile()
+        val ingest = MonitorIngest()
+        val conn = ingest.openConnection()
+        conn.accept(
+            BridgeMessage.Hello(
+                protocolVersion = PROTOCOL_VERSION, clientId = "taskflow", clientLabel = "TaskFlow",
+                storeInstanceId = "root", storeName = "TaskFlow", serializerTier = "json",
+            ),
+        )
+        conn.accept(
+            BridgeMessage.Action(1, buildJsonObject { put("type", JsonPrimitive("A")) }, buildJsonObject {}, emptyList(), 1L, false),
+        )
+
+        flushAll(ingest, dir)
+
+        val stores = discoverStores(dir)
+        assertEquals(listOf("taskflow::root"), stores.map { it.key })
+        assertEquals(listOf(1), readCapture(stores.first().file).second.map { it.actionId })
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:test --tests "*CaptureFlusherTest"`
+Expected: FAIL — `flushAll` unresolved.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `CaptureFlusher.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.server
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import org.reduxkotlin.devtools.monitor.MonitorIngest
+import java.io.File
+
+/** Write every store currently known to [ingest] into [dir] as a `.jsonl` recording. */
+internal fun flushAll(ingest: MonitorIngest, dir: File) {
+    ingest.registry.state.value.stores.forEach { entry ->
+        val rec = ingest.recordingFor(entry.ref.id) ?: return@forEach
+        writeStoreCapture(dir, entry.ref.id, rec.first, rec.second)
+    }
+}
+
+/** Continuously flush captures to [dir] whenever the ingest registry changes. Launches in [scope]. */
+internal fun startFlushing(scope: CoroutineScope, ingest: MonitorIngest, dir: File) {
+    scope.launch {
+        ingest.registry.state.collectLatest { flushAll(ingest, dir) }
+    }
+}
+```
+
+> `entry.ref.id` is the store key `clientId::storeInstanceId` (see `StoreRegistryModel`/`MonitorIngest`). Confirm `StoreEntry.ref.id` carries that exact key by reading `StoreRegistryModel.put` call sites in `MonitorIngest`; if the registry id differs from the recording key, pass the `recordingFor` key through instead.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:test --tests "*CaptureFlusherTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-devtools-cli
+git commit -m "feat(devtools-cli): flush reused MonitorIngest snapshots to per-store captures"
+```
+
+---
+
+## Task 8: `command/QueryOptions` + `Stores`/`Actions`/`Diff`/`State` commands
+
+**Files:**
+- Create: `redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/QueryOptions.kt`
+- Create: `.../command/StoresCommand.kt`, `ActionsCommand.kt`, `DiffCommand.kt`, `StateCommand.kt`
+- Test: `.../src/test/kotlin/org/reduxkotlin/devtools/cli/command/QueryResolveTest.kt`
+
+The query commands are thin: resolve the capture dir + target store file, read, filter, format, print. Put the resolve/select logic in a testable helper; the clikt classes are wiring.
+
+- [ ] **Step 1: Write the failing test for store resolution**
+
+Create `QueryResolveTest.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.command
+
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.PROTOCOL_VERSION
+import org.reduxkotlin.devtools.bridge.RecordingHeader
+import org.reduxkotlin.devtools.cli.server.writeStoreCapture
+import kotlinx.serialization.json.buildJsonObject
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class QueryResolveTest {
+    private fun seed(dir: java.io.File, key: String) {
+        val (c, s) = key.split("::")
+        writeStoreCapture(dir, key, RecordingHeader(
+            protocolVersion = PROTOCOL_VERSION, serializerTier = "json",
+            clientId = c, clientLabel = c, storeName = c, storeInstanceId = s,
+        ), listOf(BridgeMessage.Init(buildJsonObject {})))
+    }
+
+    @Test
+    fun single_store_resolves_without_flag() {
+        val dir = Files.createTempDirectory("rkq").toFile(); seed(dir, "app::root")
+        assertEquals("app::root", resolveStore(dir, null).key)
+    }
+
+    @Test
+    fun multiple_stores_require_the_flag() {
+        val dir = Files.createTempDirectory("rkq").toFile(); seed(dir, "app::root"); seed(dir, "app::acct")
+        assertFailsWith<IllegalStateException> { resolveStore(dir, null) }
+        assertEquals("app::acct", resolveStore(dir, "app::acct").key)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:test --tests "*QueryResolveTest"`
+Expected: FAIL — `resolveStore` unresolved.
+
+- [ ] **Step 3: Write the shared query options + resolver**
+
+Create `QueryOptions.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.command
+
+import com.github.ajalt.clikt.parameters.groups.OptionGroup
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.enum
+import com.github.ajalt.clikt.parameters.types.int
+import com.github.ajalt.clikt.parameters.types.long
+import org.reduxkotlin.devtools.cli.capture.Format
+import org.reduxkotlin.devtools.cli.capture.QuerySpec
+import org.reduxkotlin.devtools.cli.capture.StoreRef
+import org.reduxkotlin.devtools.cli.capture.discoverStores
+import java.io.File
+
+/** Default capture directory under the current working dir. */
+internal fun defaultCaptureDir(): File = File(".rk-devtools")
+
+/** Pick the target store: the only one if unambiguous, or the one matching [key]. */
+internal fun resolveStore(dir: File, key: String?): StoreRef {
+    val stores = discoverStores(dir)
+    check(stores.isNotEmpty()) { "no captures found in ${dir.path} (is `rk-devtools serve` running?)" }
+    if (key != null) return stores.firstOrNull { it.key == key }
+        ?: error("store '$key' not found; available: ${stores.joinToString { it.key }}")
+    check(stores.size == 1) { "multiple stores present; pass --store <key>: ${stores.joinToString { it.key }}" }
+    return stores.first()
+}
+
+/** Shared filter/format flags for query subcommands. */
+internal class QueryOptions : OptionGroup() {
+    val out by option("--out", help = "capture directory").default(".rk-devtools")
+    val store by option("--store", help = "store key (clientId::storeInstanceId)")
+    val type by option("--type", help = "action type glob, e.g. '*Card*'")
+    val sinceId by option("--since", help = "min actionId").int()
+    val untilId by option("--until", help = "max actionId").int()
+    val last by option("--last", help = "keep only the final N").int()
+    val format by option("--format").enum<Format>().default(Format.ACTIONS)
+    val pretty by option("--pretty", help = "pretty-print JSON").default("false")
+
+    fun spec() = QuerySpec(type = type, sinceId = sinceId, untilId = untilId, last = last)
+    fun dir() = File(out)
+    fun prettyEnabled() = pretty == "true" || pretty == ""
+}
+```
+
+> `enum<Format>()` matches on lowercase via clikt's `--format actions|diff|full`; verify clikt's enum option is case-insensitive in 4.4.0, else add `.enum<Format>(ignoreCase = true)`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:test --tests "*QueryResolveTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Write the four query commands**
+
+Create `ActionsCommand.kt` (the `diff`/`state` variants reuse the same pieces):
+
+```kotlin
+package org.reduxkotlin.devtools.cli.command
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.groups.provideDelegate
+import org.reduxkotlin.devtools.cli.capture.Format
+import org.reduxkotlin.devtools.cli.capture.formatRecord
+import org.reduxkotlin.devtools.cli.capture.readCapture
+
+/** `actions` — list captured actions at the chosen --format tier. */
+internal class ActionsCommand(private val forced: Format? = null) :
+    CliktCommand(name = if (forced == Format.DIFF) "diff" else "actions") {
+    private val q by QueryOptions()
+    override fun run() {
+        val ref = resolveStore(q.dir(), q.store)
+        val actions = q.spec().apply(readCapture(ref.file).second)
+        val fmt = forced ?: q.format
+        actions.forEach { echo(formatRecord(it, fmt, ref.key, q.prettyEnabled())) }
+    }
+}
+```
+
+Create `DiffCommand.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.command
+
+import org.reduxkotlin.devtools.cli.capture.Format
+
+/** `diff` — alias for `actions --format diff`. */
+internal class DiffCommand : ActionsCommand(forced = Format.DIFF)
+```
+
+Create `StateCommand.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.command
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.groups.provideDelegate
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.int
+import org.reduxkotlin.devtools.bridge.bridgeJson
+import org.reduxkotlin.devtools.cli.capture.readCapture
+import kotlinx.serialization.json.JsonElement
+
+/** `state` — print the full post-state after the latest action (or --at <actionId>). */
+internal class StateCommand : CliktCommand(name = "state") {
+    private val out by option("--out").default(".rk-devtools")
+    private val store by option("--store")
+    private val at by option("--at").int()
+    override fun run() {
+        val ref = resolveStore(java.io.File(out), store)
+        val actions = readCapture(ref.file).second
+        val target = if (at != null) actions.firstOrNull { it.actionId == at } else actions.lastOrNull()
+        if (target == null) { echo("no matching action", err = true); return }
+        echo(bridgeJson.encodeToString(JsonElement.serializer(), target.state))
+    }
+}
+```
+
+> `StateCommand` needs `import com.github.ajalt.clikt.parameters.options.default`.
+
+Create `StoresCommand.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.command
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import org.reduxkotlin.devtools.cli.capture.discoverStores
+
+/** `stores` — list the store keys present in the capture directory. */
+internal class StoresCommand : CliktCommand(name = "stores") {
+    private val out by option("--out").default(".rk-devtools")
+    override fun run() = discoverStores(java.io.File(out)).forEach { echo("${it.key}\t${it.name}") }
+}
+```
+
+- [ ] **Step 6: Verify compilation**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:compileKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add redux-kotlin-devtools-cli
+git commit -m "feat(devtools-cli): query subcommands (stores/actions/diff/state) + shared options"
+```
+
+---
+
+## Task 9: `command/ServeCommand` + `TailCommand` + `RootCommand` wiring
+
+**Files:**
+- Create: `.../command/ServeCommand.kt`, `TailCommand.kt`, `RootCommand.kt`
+- Modify: `.../Main.kt`
+
+- [ ] **Step 1: Write the serve command**
+
+Create `ServeCommand.kt`. It reuses the standalone server + ingest, starts flushing, and either renders the GUI (`--ui`) or blocks headless:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.command
+
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.int
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import org.reduxkotlin.devtools.cli.server.startFlushing
+import org.reduxkotlin.devtools.monitor.MonitorIngest
+import org.reduxkotlin.devtools.monitor.MonitorServer
+import org.reduxkotlin.devtools.monitor.rememberMonitorState
+import org.reduxkotlin.devtools.monitor.ui.MonitorApp
+import java.io.File
+
+/** `serve` — host the bridge receiver, write per-store captures, optionally launch the GUI. */
+internal class ServeCommand : CliktCommand(name = "serve") {
+    private val port by option("--port").int().default(9090)
+    private val host by option("--host").default("127.0.0.1")
+    private val token by option("--token")
+    private val out by option("--out").default(".rk-devtools")
+    private val ui by option("--ui", help = "also launch the GUI monitor").flag()
+
+    override fun run() {
+        val dir = File(out).apply { mkdirs() }
+        val ingest = MonitorIngest()
+        val server = MonitorServer(ingest, port = port, host = host, token = token)
+        val bound = server.start()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        startFlushing(scope, ingest, dir)
+        echo("serving bridge on $host:$bound  → captures in ${dir.path}")
+        if (ui) {
+            application {
+                Window(onCloseRequest = { server.stop(); exitApplication() }, title = "Redux DevTools Monitor") {
+                    MonitorApp(ingest, rememberMonitorState(ingest))
+                }
+            }
+        } else {
+            runBlocking { kotlinx.coroutines.awaitCancellation() }
+        }
+    }
+}
+```
+
+> Verify the exact package/signature of `MonitorApp` and `rememberMonitorState` against `redux-kotlin-devtools-standalone/src/commonMain/kotlin/org/reduxkotlin/devtools/monitor/Main.kt` (it uses `org.reduxkotlin.devtools.monitor.ui.MonitorApp` and `rememberMonitorState(ingest)`); adjust imports to match.
+
+- [ ] **Step 2: Write the tail command**
+
+Create `TailCommand.kt` (one-shot prints recent; `--follow` polls the file):
+
+```kotlin
+package org.reduxkotlin.devtools.cli.command
+
+import com.github.ajalt.clikt.parameters.groups.provideDelegate
+import com.github.ajalt.clikt.core.CliktCommand
+import org.reduxkotlin.devtools.cli.capture.formatRecord
+import org.reduxkotlin.devtools.cli.capture.readCapture
+
+/** `tail` — print recent actions; with --follow, poll the capture for new ones. */
+internal class TailCommand : CliktCommand(name = "tail") {
+    private val q by QueryOptions()
+    private val follow by com.github.ajalt.clikt.parameters.options.option("--follow")
+        .flag()
+
+    override fun run() {
+        val ref = resolveStore(q.dir(), q.store)
+        var lastId = -1
+        fun pump() {
+            readCapture(ref.file).second
+                .filter { it.actionId > lastId }
+                .let { q.spec().apply(it) }
+                .forEach { lastId = maxOf(lastId, it.actionId); echo(formatRecord(it, q.format, ref.key, q.prettyEnabled())) }
+        }
+        pump()
+        while (follow) { Thread.sleep(POLL_MS); runCatching { pump() } }
+    }
+
+    private companion object { const val POLL_MS = 300L }
+}
+```
+
+> Needs `import com.github.ajalt.clikt.parameters.options.flag`.
+
+- [ ] **Step 3: Write the root command and wire Main**
+
+Create `RootCommand.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli.command
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.subcommands
+
+/** Root `rk-devtools` command; dispatches to subcommands. */
+internal class RootCommand : CliktCommand(name = "rk-devtools") {
+    override fun run() = Unit
+}
+
+/** Build the configured command tree. */
+internal fun rootCommand(): CliktCommand = RootCommand().subcommands(
+    ServeCommand(), StoresCommand(), ActionsCommand(), DiffCommand(), StateCommand(), TailCommand(),
+)
+```
+
+Replace `Main.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli
+
+import org.reduxkotlin.devtools.cli.command.rootCommand
+
+/** CLI entry point for the redux-kotlin DevTools tool. */
+public fun main(args: Array<String>) {
+    rootCommand().main(args)
+}
+```
+
+- [ ] **Step 4: Verify the command tree builds and prints help**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:run --args="--help"`
+Expected: lists subcommands `serve`, `stores`, `actions`, `diff`, `state`, `tail`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-devtools-cli
+git commit -m "feat(devtools-cli): serve (reused server + optional GUI), tail, root command"
+```
+
+---
+
+## Task 10: End-to-end smoke test + distribution
+
+**Files:**
+- Test: `redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/EndToEndTest.kt`
+
+- [ ] **Step 1: Write an end-to-end test (server → capture → query helpers)**
+
+This drives the real `MonitorServer` over a loopback WebSocket using the existing `BridgeOutput` client path is heavy; instead assert the headless pipeline: feed `MonitorIngest`, flush, then run the query resolver + formatter end to end.
+
+Create `EndToEndTest.kt`:
+
+```kotlin
+package org.reduxkotlin.devtools.cli
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.PROTOCOL_VERSION
+import org.reduxkotlin.devtools.cli.capture.Format
+import org.reduxkotlin.devtools.cli.capture.formatRecord
+import org.reduxkotlin.devtools.cli.capture.readCapture
+import org.reduxkotlin.devtools.cli.command.resolveStore
+import org.reduxkotlin.devtools.cli.server.flushAll
+import org.reduxkotlin.devtools.monitor.MonitorIngest
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EndToEndTest {
+    @Test
+    fun ingest_to_capture_to_query() {
+        val dir = Files.createTempDirectory("rke2e").toFile()
+        val ingest = MonitorIngest()
+        val conn = ingest.openConnection()
+        conn.accept(BridgeMessage.Hello(PROTOCOL_VERSION, "taskflow", "TaskFlow", "root", "TaskFlow", "json"))
+        conn.accept(BridgeMessage.Action(1, buildJsonObject { put("type", JsonPrimitive("AddCard")) }, buildJsonObject {}, emptyList(), 1L, false))
+
+        flushAll(ingest, dir)
+
+        val ref = resolveStore(dir, null)
+        val actions = readCapture(ref.file).second
+        assertEquals(listOf("AddCard"), actions.map { org.reduxkotlin.devtools.cli.capture.actionType(it.action) })
+        assertTrue(formatRecord(actions.first(), Format.ACTIONS, ref.key).contains("\"type\":\"AddCard\""))
+    }
+}
+```
+
+- [ ] **Step 2: Run the full module test suite**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:test`
+Expected: PASS (all capture/server/command/e2e tests).
+
+- [ ] **Step 3: Verify the distributable installs**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:installDist`
+Expected: BUILD SUCCESSFUL; a launcher appears at `redux-kotlin-devtools-cli/build/install/rk-devtools/bin/rk-devtools`.
+
+- [ ] **Step 4: Full gate**
+
+Run: `./gradlew :redux-kotlin-devtools-cli:test detektAll apiCheck`
+Expected: BUILD SUCCESSFUL. (No `apiDump` for the CLI module — it is not a published library and applies no `convention.publishing`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-devtools-cli
+git commit -m "test(devtools-cli): end-to-end ingest→capture→query + installDist"
+```
+
+---
+
+## Task 11: Document the opt-in in the agent reference set
+
+**Files:**
+- Modify: `docs/agent/references/effects-sync.md` or create a short `docs/agent/references/devtools.md` (follow the reference-set format + anchor conventions in `docs/agent/references/_template.md`).
+
+- [ ] **Step 1: Add the integrator wiring + agent usage**
+
+Document the app-side opt-in (the `BridgeOutput(BridgeConfig(startEnabled = true))` block from the spec §8) and the agent debugging loop (`rk-devtools serve` in the background, then `rk-devtools diff --store <k> --type '*Card*' --last 10`). Cite real anchors (`redux-kotlin-devtools-bridge/.../BridgeOutput.kt → BridgeOutput`, etc.) so `scripts/check-agent-refs.sh` passes.
+
+- [ ] **Step 2: Validate anchors + commit**
+
+Run: `bash scripts/check-agent-refs.sh`
+Expected: ANCHOR CHECK OK.
+
+```bash
+git add docs/agent
+git commit -m "docs(agent): document DevTools CLI debugging loop + bridge opt-in"
+```
+
+---
+
+## Self-review notes (resolved during planning)
+
+- **Spec §4 dependency claim adjusted:** the reusable server (`MonitorServer`/`MonitorIngest`) lives in the Compose `-standalone` module, so `serve` depends on it (Compose pulled into the once-run daemon only). Query subcommands depend solely on the Compose-free `capture/` lib. The `.jsonl` codec is moved to `-devtools-bridge` (Task 0) so `capture/` shares it without Compose. Approved by the user.
+- **Spec §5 "one file" refined to one file *per store*:** the recording header is single-store, so a multiplexed single file would break GUI-loadability. Per-store files preserve interop and make `--store` a file selection. Captured in Tasks 2/6/7.
+- **`isExcess` preserved** in `formatRecord` (Task 5) so eviction is visible, per spec §5.
+- **Deferred items remain out:** no `digest`, no pipeline-timing in output, no dispatch-back, no MCP, no rotation (the `capture/` lib is the MCP seam; per-store snapshot bounded by `MonitorIngest` MAX_CAPTURED=5000 — note in Task 7 if larger histories are needed later).
+
+## Open verification points for the implementer (cheap to confirm, flagged at use site)
+
+1. `DiffEntry`/`DiffOp` package (`org.reduxkotlin.devtools.core`?) — Task 5 Step 2.
+2. clikt 4.4.0 enum-option case sensitivity — Task 8 Step 3.
+3. `StoreEntry.ref.id` == recording store key — Task 7 Step 3.
+4. `MonitorApp`/`rememberMonitorState` import paths — Task 9 Step 1.

--- a/docs/superpowers/specs/2026-06-04-redux-kotlin-devtools-cli-design.md
+++ b/docs/superpowers/specs/2026-06-04-redux-kotlin-devtools-cli-design.md
@@ -1,0 +1,183 @@
+# Redux-Kotlin DevTools CLI — Design
+
+**Date:** 2026-06-04
+**Status:** Design (approved for implementation planning)
+**Scope:** A single-entry-point CLI that bundles the DevTools bridge receiver, an append-only capture,
+the bundled GUI monitor, and an agent-facing query surface over the captured action/state/diff log.
+JVM-only dev tooling. Read-only inspection.
+
+---
+
+## 1. Why — benefit to AI agents
+
+An agent building a redux-kotlin (Kotlin Multiplatform) app today debugs half-blind: it can compile
+and unit-test, but it cannot *see* runtime — which actions fired, in what order, what state changed,
+what errored. The DevTools bridge already emits exactly that telemetry (`action + post-state +
+leaf diffs + timestamps`) over a WebSocket, but the only consumer is a human GUI. There is no CLI, no
+headless launch, and no programmatic/query access.
+
+This project adds the missing agent-readable surface, converting an already-built telemetry stream into
+a **write → run → observe → fix** loop. Because the wire protocol, ingest, and recording format already
+exist, the cost is concentrated in a thin new module — high leverage per unit of work.
+
+This is **not** the rejected scaffold/bootstrap CLI (see the AI-integration umbrella spec, §9). It is a
+runtime-observability tool, drift-proof by construction: it reads a live protocol, it does not generate
+code.
+
+## 2. What we build on (existing system)
+
+The DevTools subsystem is a hub-and-outputs design:
+
+- `devTools()` enhancer → process-global `DevToolsHub` → per-store `DevToolsSession` (bounded ring
+  buffer of actions + lifted state + `events: SharedFlow<DevToolsEvent>`).
+- Pluggable `DevToolsOutput`s: the in-app Compose drawer (`-devtools-inapp`) and `BridgeOutput`
+  (`-devtools-bridge`).
+- **Bridge wire protocol** (`-devtools-bridge`, `BridgeProtocol.kt`): app dials out over raw WebSocket
+  to a Ktor server. `BridgeMessage` sealed type carries `Hello`/`HelloAck` (handshake, protocol
+  version, optional token), `Init(state)`, and `Action { actionId, action, state, diff:
+  List<DiffEntry>, timestampMillis, isExcess }`, plus pipeline structure/trace messages. Full state on
+  the wire; leaf diffs computed app-side.
+- **Standalone monitor** (`-devtools-standalone`): Compose Desktop + wasmJs GUI with an embedded Ktor
+  server (`127.0.0.1:9090`, `/bridge`), launched via Gradle task / installer. Saves/loads recordings as
+  versioned `.jsonl` (header + one JSON record per event).
+
+Gaps this project fills: (a) no single CLI entry point bundling server + UI; (b) no agent-queryable log
+API.
+
+## 3. Approach (decision record)
+
+- **A. New CLI module wrapping the existing server.** Reuses protocol/ingest/recording. Good, but
+  leaves internal structure unspecified.
+- **B. Add a headless entrypoint to `-devtools-standalone`.** No new module, but couples a fast,
+  zero-GUI query path to a heavy Compose Multiplatform app — every query invocation drags Compose deps
+  and slow startup. Rejected: poor fit for a binary an agent shells out to repeatedly.
+- **C. (Chosen) New CLI module, internally three-layered.** As A, but split along clean seams so the
+  query path stays lean and the GUI dep is isolated.
+
+**Chosen: C.**
+
+## 4. Architecture
+
+New module **`redux-kotlin-devtools-cli`**, JVM-only, packaged as a runnable jar + native installer
+(mirrors `-devtools-standalone`'s app packaging). Package `org.reduxkotlin.devtools.cli`. Three internal
+layers, one-way dependencies:
+
+```
+cli/      subcommand parser (serve, stores, actions, diff, state, tail)
+  ├──→ capture/   PURE query library — no server, no Compose
+  │      CaptureReader (.jsonl → records) · CaptureQuery (filter) · CaptureFormatter (tiers)
+  └──→ server/    CaptureServer: bridge ingest + Ktor WS, appends each event to the capture file
+         └──→ :redux-kotlin-devtools-bridge        (reuse protocol + ingest)
+  serve --ui ──→ :redux-kotlin-devtools-standalone (optional, lazy — the only path that pulls Compose)
+```
+
+- **`capture/`** depends only on the recording schema + kotlinx.serialization. It never imports the
+  server or Ktor, so query subcommands start fast and are unit-testable as pure functions. It is the
+  natural seam for a future MCP face.
+- **`server/`** reuses the bridge ingest and Ktor server; its only added responsibility is teeing each
+  ingested event to the append-only capture file.
+- **`cli/`** is a thin subcommand parser binding the two; `serve --ui` lazily launches the standalone
+  GUI against the same ingest.
+
+Each unit answers cleanly: *what it does / how you use it / what it depends on* — and the Compose
+dependency is confined to a single optional code path.
+
+## 5. Capture format & lifecycle
+
+- **`rk-devtools serve`** runs the daemon: hosts the bridge endpoint (`127.0.0.1:9090/bridge`, same
+  defaults as the standalone monitor) and appends one record per ingested event to an append-only
+  capture file. Foreground process; the agent backgrounds it.
+- **Capture file reuses the existing standalone `.jsonl` recording format** (versioned header + one
+  JSON record per event). Consequence: the agent's live capture is also a file the GUI can save/load —
+  no new format, full interop in both directions.
+- **Default path** `./.rk-devtools/<session>.jsonl` with a stable `latest.jsonl` pointer; `--out`
+  overrides. Query subcommands default to `latest.jsonl`.
+- **Multi-store / multi-client multiplex into one file**, each record tagged with its store key
+  (`clientId + storeInstanceId`); queries filter by `--store`. App-side `isExcess` markers are preserved
+  so the agent can see when the app's ring buffer evicted history.
+- **Query subcommands are stateless file readers** — they tail the append-only file while `serve` runs;
+  no IPC, no dependency on the daemon being reachable, only on the file existing.
+- v1: one file per serve session, **no rotation** (the seam for `--max-bytes` truncation is noted, not
+  built).
+
+## 6. CLI surface
+
+```
+rk-devtools serve   [--port 9090] [--host 127.0.0.1] [--token T] [--out FILE] [--ui]
+rk-devtools stores  [--out FILE]                      # list store keys seen in the capture
+rk-devtools actions [filters] [--format ...]          # the read core
+rk-devtools diff    [filters] [--format ...]          # convenience: --format diff
+rk-devtools state   [--store K] [--at <actionId>]     # full snapshot, latest or after an action
+rk-devtools tail    [filters] [--follow] [--format]   # recent / live-follow
+```
+
+**Shared filter flags** (compose freely): `--store <key>`, `--type <glob>` (e.g. `'*Card*'`),
+`--since <id|ts>`, `--until <id|ts>`, `--last <N>`.
+
+**Output:** JSON-lines by default (one object per line → pipes to `jq`/`grep`); `--pretty` for human
+reading. Typical agent call: `rk-devtools diff --store account:ann --type '*Card*' --last 10`.
+
+## 7. The `--format` output contract (concise-logging core)
+
+Three nested tiers; the agent picks per call to control token cost. Each tier is a strict superset of
+the one above:
+
+| `--format` | Per-record payload | Answers | Cost |
+|---|---|---|---|
+| `actions` *(default)* | `{actionId, type, store, ts}` | "what fired, in what order" | minimal |
+| `diff` | `+ diff: [{path, before, after}]` (the bridge's leaf diffs) | "what changed" | medium |
+| `full` | `+ state: <full post-state JSON>` | "everything" | large |
+
+`state --at <actionId>` is the point-read companion — a full snapshot after a specific action. Because
+full post-state already ships on the wire per action, this is a read from the capture, not a replay.
+
+Error/rejection actions are not special-cased in v1; the agent surfaces them via `--type '*Failed*'`
+and similar. A dedicated triage/`digest` view is deferred (§10).
+
+## 8. App opt-in & single entry point
+
+The CLI is purely the receiver + query half and changes no app API. An app opts in with the existing
+bridge output:
+
+```kotlin
+val store = createStore(reducer, initial, devTools(DevToolsConfig(name = "TaskFlow")))
+DevToolsHub.session("TaskFlow")?.let {
+    BridgeOutput(BridgeConfig(clientLabel = "TaskFlow", startEnabled = true)).start(it)  // → 127.0.0.1:9090
+}
+```
+
+"Debugging by default" = integrators add that block in debug builds (release builds swap in
+`-devtools-inapp-noop`); the recommended wiring is documented in the agent reference set. The **single
+entry point** is `rk-devtools serve --ui`: one command stands up the bridge receiver, the append-only
+capture, and the bundled GUI monitor — a human watches live while the agent queries the same stream.
+
+## 9. Error handling & testing
+
+- **Fail fast, legibly:** capture path unwritable or port in use → clear one-line error + nonzero exit.
+  Protocol-version mismatch → the existing `HelloAck(accepted=false, reason=...)` path; a malformed
+  frame is logged and skipped, never fatal.
+- **Reader tolerance:** a query running against a file being appended skips a trailing partial line; an
+  empty/missing capture yields an empty result + a stderr note, exit 0.
+- **Testing (JVM):** `capture/` pure library against golden `.jsonl` fixtures (filtering + each format
+  tier asserted); `server/` driven by a fake bridge client emitting `BridgeMessage`s, asserting capture
+  file contents; CLI arg-parsing smoke tests. Mirrors repo test conventions (`kotlin-test`, source-set
+  layout).
+
+## 10. Explicitly deferred / out of scope
+
+- `digest` / triage view (error surfacing, action counts, anomalies).
+- Pipeline-timing (`PipelineTraced`) in query output.
+- Dispatch-back / time-travel drive — keeps the read-only model the existing specs hold intact; would
+  need a reverse channel + safety.
+- An MCP face — the pure `capture/` library is the intended seam for it.
+- Capture-file rotation / `--max-bytes` truncation.
+- Auth hardening beyond the existing shared-token (e.g. TLS, per-client keys).
+
+## 11. Open questions (resolve in planning)
+
+1. **Arg-parsing library** — clikt vs kotlinx-cli vs hand-rolled; weigh dep weight against UX.
+2. **`latest.jsonl` pointer mechanism** — symlink (portability on Windows?) vs a small pointer file.
+3. **Store-key format** — confirm the exact `clientId + storeInstanceId` rendering used in `--store`
+   filters matches what the GUI displays, for human/agent parity.
+4. **Distribution** — published artifact, Gradle `run` task, and/or `installDist`; how an agent obtains
+   the binary in a fresh checkout.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ coil = "3.2.0"
 ktor = "3.1.0"
 androidx-activity-compose = "1.11.0"
 sqldelight = "2.3.2"
+clikt = "4.4.0"
 
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
@@ -66,6 +67,7 @@ sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", ver
 sqldelight-native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 sqldelight-sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 sqldelight-web-worker-driver = { module = "app.cash.sqldelight:web-worker-driver", version.ref = "sqldelight" }
+clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 
 [plugins]
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }

--- a/redux-kotlin-devtools-bridge/api/jvm/redux-kotlin-devtools-bridge.api
+++ b/redux-kotlin-devtools-bridge/api/jvm/redux-kotlin-devtools-bridge.api
@@ -238,3 +238,48 @@ public final class org/reduxkotlin/devtools/bridge/BridgeProtocolKt {
 	public static final fun toWire (Lorg/reduxkotlin/devtools/DevToolsEvent;)Lorg/reduxkotlin/devtools/bridge/BridgeMessage;
 }
 
+public final class org/reduxkotlin/devtools/bridge/RecordingHeader {
+	public static final field Companion Lorg/reduxkotlin/devtools/bridge/RecordingHeader$Companion;
+	public fun <init> (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/reduxkotlin/devtools/bridge/RecordingHeader;
+	public static synthetic fun copy$default (Lorg/reduxkotlin/devtools/bridge/RecordingHeader;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/reduxkotlin/devtools/bridge/RecordingHeader;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getClientLabel ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getProtocolVersion ()I
+	public final fun getSerializerTier ()Ljava/lang/String;
+	public final fun getStoreInstanceId ()Ljava/lang/String;
+	public final fun getStoreName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class org/reduxkotlin/devtools/bridge/RecordingHeader$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/reduxkotlin/devtools/bridge/RecordingHeader$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/reduxkotlin/devtools/bridge/RecordingHeader;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/reduxkotlin/devtools/bridge/RecordingHeader;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/reduxkotlin/devtools/bridge/RecordingHeader$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/reduxkotlin/devtools/bridge/RecordingKt {
+	public static final fun decodeRecording (Ljava/lang/String;)Lkotlin/Pair;
+	public static final fun encodeRecording (Lorg/reduxkotlin/devtools/bridge/RecordingHeader;Ljava/util/List;)Ljava/lang/String;
+}
+

--- a/redux-kotlin-devtools-bridge/api/redux-kotlin-devtools-bridge.klib.api
+++ b/redux-kotlin-devtools-bridge/api/redux-kotlin-devtools-bridge.klib.api
@@ -257,10 +257,56 @@ final class org.reduxkotlin.devtools.bridge/BridgeOutput : org.reduxkotlin.devto
     final fun stop() // org.reduxkotlin.devtools.bridge/BridgeOutput.stop|stop(){}[0]
 }
 
+final class org.reduxkotlin.devtools.bridge/RecordingHeader { // org.reduxkotlin.devtools.bridge/RecordingHeader|null[0]
+    constructor <init>(kotlin/String = ..., kotlin/Int, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String) // org.reduxkotlin.devtools.bridge/RecordingHeader.<init>|<init>(kotlin.String;kotlin.Int;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String){}[0]
+
+    final val clientId // org.reduxkotlin.devtools.bridge/RecordingHeader.clientId|{}clientId[0]
+        final fun <get-clientId>(): kotlin/String // org.reduxkotlin.devtools.bridge/RecordingHeader.clientId.<get-clientId>|<get-clientId>(){}[0]
+    final val clientLabel // org.reduxkotlin.devtools.bridge/RecordingHeader.clientLabel|{}clientLabel[0]
+        final fun <get-clientLabel>(): kotlin/String // org.reduxkotlin.devtools.bridge/RecordingHeader.clientLabel.<get-clientLabel>|<get-clientLabel>(){}[0]
+    final val kind // org.reduxkotlin.devtools.bridge/RecordingHeader.kind|{}kind[0]
+        final fun <get-kind>(): kotlin/String // org.reduxkotlin.devtools.bridge/RecordingHeader.kind.<get-kind>|<get-kind>(){}[0]
+    final val protocolVersion // org.reduxkotlin.devtools.bridge/RecordingHeader.protocolVersion|{}protocolVersion[0]
+        final fun <get-protocolVersion>(): kotlin/Int // org.reduxkotlin.devtools.bridge/RecordingHeader.protocolVersion.<get-protocolVersion>|<get-protocolVersion>(){}[0]
+    final val serializerTier // org.reduxkotlin.devtools.bridge/RecordingHeader.serializerTier|{}serializerTier[0]
+        final fun <get-serializerTier>(): kotlin/String // org.reduxkotlin.devtools.bridge/RecordingHeader.serializerTier.<get-serializerTier>|<get-serializerTier>(){}[0]
+    final val storeInstanceId // org.reduxkotlin.devtools.bridge/RecordingHeader.storeInstanceId|{}storeInstanceId[0]
+        final fun <get-storeInstanceId>(): kotlin/String // org.reduxkotlin.devtools.bridge/RecordingHeader.storeInstanceId.<get-storeInstanceId>|<get-storeInstanceId>(){}[0]
+    final val storeName // org.reduxkotlin.devtools.bridge/RecordingHeader.storeName|{}storeName[0]
+        final fun <get-storeName>(): kotlin/String // org.reduxkotlin.devtools.bridge/RecordingHeader.storeName.<get-storeName>|<get-storeName>(){}[0]
+
+    final fun component1(): kotlin/String // org.reduxkotlin.devtools.bridge/RecordingHeader.component1|component1(){}[0]
+    final fun component2(): kotlin/Int // org.reduxkotlin.devtools.bridge/RecordingHeader.component2|component2(){}[0]
+    final fun component3(): kotlin/String // org.reduxkotlin.devtools.bridge/RecordingHeader.component3|component3(){}[0]
+    final fun component4(): kotlin/String // org.reduxkotlin.devtools.bridge/RecordingHeader.component4|component4(){}[0]
+    final fun component5(): kotlin/String // org.reduxkotlin.devtools.bridge/RecordingHeader.component5|component5(){}[0]
+    final fun component6(): kotlin/String // org.reduxkotlin.devtools.bridge/RecordingHeader.component6|component6(){}[0]
+    final fun component7(): kotlin/String // org.reduxkotlin.devtools.bridge/RecordingHeader.component7|component7(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/Int = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ...): org.reduxkotlin.devtools.bridge/RecordingHeader // org.reduxkotlin.devtools.bridge/RecordingHeader.copy|copy(kotlin.String;kotlin.Int;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // org.reduxkotlin.devtools.bridge/RecordingHeader.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // org.reduxkotlin.devtools.bridge/RecordingHeader.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // org.reduxkotlin.devtools.bridge/RecordingHeader.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<org.reduxkotlin.devtools.bridge/RecordingHeader> { // org.reduxkotlin.devtools.bridge/RecordingHeader.$serializer|null[0]
+        final val descriptor // org.reduxkotlin.devtools.bridge/RecordingHeader.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // org.reduxkotlin.devtools.bridge/RecordingHeader.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // org.reduxkotlin.devtools.bridge/RecordingHeader.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): org.reduxkotlin.devtools.bridge/RecordingHeader // org.reduxkotlin.devtools.bridge/RecordingHeader.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, org.reduxkotlin.devtools.bridge/RecordingHeader) // org.reduxkotlin.devtools.bridge/RecordingHeader.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;org.reduxkotlin.devtools.bridge.RecordingHeader){}[0]
+    }
+
+    final object Companion { // org.reduxkotlin.devtools.bridge/RecordingHeader.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<org.reduxkotlin.devtools.bridge/RecordingHeader> // org.reduxkotlin.devtools.bridge/RecordingHeader.Companion.serializer|serializer(){}[0]
+    }
+}
+
 final const val org.reduxkotlin.devtools.bridge/PROTOCOL_VERSION // org.reduxkotlin.devtools.bridge/PROTOCOL_VERSION|{}PROTOCOL_VERSION[0]
     final fun <get-PROTOCOL_VERSION>(): kotlin/Int // org.reduxkotlin.devtools.bridge/PROTOCOL_VERSION.<get-PROTOCOL_VERSION>|<get-PROTOCOL_VERSION>(){}[0]
 
 final val org.reduxkotlin.devtools.bridge/bridgeJson // org.reduxkotlin.devtools.bridge/bridgeJson|{}bridgeJson[0]
     final fun <get-bridgeJson>(): kotlinx.serialization.json/Json // org.reduxkotlin.devtools.bridge/bridgeJson.<get-bridgeJson>|<get-bridgeJson>(){}[0]
 
+final fun org.reduxkotlin.devtools.bridge/decodeRecording(kotlin/String): kotlin/Pair<org.reduxkotlin.devtools.bridge/RecordingHeader, kotlin.collections/List<org.reduxkotlin.devtools.bridge/BridgeMessage>> // org.reduxkotlin.devtools.bridge/decodeRecording|decodeRecording(kotlin.String){}[0]
+final fun org.reduxkotlin.devtools.bridge/encodeRecording(org.reduxkotlin.devtools.bridge/RecordingHeader, kotlin.collections/List<org.reduxkotlin.devtools.bridge/BridgeMessage>): kotlin/String // org.reduxkotlin.devtools.bridge/encodeRecording|encodeRecording(org.reduxkotlin.devtools.bridge.RecordingHeader;kotlin.collections.List<org.reduxkotlin.devtools.bridge.BridgeMessage>){}[0]
 final fun org.reduxkotlin.devtools.bridge/toWire(org.reduxkotlin.devtools/DevToolsEvent): org.reduxkotlin.devtools.bridge/BridgeMessage // org.reduxkotlin.devtools.bridge/toWire|toWire(org.reduxkotlin.devtools.DevToolsEvent){}[0]

--- a/redux-kotlin-devtools-bridge/src/commonMain/kotlin/org/reduxkotlin/devtools/bridge/Recording.kt
+++ b/redux-kotlin-devtools-bridge/src/commonMain/kotlin/org/reduxkotlin/devtools/bridge/Recording.kt
@@ -1,0 +1,37 @@
+package org.reduxkotlin.devtools.bridge
+
+import kotlinx.serialization.Serializable
+
+/** First line of a `.jsonl` recording — pins the format + provenance for forward compatibility. */
+@Serializable
+public data class RecordingHeader(
+    /** `"rk-devtools-recording"` discriminator. */
+    public val kind: String = "rk-devtools-recording",
+    /** Bridge protocol version the events use. */
+    public val protocolVersion: Int,
+    /** Serializer tier that produced the JSON. */
+    public val serializerTier: String,
+    /** Source client id. */
+    public val clientId: String,
+    /** Source client label. */
+    public val clientLabel: String,
+    /** Source store name. */
+    public val storeName: String,
+    /** Source store instance id. */
+    public val storeInstanceId: String,
+)
+
+/** Encodes a header + messages to newline-delimited JSON (`.jsonl`). */
+public fun encodeRecording(header: RecordingHeader, messages: List<BridgeMessage>): String = buildString {
+    appendLine(bridgeJson.encodeToString(RecordingHeader.serializer(), header))
+    messages.forEach { appendLine(bridgeJson.encodeToString(BridgeMessage.serializer(), it)) }
+}
+
+/** Decodes a `.jsonl` recording into its header + messages (ignores blank lines). */
+public fun decodeRecording(text: String): Pair<RecordingHeader, List<BridgeMessage>> {
+    val lines = text.split("\n").filter { it.isNotBlank() }
+    require(lines.isNotEmpty()) { "empty recording" }
+    val header = bridgeJson.decodeFromString(RecordingHeader.serializer(), lines.first())
+    val messages = lines.drop(1).map { bridgeJson.decodeFromString(BridgeMessage.serializer(), it) }
+    return header to messages
+}

--- a/redux-kotlin-devtools-cli/build.gradle.kts
+++ b/redux-kotlin-devtools-cli/build.gradle.kts
@@ -1,0 +1,35 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id("convention.common")
+    kotlin("jvm")
+    application
+    alias(libs.plugins.kotlin.serialization)
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+application {
+    applicationName = "rk-devtools"
+    mainClass.set("org.reduxkotlin.devtools.cli.MainKt")
+}
+
+dependencies {
+    implementation(project(":redux-kotlin-devtools-core"))
+    implementation(project(":redux-kotlin-devtools-bridge"))
+    implementation(project(":redux-kotlin-devtools-standalone"))
+    implementation(libs.clikt)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.coroutines.core)
+    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlinx.coroutines.test)
+}

--- a/redux-kotlin-devtools-cli/build.gradle.kts
+++ b/redux-kotlin-devtools-cli/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(project(":redux-kotlin-devtools-core"))
     implementation(project(":redux-kotlin-devtools-bridge"))
     implementation(project(":redux-kotlin-devtools-standalone"))
+    implementation(project(":redux-kotlin-devtools-ui"))
     implementation(libs.clikt)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.core)

--- a/redux-kotlin-devtools-cli/build.gradle.kts
+++ b/redux-kotlin-devtools-cli/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     kotlin("jvm")
     application
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.compose.multiplatform)
 }
 
 kotlin {
@@ -31,6 +33,9 @@ dependencies {
     implementation(libs.clikt)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.core)
+    implementation(compose.desktop.currentOs)
+    implementation(compose.runtime)
+    implementation(compose.ui)
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/Main.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/Main.kt
@@ -1,6 +1,8 @@
 package org.reduxkotlin.devtools.cli
 
+import org.reduxkotlin.devtools.cli.command.rootCommand
+
 /** CLI entry point for the redux-kotlin DevTools tool. */
 public fun main(args: Array<String>) {
-    println("rk-devtools (args: ${args.joinToString(" ")})")
+    rootCommand().main(args)
 }

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/Main.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/Main.kt
@@ -1,0 +1,6 @@
+package org.reduxkotlin.devtools.cli
+
+/** CLI entry point for the redux-kotlin DevTools tool. */
+public fun main(args: Array<String>) {
+    println("rk-devtools (args: ${args.joinToString(" ")})")
+}

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureFormatter.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureFormatter.kt
@@ -1,0 +1,38 @@
+package org.reduxkotlin.devtools.cli.capture
+
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.reduxkotlin.devtools.DiffEntry
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.bridgeJson
+
+/** Output granularity tiers; each is a strict superset of the previous. */
+internal enum class Format { ACTIONS, DIFF, FULL }
+
+private val prettyJson = Json(bridgeJson) { prettyPrint = true }
+
+/** Render one action record to a single JSON object string at the requested [format] tier. */
+internal fun formatRecord(
+    action: BridgeMessage.Action,
+    format: Format,
+    store: String,
+    pretty: Boolean = false,
+): String {
+    val obj: JsonObject = buildJsonObject {
+        put("actionId", JsonPrimitive(action.actionId))
+        put("type", JsonPrimitive(actionType(action.action)))
+        put("store", JsonPrimitive(store))
+        put("ts", JsonPrimitive(action.timestampMillis))
+        if (action.isExcess) put("isExcess", JsonPrimitive(true))
+        if (format == Format.DIFF || format == Format.FULL) {
+            put("diff", bridgeJson.encodeToJsonElement(ListSerializer(DiffEntry.serializer()), action.diff))
+        }
+        if (format == Format.FULL) put("state", action.state)
+    }
+    val j = if (pretty) prettyJson else bridgeJson
+    return j.encodeToString(JsonObject.serializer(), obj)
+}

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureQuery.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureQuery.kt
@@ -1,0 +1,48 @@
+package org.reduxkotlin.devtools.cli.capture
+
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+
+/**
+ * Converts a glob pattern (only `*` wildcard supported) to a [Regex].
+ *
+ * Each `*` maps to `.*` (zero or more characters), anchored `^...$`.
+ * So `*Card*` matches any string containing "Card" (including `CardOpFailed`),
+ * and a plain `Foo` (no `*`) is an exact match.
+ */
+internal fun globToRegex(glob: String): Regex {
+    val segments = glob.split("*")
+    val pattern = buildString {
+        append('^')
+        segments.forEachIndexed { index, segment ->
+            if (index > 0) append(".*")
+            append(Regex.escape(segment))
+        }
+        append('$')
+    }
+    return Regex(pattern)
+}
+
+/** Returns true when [a] satisfies all id/timestamp bounds in this [QuerySpec]. */
+internal fun QuerySpec.matchesBounds(a: BridgeMessage.Action): Boolean = (sinceId == null || a.actionId >= sinceId) &&
+        (untilId == null || a.actionId <= untilId) &&
+        (sinceTs == null || a.timestampMillis >= sinceTs) &&
+        (untilTs == null || a.timestampMillis <= untilTs)
+
+/** A filter over captured actions. `type` is a glob (`*` wildcard); id/time bounds are inclusive. */
+internal data class QuerySpec(
+    val type: String? = null,
+    val sinceId: Int? = null,
+    val untilId: Int? = null,
+    val sinceTs: Long? = null,
+    val untilTs: Long? = null,
+    val last: Int? = null,
+) {
+    /** Apply the filter, preserving capture order; `last` truncates to the final N after filtering. */
+    fun apply(actions: List<BridgeMessage.Action>): List<BridgeMessage.Action> {
+        val rx = type?.let { globToRegex(it) }
+        val filtered = actions.filter { a ->
+            (rx == null || rx.matches(actionType(a.action))) && matchesBounds(a)
+        }
+        return if (last != null && last < filtered.size) filtered.takeLast(last) else filtered
+    }
+}

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureQuery.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureQuery.kt
@@ -24,9 +24,9 @@ internal fun globToRegex(glob: String): Regex {
 
 /** Returns true when [a] satisfies all id/timestamp bounds in this [QuerySpec]. */
 internal fun QuerySpec.matchesBounds(a: BridgeMessage.Action): Boolean = (sinceId == null || a.actionId >= sinceId) &&
-        (untilId == null || a.actionId <= untilId) &&
-        (sinceTs == null || a.timestampMillis >= sinceTs) &&
-        (untilTs == null || a.timestampMillis <= untilTs)
+    (untilId == null || a.actionId <= untilId) &&
+    (sinceTs == null || a.timestampMillis >= sinceTs) &&
+    (untilTs == null || a.timestampMillis <= untilTs)
 
 /** A filter over captured actions. `type` is a glob (`*` wildcard); id/time bounds are inclusive. */
 internal data class QuerySpec(

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureReader.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureReader.kt
@@ -1,0 +1,28 @@
+package org.reduxkotlin.devtools.cli.capture
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.RecordingHeader
+import org.reduxkotlin.devtools.bridge.bridgeJson
+import java.io.File
+
+/** Parse capture [text]: first line is the header, subsequent lines are messages; a trailing partial line is skipped. */
+internal fun parseCapture(text: String): Pair<RecordingHeader, List<BridgeMessage.Action>> {
+    val lines = text.split("\n").filter { it.isNotBlank() }
+    require(lines.isNotEmpty()) { "empty capture" }
+    val header = bridgeJson.decodeFromString(RecordingHeader.serializer(), lines.first())
+    val actions = lines.drop(1).mapNotNull { line ->
+        runCatching { bridgeJson.decodeFromString(BridgeMessage.serializer(), line) }
+            .getOrNull() as? BridgeMessage.Action
+    }
+    return header to actions
+}
+
+/** Read a capture [file] from disk. */
+internal fun readCapture(file: File): Pair<RecordingHeader, List<BridgeMessage.Action>> = parseCapture(file.readText())
+
+/** Render the `type` discriminant of a serialized action for display/filtering. */
+internal fun actionType(action: JsonElement): String =
+    ((action as? JsonObject)?.get("type") as? JsonPrimitive)?.content ?: "?"

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureStore.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureStore.kt
@@ -1,0 +1,28 @@
+package org.reduxkotlin.devtools.cli.capture
+
+import org.reduxkotlin.devtools.bridge.RecordingHeader
+import org.reduxkotlin.devtools.bridge.decodeRecording
+import java.io.File
+
+/** A store discovered in a capture directory. */
+internal data class StoreRef(val key: String, val name: String, val file: File)
+
+/** Convert a wire store key (`clientId::storeInstanceId`) into a filesystem-safe base name. */
+internal fun safeKey(storeKey: String): String = storeKey.replace("::", "__").replace(Regex("[^A-Za-z0-9_.-]"), "_")
+
+/** Capture file name for a store key. */
+internal fun captureFileName(storeKey: String): String = "${safeKey(storeKey)}.jsonl"
+
+/** List the store recordings present in [dir] by reading each file's header. */
+internal fun discoverStores(dir: File): List<StoreRef> {
+    if (!dir.isDirectory) return emptyList()
+    return dir.listFiles { f -> f.isFile && f.name.endsWith(".jsonl") }
+        ?.mapNotNull { f ->
+            runCatching {
+                val header: RecordingHeader = decodeRecording(f.readText()).first
+                StoreRef(key = "${header.clientId}::${header.storeInstanceId}", name = header.storeName, file = f)
+            }.getOrNull()
+        }
+        ?.sortedBy { it.key }
+        .orEmpty()
+}

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/ActionsCommand.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/ActionsCommand.kt
@@ -1,0 +1,20 @@
+package org.reduxkotlin.devtools.cli.command
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.groups.provideDelegate
+import org.reduxkotlin.devtools.cli.capture.Format
+import org.reduxkotlin.devtools.cli.capture.formatRecord
+import org.reduxkotlin.devtools.cli.capture.readCapture
+
+/** `actions` — list captured actions at the chosen --format tier. */
+internal open class ActionsCommand(private val forced: Format? = null) :
+    CliktCommand(name = if (forced == Format.DIFF) "diff" else "actions") {
+    private val q by QueryOptions()
+
+    override fun run() {
+        val ref = resolveStore(q.dir(), q.store)
+        val actions = q.spec().apply(readCapture(ref.file).second)
+        val fmt = forced ?: q.format
+        actions.forEach { echo(formatRecord(it, fmt, ref.key, q.prettyEnabled())) }
+    }
+}

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/DiffCommand.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/DiffCommand.kt
@@ -1,0 +1,6 @@
+package org.reduxkotlin.devtools.cli.command
+
+import org.reduxkotlin.devtools.cli.capture.Format
+
+/** `diff` — alias for `actions --format diff`. */
+internal class DiffCommand : ActionsCommand(forced = Format.DIFF)

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/QueryOptions.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/QueryOptions.kt
@@ -21,7 +21,7 @@ internal fun resolveStore(dir: File, key: String?): StoreRef {
     check(stores.isNotEmpty()) { "no captures found in ${dir.path} (is `rk-devtools serve` running?)" }
     if (key != null) {
         return stores.firstOrNull { it.key == key }
-        ?: error("store '$key' not found; available: ${stores.joinToString { it.key }}")
+            ?: error("store '$key' not found; available: ${stores.joinToString { it.key }}")
     }
     check(stores.size == 1) { "multiple stores present; pass --store <key>: ${stores.joinToString { it.key }}" }
     return stores.first()

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/QueryOptions.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/QueryOptions.kt
@@ -1,0 +1,46 @@
+package org.reduxkotlin.devtools.cli.command
+
+import com.github.ajalt.clikt.parameters.groups.OptionGroup
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.enum
+import com.github.ajalt.clikt.parameters.types.int
+import org.reduxkotlin.devtools.cli.capture.Format
+import org.reduxkotlin.devtools.cli.capture.QuerySpec
+import org.reduxkotlin.devtools.cli.capture.StoreRef
+import org.reduxkotlin.devtools.cli.capture.discoverStores
+import java.io.File
+
+/** Default capture directory under the current working dir. */
+internal fun defaultCaptureDir(): File = File(".rk-devtools")
+
+/** Pick the target store: the only one if unambiguous, or the one matching [key]. */
+internal fun resolveStore(dir: File, key: String?): StoreRef {
+    val stores = discoverStores(dir)
+    check(stores.isNotEmpty()) { "no captures found in ${dir.path} (is `rk-devtools serve` running?)" }
+    if (key != null) {
+        return stores.firstOrNull { it.key == key }
+        ?: error("store '$key' not found; available: ${stores.joinToString { it.key }}")
+    }
+    check(stores.size == 1) { "multiple stores present; pass --store <key>: ${stores.joinToString { it.key }}" }
+    return stores.first()
+}
+
+/** Shared filter/format flags for query subcommands. */
+internal class QueryOptions : OptionGroup() {
+    val out by option("--out", help = "capture directory").default(".rk-devtools")
+    val store by option("--store", help = "store key (clientId::storeInstanceId)")
+    val type by option("--type", help = "action type glob, e.g. '*Card*'")
+    val sinceId by option("--since", help = "min actionId").int()
+    val untilId by option("--until", help = "max actionId").int()
+    val last by option("--last", help = "keep only the final N").int()
+
+    // ignoreCase = true allows lowercase input (e.g. --format actions) in addition to ACTIONS
+    val format by option("--format").enum<Format>(ignoreCase = true).default(Format.ACTIONS)
+    val pretty by option("--pretty", help = "pretty-print JSON").flag()
+
+    fun spec(): QuerySpec = QuerySpec(type = type, sinceId = sinceId, untilId = untilId, last = last)
+    fun dir(): File = File(out)
+    fun prettyEnabled(): Boolean = pretty
+}

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/RootCommand.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/RootCommand.kt
@@ -9,12 +9,11 @@ internal class RootCommand : CliktCommand(name = "rk-devtools") {
 }
 
 /** Build the configured command tree. */
-internal fun rootCommand(): CliktCommand =
-    RootCommand().subcommands(
-        ServeCommand(),
-        StoresCommand(),
-        ActionsCommand(),
-        DiffCommand(),
-        StateCommand(),
-        TailCommand(),
-    )
+internal fun rootCommand(): CliktCommand = RootCommand().subcommands(
+    ServeCommand(),
+    StoresCommand(),
+    ActionsCommand(),
+    DiffCommand(),
+    StateCommand(),
+    TailCommand(),
+)

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/RootCommand.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/RootCommand.kt
@@ -1,0 +1,20 @@
+package org.reduxkotlin.devtools.cli.command
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.subcommands
+
+/** Root `rk-devtools` command; dispatches to subcommands. */
+internal class RootCommand : CliktCommand(name = "rk-devtools") {
+    override fun run() = Unit
+}
+
+/** Build the configured command tree. */
+internal fun rootCommand(): CliktCommand =
+    RootCommand().subcommands(
+        ServeCommand(),
+        StoresCommand(),
+        ActionsCommand(),
+        DiffCommand(),
+        StateCommand(),
+        TailCommand(),
+    )

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/ServeCommand.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/ServeCommand.kt
@@ -1,0 +1,54 @@
+package org.reduxkotlin.devtools.cli.command
+
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.int
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.runBlocking
+import org.reduxkotlin.devtools.cli.server.startFlushing
+import org.reduxkotlin.devtools.monitor.MonitorIngest
+import org.reduxkotlin.devtools.monitor.MonitorServer
+import org.reduxkotlin.devtools.monitor.rememberMonitorState
+import org.reduxkotlin.devtools.monitor.ui.MonitorApp
+import java.io.File
+
+/** `serve` — host the bridge receiver, write per-store captures, optionally launch the GUI. */
+internal class ServeCommand : CliktCommand(name = "serve") {
+    private val port by option("--port", help = "port to listen on").int().default(9090)
+    private val host by option("--host", help = "bind address").default("127.0.0.1")
+    private val token by option("--token", help = "shared secret for non-loopback clients")
+    private val out by option("--out", help = "capture output directory").default(".rk-devtools")
+    private val ui by option("--ui", help = "also launch the GUI monitor").flag()
+
+    override fun run() {
+        val dir = File(out).apply { mkdirs() }
+        val ingest = MonitorIngest()
+        val server = MonitorServer(ingest, port = port, host = host, token = token)
+        val bound = server.start()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        startFlushing(scope, ingest, dir)
+        echo("serving bridge on $host:$bound  -> captures in ${dir.path}")
+        if (ui) {
+            application {
+                Window(
+                    onCloseRequest = {
+                        server.stop()
+                        exitApplication()
+                    },
+                    title = "Redux DevTools Monitor",
+                ) {
+                    MonitorApp(ingest, rememberMonitorState(ingest))
+                }
+            }
+        } else {
+            runBlocking { awaitCancellation() }
+        }
+    }
+}

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/StateCommand.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/StateCommand.kt
@@ -1,0 +1,28 @@
+package org.reduxkotlin.devtools.cli.command
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.int
+import kotlinx.serialization.json.JsonElement
+import org.reduxkotlin.devtools.bridge.bridgeJson
+import org.reduxkotlin.devtools.cli.capture.readCapture
+import java.io.File
+
+/** `state` — print the full post-state after the latest action (or --at <actionId>). */
+internal class StateCommand : CliktCommand(name = "state") {
+    private val out by option("--out").default(".rk-devtools")
+    private val store by option("--store")
+    private val at by option("--at").int()
+
+    override fun run() {
+        val ref = resolveStore(File(out), store)
+        val actions = readCapture(ref.file).second
+        val target = if (at != null) actions.firstOrNull { it.actionId == at } else actions.lastOrNull()
+        if (target == null) {
+            echo("no matching action", err = true)
+            return
+        }
+        echo(bridgeJson.encodeToString(JsonElement.serializer(), target.state))
+    }
+}

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/StoresCommand.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/StoresCommand.kt
@@ -1,0 +1,14 @@
+package org.reduxkotlin.devtools.cli.command
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import org.reduxkotlin.devtools.cli.capture.discoverStores
+import java.io.File
+
+/** `stores` — list the store keys present in the capture directory. */
+internal class StoresCommand : CliktCommand(name = "stores") {
+    private val out by option("--out").default(".rk-devtools")
+
+    override fun run() = discoverStores(File(out)).forEach { echo("${it.key}\t${it.name}") }
+}

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/TailCommand.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/TailCommand.kt
@@ -1,0 +1,35 @@
+package org.reduxkotlin.devtools.cli.command
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.groups.provideDelegate
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import org.reduxkotlin.devtools.cli.capture.formatRecord
+import org.reduxkotlin.devtools.cli.capture.readCapture
+
+/** `tail` — print recent actions; with --follow, poll the capture for new ones. */
+internal class TailCommand : CliktCommand(name = "tail") {
+    private val q by QueryOptions()
+    private val follow by option("--follow", help = "poll for new actions continuously").flag()
+
+    override fun run() {
+        val ref = resolveStore(q.dir(), q.store)
+        var lastId = -1
+        fun pump() {
+            val fresh = readCapture(ref.file).second.filter { it.actionId > lastId }
+            q.spec().apply(fresh).forEach {
+                lastId = maxOf(lastId, it.actionId)
+                echo(formatRecord(it, q.format, ref.key, q.prettyEnabled()))
+            }
+        }
+        pump()
+        while (follow) {
+            Thread.sleep(POLL_MS)
+            runCatching { pump() }
+        }
+    }
+
+    private companion object {
+        const val POLL_MS = 300L
+    }
+}

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/server/CaptureFlusher.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/server/CaptureFlusher.kt
@@ -1,0 +1,22 @@
+package org.reduxkotlin.devtools.cli.server
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import org.reduxkotlin.devtools.monitor.MonitorIngest
+import java.io.File
+
+/** Write every store currently known to [ingest] into [dir] as a `.jsonl` recording. */
+internal fun flushAll(ingest: MonitorIngest, dir: File) {
+    ingest.registry.state.value.stores.forEach { entry ->
+        val rec = ingest.recordingFor(entry.ref.id) ?: return@forEach
+        writeStoreCapture(dir, entry.ref.id, rec.first, rec.second)
+    }
+}
+
+/** Continuously flush captures to [dir] whenever the ingest registry changes. Launches in [scope]. */
+internal fun startFlushing(scope: CoroutineScope, ingest: MonitorIngest, dir: File) {
+    scope.launch {
+        ingest.registry.state.collectLatest { flushAll(ingest, dir) }
+    }
+}

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/server/CaptureWriter.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/server/CaptureWriter.kt
@@ -1,0 +1,23 @@
+package org.reduxkotlin.devtools.cli.server
+
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.RecordingHeader
+import org.reduxkotlin.devtools.bridge.encodeRecording
+import org.reduxkotlin.devtools.cli.capture.captureFileName
+import java.io.File
+
+/** Atomically write a store's recording into [dir] as `<safeKey>.jsonl`; returns the file. */
+internal fun writeStoreCapture(
+    dir: File,
+    storeKey: String,
+    header: RecordingHeader,
+    messages: List<BridgeMessage>,
+): File {
+    dir.mkdirs()
+    val target = File(dir, captureFileName(storeKey))
+    val tmp = File(dir, target.name + ".tmp")
+    tmp.writeText(encodeRecording(header, messages))
+    tmp.copyTo(target, overwrite = true)
+    tmp.delete()
+    return target
+}

--- a/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/EndToEndTest.kt
+++ b/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/EndToEndTest.kt
@@ -1,0 +1,54 @@
+package org.reduxkotlin.devtools.cli
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.PROTOCOL_VERSION
+import org.reduxkotlin.devtools.cli.capture.Format
+import org.reduxkotlin.devtools.cli.capture.actionType
+import org.reduxkotlin.devtools.cli.capture.formatRecord
+import org.reduxkotlin.devtools.cli.capture.readCapture
+import org.reduxkotlin.devtools.cli.command.resolveStore
+import org.reduxkotlin.devtools.cli.server.flushAll
+import org.reduxkotlin.devtools.monitor.MonitorIngest
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class EndToEndTest {
+    @Test
+    fun ingest_to_capture_to_query() {
+        val dir = Files.createTempDirectory("rke2e").toFile()
+        val ingest = MonitorIngest()
+        val conn = ingest.openConnection()
+        conn.accept(
+            BridgeMessage.Hello(
+                protocolVersion = PROTOCOL_VERSION,
+                clientId = "taskflow",
+                clientLabel = "TaskFlow",
+                storeInstanceId = "root",
+                storeName = "TaskFlow",
+                serializerTier = "json",
+            ),
+        )
+        conn.accept(
+            BridgeMessage.Action(
+                actionId = 1,
+                action = buildJsonObject { put("type", JsonPrimitive("AddCard")) },
+                state = buildJsonObject {},
+                diff = emptyList(),
+                timestampMillis = 1L,
+                isExcess = false,
+            ),
+        )
+
+        flushAll(ingest, dir)
+
+        val ref = resolveStore(dir, null)
+        val actions = readCapture(ref.file).second
+        assertEquals(listOf("AddCard"), actions.map { actionType(it.action) })
+        assertTrue(formatRecord(actions.first(), Format.ACTIONS, ref.key).contains("\"type\":\"AddCard\""))
+    }
+}

--- a/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureFormatterTest.kt
+++ b/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureFormatterTest.kt
@@ -1,0 +1,61 @@
+package org.reduxkotlin.devtools.cli.capture
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.reduxkotlin.devtools.DiffEntry
+import org.reduxkotlin.devtools.DiffOp
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class CaptureFormatterTest {
+    private val action = BridgeMessage.Action(
+        actionId = 7,
+        action = buildJsonObject { put("type", JsonPrimitive("AddCard")) },
+        state = buildJsonObject { put("count", JsonPrimitive(1)) },
+        diff = listOf(DiffEntry(DiffOp.CHANGED, "count", JsonPrimitive(0), JsonPrimitive(1))),
+        timestampMillis = 123L,
+        isExcess = false,
+    )
+
+    @Test
+    fun actions_tier_omits_diff_and_state() {
+        val line = formatRecord(action, Format.ACTIONS, store = "taskflow::root")
+        val obj = Json.parseToJsonElement(line).jsonObject
+        assertEquals(setOf("actionId", "type", "store", "ts"), obj.keys)
+    }
+
+    @Test
+    fun diff_tier_adds_diff_only() {
+        val obj = Json.parseToJsonElement(formatRecord(action, Format.DIFF, "s")).jsonObject
+        assertTrue("diff" in obj.keys && "state" !in obj.keys)
+    }
+
+    @Test
+    fun full_tier_adds_state() {
+        val obj = Json.parseToJsonElement(formatRecord(action, Format.FULL, "s")).jsonObject
+        assertTrue("diff" in obj.keys && "state" in obj.keys)
+    }
+
+    @Test
+    fun isExcess_true_emits_isExcess_key() {
+        val excessAction = action.copy(isExcess = true)
+        val obj = Json.parseToJsonElement(formatRecord(excessAction, Format.ACTIONS, "s")).jsonObject
+        assertTrue("isExcess" in obj.keys)
+        assertEquals(true, obj["isExcess"]?.jsonPrimitive?.content?.toBooleanStrictOrNull())
+    }
+
+    @Test
+    fun pretty_true_produces_multiline_output() {
+        val prettyResult = formatRecord(action, Format.FULL, "s", pretty = true)
+        val compactResult = formatRecord(action, Format.FULL, "s", pretty = false)
+        assertTrue('\n' in prettyResult)
+        assertFalse('\n' in compactResult)
+    }
+}

--- a/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureQueryTest.kt
+++ b/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureQueryTest.kt
@@ -1,0 +1,37 @@
+package org.reduxkotlin.devtools.cli.capture
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class CaptureQueryTest {
+    private fun a(id: Int, type: String, ts: Long = id.toLong()) = BridgeMessage.Action(
+        actionId = id,
+        action = buildJsonObject { put("type", JsonPrimitive(type)) },
+        state = buildJsonObject {},
+        diff = emptyList(),
+        timestampMillis = ts,
+        isExcess = false,
+    )
+
+    private val data = listOf(a(1, "AddCard"), a(2, "MoveCard"), a(3, "AddColumn"), a(4, "CardOpFailed"))
+
+    @Test
+    fun filters_by_type_glob() {
+        // *Card* = zero-or-more + "Card" + zero-or-more → matches any string containing "Card"
+        assertEquals(listOf(1, 2, 4), QuerySpec(type = "*Card*").apply(data).map { it.actionId })
+        // Add* = "Add" then anything
+        assertEquals(listOf(1, 3), QuerySpec(type = "Add*").apply(data).map { it.actionId })
+        // exact match (no wildcard)
+        assertEquals(listOf(2), QuerySpec(type = "MoveCard").apply(data).map { it.actionId })
+    }
+
+    @Test
+    fun filters_by_since_until_id_and_last() {
+        assertEquals(listOf(2, 3), QuerySpec(sinceId = 2, untilId = 3).apply(data).map { it.actionId })
+        assertEquals(listOf(3, 4), QuerySpec(last = 2).apply(data).map { it.actionId })
+    }
+}

--- a/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureReaderTest.kt
+++ b/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureReaderTest.kt
@@ -1,0 +1,36 @@
+package org.reduxkotlin.devtools.cli.capture
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.PROTOCOL_VERSION
+import org.reduxkotlin.devtools.bridge.RecordingHeader
+import org.reduxkotlin.devtools.bridge.encodeRecording
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class CaptureReaderTest {
+    private fun header() = RecordingHeader(
+        protocolVersion = PROTOCOL_VERSION, serializerTier = "json",
+        clientId = "taskflow", clientLabel = "TaskFlow", storeName = "TaskFlow", storeInstanceId = "root",
+    )
+
+    private fun action(id: Int, type: String) = BridgeMessage.Action(
+        actionId = id,
+        action = buildJsonObject { put("type", JsonPrimitive(type)) },
+        state = buildJsonObject { put("n", JsonPrimitive(id)) },
+        diff = emptyList(),
+        timestampMillis = id.toLong(),
+        isExcess = false,
+    )
+
+    @Test
+    fun reads_actions_and_tolerates_trailing_partial_line() {
+        val text = encodeRecording(header(), listOf(action(1, "A"), action(2, "B"))) + "{\"t\":\"acti"  // partial
+        val (h, actions) = parseCapture(text)
+        assertEquals("TaskFlow", h.storeName)
+        assertEquals(listOf(1, 2), actions.map { it.actionId })
+        assertEquals(listOf("A", "B"), actions.map { actionType(it.action) })
+    }
+}

--- a/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureReaderTest.kt
+++ b/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureReaderTest.kt
@@ -12,8 +12,12 @@ import kotlin.test.assertEquals
 
 internal class CaptureReaderTest {
     private fun header() = RecordingHeader(
-        protocolVersion = PROTOCOL_VERSION, serializerTier = "json",
-        clientId = "taskflow", clientLabel = "TaskFlow", storeName = "TaskFlow", storeInstanceId = "root",
+        protocolVersion = PROTOCOL_VERSION,
+        serializerTier = "json",
+        clientId = "taskflow",
+        clientLabel = "TaskFlow",
+        storeName = "TaskFlow",
+        storeInstanceId = "root",
     )
 
     private fun action(id: Int, type: String) = BridgeMessage.Action(
@@ -27,7 +31,7 @@ internal class CaptureReaderTest {
 
     @Test
     fun reads_actions_and_tolerates_trailing_partial_line() {
-        val text = encodeRecording(header(), listOf(action(1, "A"), action(2, "B"))) + "{\"t\":\"acti"  // partial
+        val text = encodeRecording(header(), listOf(action(1, "A"), action(2, "B"))) + "{\"t\":\"acti" // partial
         val (h, actions) = parseCapture(text)
         assertEquals("TaskFlow", h.storeName)
         assertEquals(listOf(1, 2), actions.map { it.actionId })

--- a/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureStoreTest.kt
+++ b/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/capture/CaptureStoreTest.kt
@@ -1,0 +1,12 @@
+package org.reduxkotlin.devtools.cli.capture
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class CaptureStoreTest {
+    @Test
+    fun safeKey_sanitizes_separator_and_unsafe_chars() {
+        assertEquals("taskflow__TaskFlow-root", safeKey("taskflow::TaskFlow-root"))
+        assertEquals("a_b__c_d", safeKey("a/b::c d"))
+    }
+}

--- a/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/command/QueryResolveTest.kt
+++ b/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/command/QueryResolveTest.kt
@@ -1,0 +1,52 @@
+package org.reduxkotlin.devtools.cli.command
+
+import kotlinx.serialization.json.buildJsonObject
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.PROTOCOL_VERSION
+import org.reduxkotlin.devtools.bridge.RecordingHeader
+import org.reduxkotlin.devtools.cli.server.writeStoreCapture
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+internal class QueryResolveTest {
+    private fun seed(dir: java.io.File, key: String) {
+        val (c, s) = key.split("::")
+        writeStoreCapture(
+            dir,
+            key,
+            RecordingHeader(
+                protocolVersion = PROTOCOL_VERSION,
+                serializerTier = "json",
+                clientId = c,
+                clientLabel = c,
+                storeName = c,
+                storeInstanceId = s,
+            ),
+            listOf(BridgeMessage.Init(buildJsonObject {})),
+        )
+    }
+
+    @Test
+    fun single_store_resolves_without_flag() {
+        val dir = Files.createTempDirectory("rkq").toFile()
+        seed(dir, "app::root")
+        assertEquals("app::root", resolveStore(dir, null).key)
+    }
+
+    @Test
+    fun no_captures_throws() {
+        val dir = java.nio.file.Files.createTempDirectory("rkq-empty").toFile()
+        kotlin.test.assertFailsWith<IllegalStateException> { resolveStore(dir, null) }
+    }
+
+    @Test
+    fun multiple_stores_require_the_flag() {
+        val dir = Files.createTempDirectory("rkq").toFile()
+        seed(dir, "app::root")
+        seed(dir, "app::acct")
+        assertFailsWith<IllegalStateException> { resolveStore(dir, null) }
+        assertEquals("app::acct", resolveStore(dir, "app::acct").key)
+    }
+}

--- a/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/server/CaptureFlusherTest.kt
+++ b/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/server/CaptureFlusherTest.kt
@@ -1,0 +1,48 @@
+package org.reduxkotlin.devtools.cli.server
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.PROTOCOL_VERSION
+import org.reduxkotlin.devtools.cli.capture.discoverStores
+import org.reduxkotlin.devtools.cli.capture.readCapture
+import org.reduxkotlin.devtools.monitor.MonitorIngest
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class CaptureFlusherTest {
+    @Test
+    fun flushes_each_store_to_a_capture_file() {
+        val dir = Files.createTempDirectory("rkflush").toFile()
+        val ingest = MonitorIngest()
+        val conn = ingest.openConnection()
+        conn.accept(
+            BridgeMessage.Hello(
+                protocolVersion = PROTOCOL_VERSION,
+                clientId = "taskflow",
+                clientLabel = "TaskFlow",
+                storeInstanceId = "root",
+                storeName = "TaskFlow",
+                serializerTier = "json",
+            ),
+        )
+        conn.accept(
+            BridgeMessage.Action(
+                actionId = 1,
+                action = buildJsonObject { put("type", JsonPrimitive("A")) },
+                state = buildJsonObject {},
+                diff = emptyList(),
+                timestampMillis = 1L,
+                isExcess = false,
+            ),
+        )
+
+        flushAll(ingest, dir)
+
+        val stores = discoverStores(dir)
+        assertEquals(listOf("taskflow::root"), stores.map { it.key })
+        assertEquals(listOf(1), readCapture(stores.first().file).second.map { it.actionId })
+    }
+}

--- a/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/server/CaptureWriterTest.kt
+++ b/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/server/CaptureWriterTest.kt
@@ -1,0 +1,31 @@
+package org.reduxkotlin.devtools.cli.server
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.PROTOCOL_VERSION
+import org.reduxkotlin.devtools.bridge.RecordingHeader
+import org.reduxkotlin.devtools.cli.capture.readCapture
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class CaptureWriterTest {
+    @Test
+    fun writes_a_gui_loadable_recording_for_a_store() {
+        val dir = Files.createTempDirectory("rkcap").toFile()
+        val header = RecordingHeader(
+            protocolVersion = PROTOCOL_VERSION, serializerTier = "json",
+            clientId = "taskflow", clientLabel = "TaskFlow", storeName = "TaskFlow", storeInstanceId = "root",
+        )
+        val msgs = listOf(
+            BridgeMessage.Action(1, buildJsonObject { put("type", JsonPrimitive("A")) }, buildJsonObject {}, emptyList(), 1L, false),
+        )
+        val file: File = writeStoreCapture(dir, "taskflow::root", header, msgs)
+        assertTrue(file.name.endsWith(".jsonl"))
+        assertEquals(listOf(1), readCapture(file).second.map { it.actionId })
+    }
+}

--- a/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/server/CaptureWriterTest.kt
+++ b/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/server/CaptureWriterTest.kt
@@ -18,11 +18,22 @@ internal class CaptureWriterTest {
     fun writes_a_gui_loadable_recording_for_a_store() {
         val dir = Files.createTempDirectory("rkcap").toFile()
         val header = RecordingHeader(
-            protocolVersion = PROTOCOL_VERSION, serializerTier = "json",
-            clientId = "taskflow", clientLabel = "TaskFlow", storeName = "TaskFlow", storeInstanceId = "root",
+            protocolVersion = PROTOCOL_VERSION,
+            serializerTier = "json",
+            clientId = "taskflow",
+            clientLabel = "TaskFlow",
+            storeName = "TaskFlow",
+            storeInstanceId = "root",
         )
         val msgs = listOf(
-            BridgeMessage.Action(1, buildJsonObject { put("type", JsonPrimitive("A")) }, buildJsonObject {}, emptyList(), 1L, false),
+            BridgeMessage.Action(
+                1,
+                buildJsonObject { put("type", JsonPrimitive("A")) },
+                buildJsonObject {},
+                emptyList(),
+                1L,
+                false,
+            ),
         )
         val file: File = writeStoreCapture(dir, "taskflow::root", header, msgs)
         assertTrue(file.name.endsWith(".jsonl"))

--- a/redux-kotlin-devtools-standalone/src/commonMain/kotlin/org/reduxkotlin/devtools/monitor/MonitorIngest.kt
+++ b/redux-kotlin-devtools-standalone/src/commonMain/kotlin/org/reduxkotlin/devtools/monitor/MonitorIngest.kt
@@ -4,6 +4,7 @@ import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
 import org.reduxkotlin.devtools.DevToolsEvent
 import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.RecordingHeader
 import org.reduxkotlin.devtools.inapp.model.InAppModel
 import org.reduxkotlin.devtools.inapp.model.StoreRef
 import org.reduxkotlin.devtools.inapp.model.StoreRegistryModel

--- a/redux-kotlin-devtools-standalone/src/commonMain/kotlin/org/reduxkotlin/devtools/monitor/Recording.kt
+++ b/redux-kotlin-devtools-standalone/src/commonMain/kotlin/org/reduxkotlin/devtools/monitor/Recording.kt
@@ -1,42 +1,7 @@
 package org.reduxkotlin.devtools.monitor
 
-import kotlinx.serialization.Serializable
-import org.reduxkotlin.devtools.bridge.BridgeMessage
-import org.reduxkotlin.devtools.bridge.bridgeJson
-
-/** First line of a `.jsonl` recording — pins the format + provenance for forward compatibility. */
-@Serializable
-public data class RecordingHeader(
-    /** `"rk-devtools-recording"` discriminator. */
-    public val kind: String = "rk-devtools-recording",
-    /** Bridge protocol version the events use. */
-    public val protocolVersion: Int,
-    /** Serializer tier that produced the JSON. */
-    public val serializerTier: String,
-    /** Source client id. */
-    public val clientId: String,
-    /** Source client label. */
-    public val clientLabel: String,
-    /** Source store name. */
-    public val storeName: String,
-    /** Source store instance id. */
-    public val storeInstanceId: String,
-)
-
-/** Encodes a header + messages to newline-delimited JSON (`.jsonl`). */
-public fun encodeRecording(header: RecordingHeader, messages: List<BridgeMessage>): String = buildString {
-    appendLine(bridgeJson.encodeToString(RecordingHeader.serializer(), header))
-    messages.forEach { appendLine(bridgeJson.encodeToString(BridgeMessage.serializer(), it)) }
-}
-
-/** Decodes a `.jsonl` recording into its header + messages (ignores blank lines). */
-public fun decodeRecording(text: String): Pair<RecordingHeader, List<BridgeMessage>> {
-    val lines = text.split("\n").filter { it.isNotBlank() }
-    require(lines.isNotEmpty()) { "empty recording" }
-    val header = bridgeJson.decodeFromString(RecordingHeader.serializer(), lines.first())
-    val messages = lines.drop(1).map { bridgeJson.decodeFromString(BridgeMessage.serializer(), it) }
-    return header to messages
-}
+// RecordingHeader / encodeRecording / decodeRecording now live in :redux-kotlin-devtools-bridge
+// (org.reduxkotlin.devtools.bridge). Platform file pickers remain here.
 
 /** Writes [text] as a recording file/blob named [suggestedName]; platform-specific. */
 public expect fun saveRecording(suggestedName: String, text: String)

--- a/redux-kotlin-devtools-standalone/src/commonMain/kotlin/org/reduxkotlin/devtools/monitor/ui/App.kt
+++ b/redux-kotlin-devtools-standalone/src/commonMain/kotlin/org/reduxkotlin/devtools/monitor/ui/App.kt
@@ -10,10 +10,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.reduxkotlin.devtools.bridge.BridgeMessage
+import org.reduxkotlin.devtools.bridge.decodeRecording
+import org.reduxkotlin.devtools.bridge.encodeRecording
 import org.reduxkotlin.devtools.monitor.MonitorIngest
 import org.reduxkotlin.devtools.monitor.MonitorState
-import org.reduxkotlin.devtools.monitor.decodeRecording
-import org.reduxkotlin.devtools.monitor.encodeRecording
 import org.reduxkotlin.devtools.monitor.loadRecording
 import org.reduxkotlin.devtools.monitor.saveRecording
 

--- a/redux-kotlin-devtools-standalone/src/commonTest/kotlin/org/reduxkotlin/devtools/monitor/RecordingCodecTest.kt
+++ b/redux-kotlin-devtools-standalone/src/commonTest/kotlin/org/reduxkotlin/devtools/monitor/RecordingCodecTest.kt
@@ -4,6 +4,9 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.reduxkotlin.devtools.bridge.BridgeMessage
 import org.reduxkotlin.devtools.bridge.PROTOCOL_VERSION
+import org.reduxkotlin.devtools.bridge.RecordingHeader
+import org.reduxkotlin.devtools.bridge.decodeRecording
+import org.reduxkotlin.devtools.bridge.encodeRecording
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,7 @@ include(
     ":redux-kotlin-devtools-inapp-noop",
     ":redux-kotlin-devtools-ui",
     ":redux-kotlin-devtools-standalone",
+    ":redux-kotlin-devtools-cli",
     ":examples:counter:common",
     ":examples:counter:android",
     ":examples:todos:common",


### PR DESCRIPTION
Implements the redux-kotlin DevTools CLI per the brainstormed design + plan:
- Design: `docs/superpowers/specs/2026-06-04-redux-kotlin-devtools-cli-design.md`
- Plan: `docs/superpowers/plans/2026-06-04-redux-kotlin-devtools-cli.md`

## Summary
A JVM CLI (`rk-devtools`) that turns the existing DevTools bridge telemetry into an agent-readable write→run→observe→fix loop.

- **`serve [--ui]`** — hosts the bridge receiver (reusing standalone's `MonitorServer`/`MonitorIngest`) and writes one GUI-loadable `.jsonl` recording per store under `.rk-devtools/`. `--ui` also launches the bundled Compose monitor against the same ingest (one server, no port clash).
- **Query subcommands** (`stores`, `actions`, `diff`, `state`, `tail --follow`) over the capture, with `--format actions|diff|full` nested tiers and filters (`--store`, `--type '*Card*'`, `--since/--until`, `--last N`, `--at`). JSON-lines by default.
- **Three-layer module**: Compose-free `capture/` query lib (reader/query/formatter — the query path never touches Compose at runtime), `server/` writer+flusher, `command/` clikt frontend.
- **Prereq refactor (Task 0):** moved the `.jsonl` recording codec (`RecordingHeader`/`encodeRecording`/`decodeRecording`) from `-devtools-standalone` (Compose) down into `-devtools-bridge` so the capture lib shares it Compose-free. Behavior-preserving; bridge ABI dump updated.
- Agent reference guide added: `docs/agent/references/devtools.md` (anchors pass `scripts/check-agent-refs.sh`).

Built TDD, task-by-task, each with spec + code-quality review. Final holistic review: READY TO MERGE.

## Test Plan
- [x] `./gradlew :redux-kotlin-devtools-cli:test` — full module suite green (capture/server/command/e2e)
- [x] `./gradlew :redux-kotlin-devtools-cli:check` — green
- [x] `./gradlew :redux-kotlin-devtools-bridge:checkKotlinAbi` — green (codec move)
- [x] `./gradlew :redux-kotlin-devtools-standalone:jvmTest` — green (refactor behavior-preserving)
- [x] `./gradlew detektAll` — green
- [x] `./gradlew :redux-kotlin-devtools-cli:installDist` — produces `rk-devtools` launcher
- [x] `bash scripts/check-agent-refs.sh` — ANCHOR CHECK OK

## CI caveat (pre-existing, NOT from this branch)
A whole-tree build will fail `:redux-kotlin-devtools-inapp:checkKotlinAbi` — a Compose-generated synthetic lambda hash drift in a module this branch never touches (verified: `git diff origin/master..HEAD --stat -- redux-kotlin-devtools-inapp` is empty). It is red on `master` too; regenerate that module's ABI dump separately.

## Known follow-ups (minor, deferred per design v1)
- `CaptureFlusher` full-rewrites each store file per emission (design §5 said "append-only"); fine for v1, write-amplifies on long sessions.
- `writeStoreCapture` uses tmp+copy, not `Files.move(ATOMIC_MOVE)` — tiny torn-read window, self-healing.
- `discoverStores` uses the strict codec while `readCapture` is partial-line tolerant — could unify.
- Headless `serve` relies on SIGINT (no graceful `stop()`).
- Deferred by design: `digest`/triage, pipeline-timing, dispatch-back/time-travel, MCP face, capture rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)