### PR TITLE
docs(agent): strategy polish — wire devtools, fix codegen pointer, §8 refresh, inapp ABI

### DIFF
--- a/.claude/skills/redux-kotlin/SKILL.md
+++ b/.claude/skills/redux-kotlin/SKILL.md
@@ -31,6 +31,7 @@ companion modules on one `Store<S>` contract. Recommended app organization is **
 | **Testing** + the verify loop | [`testing.md`](../../../docs/agent/references/testing.md) |
 | The 5 **platform shims** | [`platform-shims.md`](../../../docs/agent/references/platform-shims.md) |
 | **Modularization** | [`modularization.md`](../../../docs/agent/references/modularization.md) |
+| **Debugging** a running app (actions/state/diffs) | [`devtools.md`](../../../docs/agent/references/devtools.md) |
 
 ## Pointers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,6 @@ Canonical example: `examples/taskflow`.
 
 ## Deeper knowledge
 
-- **T1** per-concern guides → `docs/agent/references/` (all seven live: feature-slice, store-setup, compose-binding, effects-sync, testing, platform-shims, modularization — see `docs/agent/references/README.md`).
+- **T1** per-concern guides → `docs/agent/references/` (all eight live: feature-slice, store-setup, compose-binding, effects-sync, testing, platform-shims, modularization, devtools — see `docs/agent/references/README.md`).
 - Task → guide routing (decision table) → `docs/agent/references/README.md`.
 - **T2** → `examples/taskflow/ARCHITECTURE.md` (full architecture + design rules) and `docs/agent/api-map.md` (module → `.api` index).

--- a/docs/agent/references/feature-slice.md
+++ b/docs/agent/references/feature-slice.md
@@ -162,8 +162,9 @@ not. Document public symbols as you write them, and never bypass the hook with `
 
 KSP `@Reduce` / `@ReduxInitial` codegen is packaging-agnostic: a `@Reduce`-annotated reducer can live
 in any `feature/*` package and the generated routing wiring follows it — package-by-feature does not
-change how codegen resolves it. Full codegen treatment is deferred to a planned guide
-*(planned — 0-rest)*.
+change how codegen resolves it. Full codegen reference (annotations, the generated `ReduxModule` wiring,
+and v1 limits) lives in `redux-kotlin-routing-codegen/README.md`. KSP extension (multi-model `onAction`
+/ effect handlers) is a separate deferred sub-project — see the AI-integration umbrella spec §8.
 
 ## See also
 

--- a/docs/superpowers/specs/2026-06-03-redux-kotlin-ai-integration-strategy-design.md
+++ b/docs/superpowers/specs/2026-06-03-redux-kotlin-ai-integration-strategy-design.md
@@ -185,17 +185,26 @@ Each phase is its own sub-project (spec → plan → build). Ordered so value la
 
 ## 8. Open best-practice questions
 
-Resolved per sub-project, not here:
+Status updated 2026-06-04 after Phases 0–4 shipped:
 
-1. **Store-topology decision rule** — when 1 store vs taskflow's 2-store + `AccountRegistry`?
-2. **Module-selection table** — concurrent vs threadsafe vs core; when granular / multimodel.
-3. **Verify-tier standardization** — which of headless-screenshot / UI-behavior / state-machine become
-   standard (overlap risk flagged; tier-1 is the only committed scope today).
-4. **KSP extension scope** — multi-model `onAction` / effect handlers: a separate later sub-project.
-5. **Skill granularity** — one skill vs several (feature / store / testing).
-6. **`AGENTS.md` ↔ `CLAUDE.md`** — unify (one generated source, maintainer + app-builder views) or split.
-7. **External distribution mechanics** — how `AGENTS.md` / the skill ship with the published library (docs
-   page? template repo? part of the artifact?).
+1. ✅ **Store-topology decision rule** — answered by `docs/agent/references/store-setup.md` ("One store vs.
+   two" decision rule).
+2. ✅ **Module-selection table** — answered by `docs/agent/references/modularization.md` (the
+   module-selection table + decision rules).
+3. ⏳ **Verify-tier standardization** — partially advanced: the **DevTools CLI** (shipped) adds a
+   runtime action/state/diff observability tier an agent can query (`docs/agent/references/devtools.md`).
+   Headless-screenshot / UI-behavior / state-machine tiers remain undesigned; tier-1 (compile + unit) is
+   still the only committed *test* scope.
+4. ⏳ **KSP extension scope** — multi-model `onAction` / effect handlers: still a deferred sub-project
+   (intentional; not started).
+5. ✅ **Skill granularity** — settled as **one** skill with a decision-routing table (no per-concern split).
+6. ⛔ **`AGENTS.md` ↔ `CLAUDE.md`** — STILL OPEN. Two overlapping files, no single source; no owner yet.
+7. ⛔ **External distribution mechanics** — STILL OPEN and the largest strategic gap: the strategy is
+   external-first, but nothing ships externally yet (no docs page / template repo / artifact packaging).
+   Its own sub-project (spec → plan → build).
+
+Also unmeasured: the §7 success metrics have no baseline run yet — needs a tokens-to-correct-slice
+cold-vs-equipped measurement to validate the knowledge-first bet.
 
 ## 9. Explicitly out of scope
 

--- a/redux-kotlin-devtools-inapp/api/jvm/redux-kotlin-devtools-inapp.api
+++ b/redux-kotlin-devtools-inapp/api/jvm/redux-kotlin-devtools-inapp.api
@@ -37,6 +37,12 @@ public final class org/reduxkotlin/devtools/inapp/ReduxDevToolsHostKt {
 	public static final fun ReduxDevToolsHost (Lorg/reduxkotlin/devtools/inapp/InAppConfig;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
+public final class org/reduxkotlin/devtools/inapp/ui/ComposableSingletons$DrawerActionLogKt {
+	public static final field INSTANCE Lorg/reduxkotlin/devtools/inapp/ui/ComposableSingletons$DrawerActionLogKt;
+	public fun <init> ()V
+	public final fun getLambda$839140025$redux_kotlin_devtools_inapp ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class org/reduxkotlin/devtools/inapp/ui/ComposableSingletons$DrawerKt {
 	public static final field INSTANCE Lorg/reduxkotlin/devtools/inapp/ui/ComposableSingletons$DrawerKt;
 	public fun <init> ()V


### PR DESCRIPTION
Audit follow-ups on the AI-integration strategy surface.

## Changes
- **Wire the `devtools` guide in** — it was indexed in `references/README.md` but missing from the Claude skill's decision routing and the AGENTS.md T1 list (silent rot; no CI catches routing completeness). Added to both.
- **Fix dangling codegen pointer** — `feature-slice.md` promised a "(planned — 0-rest)" codegen guide that isn't coming; repointed to the real `redux-kotlin-routing-codegen/README.md`, with KSP extension left as a deferred sub-project.
- **Refresh umbrella spec §8** — marked resolved questions (store-topology → store-setup.md, module table → modularization.md, skill granularity → one-skill), noted the DevTools CLI advances the verify-tier question, and flagged #6 (AGENTS↔CLAUDE unification) and #7 (external distribution) as still-open, plus the §7 metrics baseline as unmeasured.
- **Refresh stale inapp ABI dump** — committed dump lagged the Compose compiler output (a `ComposableSingletons` lambda accessor), failing `checkKotlinAbi` on master. Regenerated; no real public-API change.

## Verification
- [x] `scripts/assemble-agent-knowledge.sh --check` — ASSEMBLE CHECK OK
- [x] `scripts/check-agent-refs.sh` — ANCHOR CHECK OK
- [x] `:redux-kotlin-devtools-inapp:checkKotlinAbi` — now green
- [x] `detektAll` — green

Carries `api-reviewed` (the only `.api` change is the inapp dump resync — no public surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)