### PR TITLE
feat(compose-saveable): rememberSaveable-style store persistence for Compose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ same single `Store<S>` contract. Take the core, add only the companions you need
 
 ## Module map
 
-The nine published core modules (each "use for X"):
+The ten published core modules (each "use for X"):
 
 <!-- assemble:modules:start -->
 - `redux-kotlin` — core contract: `Store`/`TypedStore`, `Reducer`, `Middleware`, `createStore`, `applyMiddleware`, `combineReducers`, `compose`.
@@ -25,6 +25,7 @@ The nine published core modules (each "use for X"):
 - `redux-kotlin-multimodel-granular` — granular subscriptions for `ModelState`.
 - `redux-kotlin-compose` — Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`).
 - `redux-kotlin-compose-multimodel` — Compose bindings for `ModelState`.
+- `redux-kotlin-compose-saveable` — `StateSaver` + `Store<S>.rememberSaveableState` store-anchored snapshot persistence (rotation + process death) via `SaveableStateRegistry`.
 <!-- assemble:modules:end -->
 
 More modules exist (routing/bundle/bom/devtools/codegen) → see `docs/agent/api-map.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ gate and conventions that aren't obvious from the source.
 
 ## Modules
 
-Nine published library modules (each applies `convention.library-mpp-*` +
+Ten published library modules (each applies `convention.library-mpp-*` +
 `convention.publishing-mpp`):
 
 - `redux-kotlin` — core: `Store`/`TypedStore`, `Reducer`, `Middleware`, `createStore`, `applyMiddleware`, `combineReducers`, `compose`.
@@ -19,6 +19,7 @@ Nine published library modules (each applies `convention.library-mpp-*` +
 - `redux-kotlin-multimodel-granular` — granular subscriptions for `ModelState`.
 - `redux-kotlin-compose` — Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`).
 - `redux-kotlin-compose-multimodel` — Compose bindings for `ModelState`.
+- `redux-kotlin-compose-saveable` — `rememberSaveableState` store-anchored snapshot persistence (survives rotation + process death) via Compose `SaveableStateRegistry` + kotlinx.serialization.
 
 `examples/` holds sample apps (`convention.control`, not published). `website/`
 is the Docusaurus docs site.

--- a/docs/agent/AGENTS-external.md
+++ b/docs/agent/AGENTS-external.md
@@ -32,6 +32,7 @@ implementation("org.reduxkotlin:redux-kotlin:0.6.1")
 - `redux-kotlin-multimodel-granular` — granular subscriptions for `ModelState`.
 - `redux-kotlin-compose` — Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`).
 - `redux-kotlin-compose-multimodel` — Compose bindings for `ModelState`.
+- `redux-kotlin-compose-saveable` — `StateSaver` + `Store<S>.rememberSaveableState` store-anchored snapshot persistence (rotation + process death) via `SaveableStateRegistry`.
 <!-- assemble:modules:end -->
 
 Full module → public-API index:

--- a/docs/agent/_fragments/modules.md
+++ b/docs/agent/_fragments/modules.md
@@ -7,3 +7,4 @@
 - `redux-kotlin-multimodel-granular` — granular subscriptions for `ModelState`.
 - `redux-kotlin-compose` — Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`).
 - `redux-kotlin-compose-multimodel` — Compose bindings for `ModelState`.
+- `redux-kotlin-compose-saveable` — `StateSaver` + `Store<S>.rememberSaveableState` store-anchored snapshot persistence (rotation + process death) via `SaveableStateRegistry`.

--- a/docs/agent/api-map.md
+++ b/docs/agent/api-map.md
@@ -24,6 +24,7 @@ Read the committed `.api` dump for a module's public surface; regenerate with `.
 | `:redux-kotlin-multimodel-granular` | `redux-kotlin-multimodel-granular/api/redux-kotlin-multimodel-granular.klib.api` | Granular subscriptions for `ModelState`. |
 | `:redux-kotlin-compose` | `redux-kotlin-compose/api/redux-kotlin-compose.klib.api` | Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`). |
 | `:redux-kotlin-compose-multimodel` | `redux-kotlin-compose-multimodel/api/redux-kotlin-compose-multimodel.klib.api` | Compose bindings for `ModelState`. |
+| `:redux-kotlin-compose-saveable` | `redux-kotlin-compose-saveable/api/redux-kotlin-compose-saveable.klib.api` | `StateSaver<S,Snapshot>` + `Store<S>.rememberSaveableState` snapshot persistence for Compose via `SaveableStateRegistry` (survives rotation + process death). |
 | `:redux-kotlin-routing` | `redux-kotlin-routing/api/redux-kotlin-routing.klib.api` | Routing DSL + `@Reduce`/`@ReduxInitial` annotations and `ReduxModule` contribution surface. |
 | `:redux-kotlin-routing-codegen-sample` | `redux-kotlin-routing-codegen-sample/api/redux-kotlin-routing-codegen-sample.klib.api` | Sample showing KSP-generated routing wiring (`ReduxModule` output). |
 | `:redux-kotlin-bundle` | `redux-kotlin-bundle/api/redux-kotlin-bundle.klib.api` | One-call assembly of a concurrent `ModelState` store + registry + routing (`createConcurrentModelStore`, `getOrCreateConcurrentModelStore`). |

--- a/docs/superpowers/plans/2026-06-09-redux-kotlin-compose-saveable.md
+++ b/docs/superpowers/plans/2026-06-09-redux-kotlin-compose-saveable.md
@@ -1,0 +1,626 @@
+# redux-kotlin-compose-saveable Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `redux-kotlin-compose-saveable` companion module whose `Store<S>.rememberSaveableState(saver)` persists a minimal serialized snapshot of store state across Android rotation and process death, rehydrating via a single dispatched action.
+
+**Architecture:** A `StateSaver` value type (serializer + `save` projection + `restore` action factory, no Compose state) is consumed by a `@Composable` anchor that drives Compose's `SaveableStateRegistry` directly: on a real restore it decodes and dispatches the restore action exactly once (fixing the clobber where one-directional bindings would overwrite the restored value with the store's initial state); a registered provider serializes the projection only at save time. The composable delegates to an `internal` non-composable `wireSaveable` so the correctness path is unit-testable without a composition.
+
+**Tech Stack:** Kotlin Multiplatform, Compose Multiplatform 1.11.0 (`runtime`, `runtime-saveable`), kotlinx.serialization 1.7.3, kotlin-test, Compose `compose.uiTest` (desktop) for integration.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-redux-kotlin-compose-saveable-design.md`
+
+---
+
+## File structure
+
+| Path | Responsibility |
+|---|---|
+| `redux-kotlin-compose-saveable/build.gradle.kts` | Module build wiring (create) |
+| `redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/StateSaver.kt` | The `StateSaver` value type (create) |
+| `redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/RememberSaveableState.kt` | `rememberSaveableState` composable + `internal wireSaveable` (create) |
+| `redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/TestFixtures.kt` | Shared test state/actions/reducer/saver (create) |
+| `redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/StateSaverTest.kt` | `StateSaver` round-trip (create) |
+| `redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/RegistryRoundTripTest.kt` | Primary mechanism test via `SaveableStateRegistry` (create) |
+| `redux-kotlin-compose-saveable/src/jvmTest/kotlin/org/reduxkotlin/compose/saveable/SaveableIntegrationTest.kt` | End-to-end via `StateRestorationTester` (create) |
+| `redux-kotlin-compose-saveable/api/redux-kotlin-compose-saveable.api` | Public API dump (generated) |
+| `settings.gradle.kts` | Register the module (modify) |
+| `gradle/libs.versions.toml` | Add `compose-runtime-saveable` library (modify) |
+| `redux-kotlin-bom/build.gradle.kts` | Add BOM constraint (modify) |
+| `redux-kotlin-bundle-compose/build.gradle.kts` | Add `api` dependency (modify) |
+| `CLAUDE.md`, `docs/agent/_fragments/modules.md` | Module docs (modify) |
+
+---
+
+## Task 1: Scaffold the module (build wiring)
+
+**Files:**
+- Create: `redux-kotlin-compose-saveable/build.gradle.kts`
+- Modify: `gradle/libs.versions.toml`
+- Modify: `settings.gradle.kts`
+
+- [ ] **Step 1: Add the `runtime-saveable` library to the version catalog**
+
+In `gradle/libs.versions.toml`, under `[libraries]`, add (next to the other `kotlinx-serialization-json`/compose entries):
+
+```toml
+compose-runtime-saveable = { module = "org.jetbrains.compose.runtime:runtime-saveable", version.ref = "compose-multiplatform" }
+```
+
+(The `compose.runtimeSaveable` Gradle accessor is deprecated in Compose 1.11; use this catalog entry instead.)
+
+- [ ] **Step 2: Create the module build file**
+
+Create `redux-kotlin-compose-saveable/build.gradle.kts`:
+
+```kotlin
+plugins {
+    id("convention.library-mpp-loved")
+    alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
+    id("convention.publishing-mpp")
+}
+
+val hasAndroidSdk: Boolean = run {
+    val localProps = rootProject.file("local.properties")
+    val hasSdkInLocalProperties = localProps.exists() && localProps.readText().lineSequence().any {
+        it.trim().startsWith("sdk.dir=") && it.substringAfter("sdk.dir=").isNotBlank()
+    }
+    val hasSdkInEnv =
+        !System.getenv("ANDROID_HOME").isNullOrBlank() ||
+            !System.getenv("ANDROID_SDK_ROOT").isNullOrBlank()
+    hasSdkInLocalProperties || hasSdkInEnv
+}
+
+kotlin {
+    if (hasAndroidSdk) {
+        android {
+            namespace = "org.reduxkotlin.compose.saveable"
+        }
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":redux-kotlin-compose"))
+                implementation(compose.runtime)
+                implementation(libs.compose.runtime.saveable)
+                implementation(libs.kotlinx.serialization.json)
+            }
+        }
+        named("jvmTest") {
+            dependencies {
+                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+                implementation(compose.uiTest)
+                implementation(compose.foundation)
+                implementation(compose.desktop.currentOs)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Register the module in settings**
+
+In `settings.gradle.kts`, inside the `include(` list, add this line after `":redux-kotlin-compose-multimodel",`:
+
+```kotlin
+    ":redux-kotlin-compose-saveable",
+```
+
+- [ ] **Step 4: Verify the module configures and compiles (empty sources)**
+
+Run: `./gradlew :redux-kotlin-compose-saveable:compileKotlinJvm`
+Expected: `BUILD SUCCESSFUL` (no sources yet — compiles an empty source set).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gradle/libs.versions.toml settings.gradle.kts redux-kotlin-compose-saveable/build.gradle.kts
+git commit -m "build(compose-saveable): scaffold module"
+```
+
+---
+
+## Task 2: `StateSaver` value type
+
+**Files:**
+- Create: `redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/TestFixtures.kt`
+- Create: `redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/StateSaverTest.kt`
+- Create: `redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/StateSaver.kt`
+
+- [ ] **Step 1: Write shared test fixtures**
+
+Create `redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/TestFixtures.kt`:
+
+```kotlin
+package org.reduxkotlin.compose.saveable
+
+import kotlinx.serialization.Serializable
+import org.reduxkotlin.Store
+import org.reduxkotlin.createStore
+
+internal data class TestState(val tab: Int = 0, val query: String = "")
+
+internal data class SetTab(val tab: Int)
+
+internal data class RehydrateUi(val tab: Int, val query: String)
+
+@Serializable
+internal data class UiSnapshot(val tab: Int, val query: String)
+
+internal val testReducer: (TestState, Any) -> TestState = { state, action ->
+    when (action) {
+        is SetTab -> state.copy(tab = action.tab)
+        is RehydrateUi -> state.copy(tab = action.tab, query = action.query)
+        else -> state
+    }
+}
+
+internal fun newTestStore(initial: TestState = TestState()): Store<TestState> =
+    createStore(testReducer, initial)
+
+internal val testSaver: StateSaver<TestState, UiSnapshot> = StateSaver(
+    serializer = UiSnapshot.serializer(),
+    save = { state -> UiSnapshot(state.tab, state.query) },
+    restore = { snapshot -> RehydrateUi(snapshot.tab, snapshot.query) },
+)
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/StateSaverTest.kt`:
+
+```kotlin
+package org.reduxkotlin.compose.saveable
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StateSaverTest {
+
+    @Test
+    fun encode_then_decode_roundtrips_snapshot() {
+        val snapshot = testSaver.save(TestState(tab = 4, query = "hi"))
+        val encoded = testSaver.json.encodeToString(testSaver.serializer, snapshot)
+        val decoded = testSaver.json.decodeFromString(testSaver.serializer, encoded)
+        assertEquals(snapshot, decoded)
+    }
+
+    @Test
+    fun restore_builds_expected_action() {
+        val action = testSaver.restore(UiSnapshot(tab = 4, query = "hi"))
+        assertEquals(RehydrateUi(4, "hi"), action)
+    }
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-compose-saveable:jvmTest`
+Expected: FAIL — `Unresolved reference: StateSaver` (compilation error in `TestFixtures.kt`/`StateSaverTest.kt`).
+
+- [ ] **Step 4: Implement `StateSaver`**
+
+Create `redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/StateSaver.kt`:
+
+```kotlin
+package org.reduxkotlin.compose.saveable
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+
+/**
+ * Describes how a slice of store state [S] is projected to a small
+ * serializable [Snapshot], and how a restored snapshot is turned back into
+ * an action the store's reducer applies.
+ *
+ * Holds no Compose state — its serialization round-trip is unit-testable
+ * without a composition. Reuse one instance across screens.
+ */
+public class StateSaver<S, Snapshot : Any>(
+    /** Serializer for the [Snapshot] type (e.g. `MySnapshot.serializer()`). */
+    public val serializer: KSerializer<Snapshot>,
+    /** Projects current state to the minimal snapshot worth persisting. */
+    public val save: (S) -> Snapshot,
+    /** Turns a restored snapshot into an action the reducer applies. */
+    public val restore: (Snapshot) -> Any,
+    /** JSON codec; override to tune (e.g. `Json { ignoreUnknownKeys = true }`). */
+    public val json: Json = Json,
+)
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-compose-saveable:jvmTest`
+Expected: PASS (both `StateSaverTest` tests green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add redux-kotlin-compose-saveable/src/commonMain redux-kotlin-compose-saveable/src/commonTest
+git commit -m "feat(compose-saveable): add StateSaver value type"
+```
+
+---
+
+## Task 3: `wireSaveable` + `rememberSaveableState` (the mechanism)
+
+**Files:**
+- Create: `redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/RegistryRoundTripTest.kt`
+- Create: `redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/RememberSaveableState.kt`
+
+- [ ] **Step 1: Write the failing mechanism test**
+
+Create `redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/RegistryRoundTripTest.kt`:
+
+```kotlin
+package org.reduxkotlin.compose.saveable
+
+import androidx.compose.runtime.saveable.SaveableStateRegistry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RegistryRoundTripTest {
+
+    @Test
+    fun restore_rehydrates_a_fresh_store() {
+        // Phase 1: a source store with non-initial state, register the provider.
+        val source = newTestStore(TestState(tab = 5, query = "x"))
+        val registry1 = SaveableStateRegistry(restoredValues = null) { true }
+        wireSaveable(source, registry1, "k", testSaver)
+        val saved = registry1.performSave()
+
+        // Phase 2: a brand-new store (simulating process death) seeded with the
+        // saved values. Restore must dispatch the rehydrate action.
+        val fresh = newTestStore(TestState())
+        val registry2 = SaveableStateRegistry(restoredValues = saved) { true }
+        wireSaveable(fresh, registry2, "k", testSaver)
+
+        assertEquals(TestState(tab = 5, query = "x"), fresh.state)
+    }
+
+    @Test
+    fun cold_start_dispatches_nothing() {
+        val store = newTestStore(TestState(tab = 9))
+        var notified = 0
+        val unsubscribe = store.subscribe { notified++ }
+
+        val registry = SaveableStateRegistry(restoredValues = null) { true } // empty == cold start
+        wireSaveable(store, registry, "k", testSaver)
+
+        unsubscribe()
+        assertEquals(0, notified)
+        assertEquals(TestState(tab = 9), store.state)
+    }
+
+    @Test
+    fun corrupt_snapshot_is_ignored_as_cold_start() {
+        val store = newTestStore(TestState(tab = 9))
+        var notified = 0
+        val unsubscribe = store.subscribe { notified++ }
+
+        val registry = SaveableStateRegistry(restoredValues = mapOf("k" to listOf("not-json"))) { true }
+        wireSaveable(store, registry, "k", testSaver)
+
+        unsubscribe()
+        assertEquals(0, notified)
+        assertEquals(TestState(tab = 9), store.state)
+    }
+
+    @Test
+    fun failing_save_does_not_crash_perform_save() {
+        val store = newTestStore(TestState(tab = 1))
+        val throwingSaver = StateSaver<TestState, UiSnapshot>(
+            serializer = UiSnapshot.serializer(),
+            save = { error("boom") },
+            restore = { RehydrateUi(it.tab, it.query) },
+        )
+        val registry = SaveableStateRegistry(restoredValues = null) { true }
+        wireSaveable(store, registry, "k", throwingSaver)
+
+        val saved = registry.performSave() // must not throw
+        assertEquals(null, saved["k"]?.firstOrNull())
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-compose-saveable:jvmTest --tests "*RegistryRoundTripTest*"`
+Expected: FAIL — `Unresolved reference: wireSaveable`.
+
+- [ ] **Step 3: Implement the composable and `wireSaveable`**
+
+Create `redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/RememberSaveableState.kt`:
+
+```kotlin
+package org.reduxkotlin.compose.saveable
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.currentCompositeKeyHash
+import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
+import androidx.compose.runtime.saveable.SaveableStateRegistry
+import org.reduxkotlin.Store
+
+/**
+ * Anchors saveable persistence for [this] store to the enclosing
+ * [SaveableStateRegistry]. Place it **once** per persisted scope (typically
+ * near the root, or once per screen).
+ *
+ * On a real restore (rotation or process death) the saved snapshot is decoded
+ * and dispatched via [StateSaver.restore] exactly once, so downstream bindings
+ * observe the rehydrated store (a single stale frame is possible before they
+ * re-sample). On cold start nothing is dispatched. The latest projection is
+ * provided to the registry and serialized only when the platform actually
+ * saves — there is no steady-state subscription.
+ *
+ * The persisted store must accept main-thread reads and dispatch (the
+ * Compose-facing store: concurrent/threadsafe, or main-confined).
+ *
+ * @param saver describes the snapshot projection and restore action.
+ * @param key stable registry key. Required when multiple anchors exist, inside
+ *   lists, or across navigation where positional keys collide. Defaults to the
+ *   call-site composite key.
+ */
+@Composable
+public fun <S, Snapshot : Any> Store<S>.rememberSaveableState(
+    saver: StateSaver<S, Snapshot>,
+    key: String? = null,
+) {
+    val store = this
+    val registry = LocalSaveableStateRegistry.current
+    val finalKey = key ?: currentCompositeKeyHash.toString(radix = 36)
+    DisposableEffect(store, registry, finalKey) {
+        val entry = wireSaveable(store, registry, finalKey, saver)
+        onDispose { entry?.unregister() }
+    }
+}
+
+/**
+ * Non-composable core: consume any restored snapshot and dispatch the restore
+ * action exactly once (only on a real restore), then register the save
+ * provider. Extracted so the correctness path is testable without a
+ * composition. Returns the provider entry to unregister on dispose.
+ */
+internal fun <S, Snapshot : Any> wireSaveable(
+    store: Store<S>,
+    registry: SaveableStateRegistry?,
+    key: String,
+    saver: StateSaver<S, Snapshot>,
+): SaveableStateRegistry.Entry? {
+    val restored = (registry?.consumeRestored(key) as? String)?.let { encoded ->
+        runCatching { saver.json.decodeFromString(saver.serializer, encoded) }.getOrNull()
+    }
+    if (restored != null) {
+        store.dispatch(saver.restore(restored))
+    }
+    return registry?.registerProvider(key) {
+        runCatching { saver.json.encodeToString(saver.serializer, saver.save(store.state)) }.getOrNull()
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./gradlew :redux-kotlin-compose-saveable:jvmTest --tests "*RegistryRoundTripTest*"`
+Expected: PASS (all four tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-compose-saveable/src/commonMain redux-kotlin-compose-saveable/src/commonTest
+git commit -m "feat(compose-saveable): rememberSaveableState anchor + wireSaveable"
+```
+
+---
+
+## Task 4: End-to-end integration test (`StateRestorationTester`)
+
+**Files:**
+- Create: `redux-kotlin-compose-saveable/src/jvmTest/kotlin/org/reduxkotlin/compose/saveable/SaveableIntegrationTest.kt`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `redux-kotlin-compose-saveable/src/jvmTest/kotlin/org/reduxkotlin/compose/saveable/SaveableIntegrationTest.kt`:
+
+```kotlin
+package org.reduxkotlin.compose.saveable
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.StateRestorationTester
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import org.reduxkotlin.compose.fieldState
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class SaveableIntegrationTest {
+
+    @Test
+    fun child_binding_shows_restored_value_after_state_restoration() = runComposeUiTest {
+        val tester = StateRestorationTester(this)
+        tester.setContent {
+            // `remember` (not rememberSaveable): re-initialized on restore, so the
+            // store is recreated fresh — simulating process death. The anchor must
+            // rehydrate it from the saved snapshot.
+            val store = remember { newTestStore(TestState()) }
+            store.rememberSaveableState(testSaver, key = "root")
+            Column {
+                BasicText(
+                    text = store.fieldState(TestState::tab).value.toString(),
+                    modifier = Modifier.testTag("tab"),
+                )
+                BasicText(
+                    text = "set",
+                    modifier = Modifier
+                        .testTag("set")
+                        .clickable { store.dispatch(SetTab(7)) },
+                )
+            }
+        }
+
+        onNodeWithTag("tab").assertTextEquals("0")
+        onNodeWithTag("set").performClick()
+        onNodeWithTag("tab").assertTextEquals("7")
+
+        tester.emulateSavedInstanceStateRestore()
+
+        // The button was not clicked again; only rehydration can produce "7".
+        onNodeWithTag("tab").assertTextEquals("7")
+    }
+}
+```
+
+- [ ] **Step 2: Run the integration test**
+
+Run: `./gradlew :redux-kotlin-compose-saveable:jvmTest --tests "*SaveableIntegrationTest*"`
+Expected: PASS. If `StateRestorationTester`'s restore method resolves under a different name in the pinned Compose (`emulateSaveAndRestore`), adjust the single call accordingly and re-run.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add redux-kotlin-compose-saveable/src/jvmTest
+git commit -m "test(compose-saveable): end-to-end StateRestorationTester integration"
+```
+
+---
+
+## Task 5: Public API dump
+
+**Files:**
+- Create (generated): `redux-kotlin-compose-saveable/api/redux-kotlin-compose-saveable.api`
+
+- [ ] **Step 1: Generate the API dump**
+
+Run: `./gradlew :redux-kotlin-compose-saveable:apiDump`
+Expected: `BUILD SUCCESSFUL`; a new `redux-kotlin-compose-saveable/api/redux-kotlin-compose-saveable.api` file appears containing `StateSaver` and `rememberSaveableState` (and NOT `wireSaveable`, which is `internal`).
+
+- [ ] **Step 2: Verify the dump matches**
+
+Run: `./gradlew :redux-kotlin-compose-saveable:apiCheck`
+Expected: `BUILD SUCCESSFUL` (committed dump matches the surface).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add redux-kotlin-compose-saveable/api
+git commit -m "build(compose-saveable): commit public API dump"
+```
+
+---
+
+## Task 6: BOM + bundle-compose membership
+
+**Files:**
+- Modify: `redux-kotlin-bom/build.gradle.kts`
+- Modify: `redux-kotlin-bundle-compose/build.gradle.kts`
+
+- [ ] **Step 1: Add the BOM constraint**
+
+In `redux-kotlin-bom/build.gradle.kts`, inside the `constraints { ... }` block, add after the `redux-kotlin-compose-multimodel` line:
+
+```kotlin
+        api("$g:redux-kotlin-compose-saveable:$v")
+```
+
+- [ ] **Step 2: Add to the Compose bundle**
+
+In `redux-kotlin-bundle-compose/build.gradle.kts`, inside `commonMain { dependencies { ... } }`, add after the `redux-kotlin-compose-multimodel` line:
+
+```kotlin
+                api(project(":redux-kotlin-compose-saveable"))
+```
+
+- [ ] **Step 3: Verify both modules build**
+
+Run: `./gradlew :redux-kotlin-bom:assemble :redux-kotlin-bundle-compose:compileKotlinJvm`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add redux-kotlin-bom/build.gradle.kts redux-kotlin-bundle-compose/build.gradle.kts
+git commit -m "build(compose-saveable): add to BOM and bundle-compose"
+```
+
+---
+
+## Task 7: Module docs
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `docs/agent/_fragments/modules.md`
+
+- [ ] **Step 1: Update CLAUDE.md module list**
+
+In `CLAUDE.md`, in the `## Modules` section: change the lead sentence "Nine published library modules" to "Ten published library modules", and add this bullet after the `redux-kotlin-compose-multimodel` bullet:
+
+```markdown
+- `redux-kotlin-compose-saveable` — `rememberSaveableState` store-anchored snapshot persistence (survives rotation + process death) via Compose `SaveableStateRegistry` + kotlinx.serialization.
+```
+
+- [ ] **Step 2: Update the agent modules fragment**
+
+In `docs/agent/_fragments/modules.md`, add this bullet immediately after the `redux-kotlin-compose-multimodel` line (it is the last line in the file):
+
+```markdown
+- `redux-kotlin-compose-saveable` — `StateSaver` + `Store<S>.rememberSaveableState` store-anchored snapshot persistence (rotation + process death) via `SaveableStateRegistry`.
+```
+
+- [ ] **Step 3: Verify docs files are well-formed**
+
+Run: `git diff --stat CLAUDE.md docs/agent/_fragments/modules.md`
+Expected: both files show the added lines.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md docs/agent/_fragments/modules.md
+git commit -m "docs(compose-saveable): add module to CLAUDE.md and agent modules fragment"
+```
+
+---
+
+## Task 8: Full build gate
+
+- [ ] **Step 1: Run the module's full test matrix the host can run**
+
+Run: `./gradlew :redux-kotlin-compose-saveable:allTests`
+Expected: `BUILD SUCCESSFUL` (commonTest + jvmTest green; native/iOS targets are host-gated — trust CI for those).
+
+- [ ] **Step 2: Run the lint + API gates across the tree**
+
+Run: `./gradlew detektAll apiCheck`
+Expected: `BUILD SUCCESSFUL`. If detekt auto-corrects formatting (pre-commit hook), re-stage and re-commit.
+
+- [ ] **Step 3: Final verification commit (if the gates changed any files)**
+
+```bash
+git add -A
+git commit -m "chore(compose-saveable): satisfy detekt + apiCheck gates" || echo "nothing to commit"
+```
+
+---
+
+## Website docs — follow-up (separate PR)
+
+Spec §12 lists a short usage page on the Docusaurus site. This is intentionally **out of this plan's critical path** (it touches `website/` sidebar wiring and the `yarn build` `onBrokenLinks: throw` guard, independent of the module). After the module merges, add a page mirroring an existing extensions page under `website/docs/`, wire it into `website/sidebars.ts`, and run `cd website && yarn build` before committing.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §4 module → Task 1; §5 `StateSaver` → Task 2; §5/§6 composable + `wireSaveable` → Task 3; §11 commonTest round-trip + cold-start + corrupt + failing-save → Task 3; §11 integration → Task 4; §8 defensive decode/encode → Task 3 (`runCatching`); §12 apiDump → Task 5, BOM + bundle-compose → Task 6, docs → Task 7 (+ website follow-up); §7 threading → documented in `rememberSaveableState` KDoc (Task 3).
+- **Type consistency:** `StateSaver(serializer, save, restore, json)`, `wireSaveable(store, registry, key, saver)`, and `rememberSaveableState(saver, key)` are used identically across Tasks 2–4 and the fixtures.
+- **No placeholders:** every code/edit step shows concrete content; the only soft spot is the `StateRestorationTester` restore method name (Task 4 Step 2 gives the exact fallback).

--- a/docs/superpowers/plans/2026-06-09-redux-kotlin-compose-saveable.md
+++ b/docs/superpowers/plans/2026-06-09-redux-kotlin-compose-saveable.md
@@ -496,26 +496,31 @@ git commit -m "test(compose-saveable): end-to-end StateRestorationTester integra
 
 ---
 
-## Task 5: Public API dump
+## Task 5: Public API (ABI) dump
+
+This repo validates its public surface with Kotlin's built-in ABI validation —
+tasks `updateKotlinAbi` / `checkKotlinAbi`, dumps under `api/` (a merged
+`<module>.klib.api` plus a per-target `api/jvm/<module>.api`). There is **no**
+`apiDump`/`apiCheck` task (the CLAUDE.md names are stale).
 
 **Files:**
-- Create (generated): `redux-kotlin-compose-saveable/api/redux-kotlin-compose-saveable.api`
+- Create (generated): `redux-kotlin-compose-saveable/api/redux-kotlin-compose-saveable.klib.api` and `redux-kotlin-compose-saveable/api/jvm/redux-kotlin-compose-saveable.api`
 
-- [ ] **Step 1: Generate the API dump**
+- [ ] **Step 1: Generate the ABI dump**
 
-Run: `./gradlew :redux-kotlin-compose-saveable:apiDump`
-Expected: `BUILD SUCCESSFUL`; a new `redux-kotlin-compose-saveable/api/redux-kotlin-compose-saveable.api` file appears containing `StateSaver` and `rememberSaveableState` (and NOT `wireSaveable`, which is `internal`).
+Run: `./gradlew :redux-kotlin-compose-saveable:updateKotlinAbi`
+Expected: `BUILD SUCCESSFUL`; new files appear under `redux-kotlin-compose-saveable/api/` containing `StateSaver` and `rememberSaveableState` (and NOT `wireSaveable`, which is `internal`).
 
 - [ ] **Step 2: Verify the dump matches**
 
-Run: `./gradlew :redux-kotlin-compose-saveable:apiCheck`
+Run: `./gradlew :redux-kotlin-compose-saveable:checkKotlinAbi`
 Expected: `BUILD SUCCESSFUL` (committed dump matches the surface).
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add redux-kotlin-compose-saveable/api
-git commit -m "build(compose-saveable): commit public API dump"
+git commit -m "build(compose-saveable): commit public ABI dump"
 ```
 
 ---
@@ -601,7 +606,7 @@ Expected: `BUILD SUCCESSFUL` (commonTest + jvmTest green; native/iOS targets are
 
 - [ ] **Step 2: Run the lint + API gates across the tree**
 
-Run: `./gradlew detektAll apiCheck`
+Run: `./gradlew detektAll checkKotlinAbi`
 Expected: `BUILD SUCCESSFUL`. If detekt auto-corrects formatting (pre-commit hook), re-stage and re-commit.
 
 - [ ] **Step 3: Final verification commit (if the gates changed any files)**

--- a/docs/superpowers/specs/2026-06-09-redux-kotlin-compose-saveable-design.md
+++ b/docs/superpowers/specs/2026-06-09-redux-kotlin-compose-saveable-design.md
@@ -1,0 +1,289 @@
+# redux-kotlin-compose-saveable — Design
+
+- **Date:** 2026-06-09
+- **Status:** Approved (brainstorming complete; pending spec review)
+- **Module:** `redux-kotlin-compose-saveable` (new companion)
+
+## 1. Goal
+
+Let Redux state that backs a Compose UI **survive Android configuration
+changes / rotation and process (app) death**, using a minimal serialized
+snapshot of only the fields worth keeping. The mechanism rides Compose's
+own saved-state machinery, so rotation and process death are covered by a
+single code path, and degrades gracefully on non-Android targets.
+
+Explicitly **out of scope**: long-term disk persistence (DataStore/file
+across full restarts/updates). That is a different concern and can be a
+separate module later.
+
+## 2. Background & the core problem
+
+The existing `redux-kotlin-compose` bindings (`fieldState`,
+`selectorState`) are strictly one-directional: `store.state → Compose
+State`. They re-sample `store.state` inside `DisposableEffect` and
+overwrite the Compose value.
+
+Target apps run the store as a **process/DI singleton**. Consequences:
+
+- **Rotation** already preserves store state for free — the process lives
+  and the singleton holds. No work required for the store's own state.
+- **Process death** re-creates the singleton from its *initial* state, so
+  that state is lost.
+
+Therefore the real target is process-death restore. Compose's
+`SaveableStateRegistry` (the primitive under `rememberSaveable`) covers
+**both** rotation and process death through the same
+`registry → savedInstanceState` path, so building on it gets rotation
+included regardless.
+
+### The clobber problem (the design's load-bearing constraint)
+
+A Redux store can only change via `dispatch`. If a snapshot is restored
+but *not written back into the store*, the store still holds its initial
+state, and the one-directional bindings will **immediately overwrite the
+restored value with the store's initial value** on first subscription.
+
+So saveable support fundamentally requires a **rehydrate action**, not
+just a `Saver`. The restored snapshot must be pushed back into the store
+via `dispatch` so the store — the single source of truth — is correct
+before any binding re-samples it.
+
+## 3. Locked decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| API shape | Store-anchored snapshot | One write-back keeps single-source-of-truth; minimal payload via projection |
+| Module | New companion `redux-kotlin-compose-saveable` | Matches repo's opt-in-companion ethos; base compose module stays dependency-light |
+| Serialization | kotlinx.serialization (String) | Fully KMP; Bundle-safe; already a repo dependency |
+| Restore detection | Drive `SaveableStateRegistry` directly | Knows whether a restore actually happened → dispatch only then (no idempotency assumption) |
+| Public unit | `StateSaver` value type | Clean call site; serialization round-trip testable without Compose |
+| Restore write-back | User-supplied `restore: (Snapshot) -> Any` action | Zero-magic; works with any action/middleware; no store-setup coupling |
+
+## 4. Module structure
+
+`redux-kotlin-compose-saveable`, package `org.reduxkotlin.compose.saveable`,
+mirroring the `redux-kotlin-registry` template.
+
+- Plugins: `convention.library-mpp-loved`, compose-compiler,
+  compose-multiplatform, `convention.publishing-mpp`.
+- `commonMain` deps:
+  - `api(project(":redux-kotlin-compose"))`
+  - `implementation(compose.runtime)`
+  - `implementation(compose.runtimeSaveable)` — provides
+    `SaveableStateRegistry`, `LocalSaveableStateRegistry`,
+    `currentCompositeKeyHash`.
+  - `implementation(libs.kotlinx.serialization.json)`
+  - Apply the `kotlinx-serialization` plugin (for user `@Serializable`
+    snapshot types compiled in their own modules; the library itself uses
+    the runtime API with explicit `KSerializer`).
+- Same KMP targets as `redux-kotlin-compose`.
+- Register in `settings.gradle.kts`.
+
+## 5. Public API (2 symbols)
+
+```kotlin
+package org.reduxkotlin.compose.saveable
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import org.reduxkotlin.Store
+
+/**
+ * Describes how a slice of store state [S] is projected to a small
+ * serializable [Snapshot], and how a restored snapshot is turned back
+ * into an action the store's reducer applies.
+ *
+ * Holds no Compose state — its [save]/[restore]/serialization round-trip
+ * is unit-testable without a composition. Reuse one instance across
+ * screens.
+ */
+public class StateSaver<S, Snapshot : Any>(
+    /** Serializer for the [Snapshot] type (e.g. `MySnapshot.serializer()`). */
+    public val serializer: KSerializer<Snapshot>,
+    /** Project current state to the minimal snapshot worth persisting. */
+    public val save: (S) -> Snapshot,
+    /** Turn a restored snapshot into an action the reducer applies. */
+    public val restore: (Snapshot) -> Any,
+    /** JSON codec; override to tune (e.g. `ignoreUnknownKeys`). */
+    public val json: Json = Json,
+)
+
+/**
+ * Anchors saveable persistence for [this] store to the enclosing
+ * [androidx.compose.runtime.saveable.SaveableStateRegistry]. Place it
+ * **once** per persisted scope (typically near the root, or once per
+ * screen).
+ *
+ * On a real restore (rotation or process death) the saved snapshot is
+ * decoded and dispatched via [StateSaver.restore] exactly once, before
+ * downstream bindings re-sample the store. On cold start nothing is
+ * dispatched. While mounted, the latest projection is provided to the
+ * registry and serialized only when the platform actually saves.
+ *
+ * Returns [Unit]; named to pair with [fieldState]/[selectorState].
+ *
+ * @param key stable registry key. Required when multiple anchors exist,
+ *   inside lists, or across navigation where positional keys collide.
+ *   Defaults to the call-site composite key.
+ */
+@Composable
+public fun <S, Snapshot : Any> Store<S>.rememberSaveableState(
+    saver: StateSaver<S, Snapshot>,
+    key: String? = null,
+)
+```
+
+### Usage
+
+```kotlin
+@Serializable
+data class UiSnapshot(val tab: Int, val query: String)
+
+val uiSaver = StateSaver(
+    serializer = UiSnapshot.serializer(),
+    save = { s: AppState -> UiSnapshot(s.tab, s.query) },
+    restore = { RehydrateUi(it.tab, it.query) },   // reducer merges these onto state
+)
+
+@Composable
+fun App(store: Store<AppState>) {
+    store.rememberSaveableState(uiSaver)
+    // … screen content; child fieldState bindings see the rehydrated store
+}
+```
+
+The reducer handling `RehydrateUi` is user code — the library plumbs the
+action; the user applies it (state transitions belong in reducers).
+
+## 6. Mechanism
+
+```kotlin
+@Composable
+public fun <S, Snapshot : Any> Store<S>.rememberSaveableState(
+    saver: StateSaver<S, Snapshot>,
+    key: String?,
+) {
+    val store = this
+    val registry = LocalSaveableStateRegistry.current
+    val finalKey = key ?: currentCompositeKeyHash.toString(radix = 36) // KMP-safe radix
+
+    // Consume during composition (what rememberSaveable does internally).
+    // Defensive decode: schema drift across app versions → null → treated
+    // as a cold start instead of a crash.
+    val restored: Snapshot? = remember(store, finalKey) {
+        (registry?.consumeRestored(finalKey) as? String)?.let { encoded ->
+            runCatching { saver.json.decodeFromString(saver.serializer, encoded) }
+                .getOrNull()
+        }
+    }
+
+    DisposableEffect(store, registry, finalKey) {
+        // Dispatch ONLY on a real restore. Cold start dispatches nothing.
+        if (restored != null) {
+            store.dispatch(saver.restore(restored))
+        }
+        // Provider is invoked by the platform at save time and samples
+        // store.state THEN — no steady-state subscription, no per-dispatch
+        // work, serialization only when actually saving.
+        val entry = registry?.registerProvider(finalKey) {
+            saver.json.encodeToString(saver.serializer, saver.save(store.state))
+        }
+        onDispose { entry?.unregister() }
+    }
+}
+```
+
+Three load-bearing properties:
+
+1. **Restore-only dispatch.** Because we consume the registry directly we
+   *know* whether a restore occurred; we never rely on the reducer being
+   idempotent under `restore∘save`, and cold start has zero side effects.
+2. **Fixes the clobber.** The restored value is written back via
+   `dispatch`, so child `fieldState`/`selectorState` re-sample the
+   rehydrated store, not stale initial state.
+3. **Zero steady-state cost.** No subscription, no `MutableState` holder;
+   `save()` + `encode` run only at save time (≈ once per backgrounding).
+
+**Ordering / one-frame flash.** The rehydrate dispatch runs at commit
+(`DisposableEffect`). On restore there can be a single stale frame before
+child bindings receive the rehydrate notification — identical in class to
+the existing B3 race the compose module already documents and accepts. A
+zero-flash variant (dispatch during composition, before children compose)
+exists but trades idiom for timing; **not shipped** in v1 — documented
+only.
+
+## 7. Threading (precondition, not library code)
+
+- `registerProvider`'s lambda runs on the **main thread** at save time and
+  reads `store.state`. On the concurrent/threadsafe store (what the bundle
+  ships) reads are safe. On a plain core store dispatched from another
+  thread this is an unsynchronized ref read — the same pre-existing hazard
+  as `fieldState`.
+- `store.dispatch(...)` runs on **main** (inside `DisposableEffect`). A
+  `SameThreadEnforced` store created off-main will **throw**.
+
+**Contract:** the persisted store must accept main-thread reads and
+dispatch — i.e. the Compose-facing store (concurrent/threadsafe, or
+main-confined). This is documented in the KDoc and the module README; the
+library adds no threading machinery of its own.
+
+## 8. Serialization, versioning, errors
+
+- Default codec encodes the snapshot to a `String` (Bundle-safe;
+  cross-platform). `String` passes `SaveableStateRegistry.canBeSaved`.
+- **Schema drift** (saved snapshot no longer matches the type): decode is
+  wrapped in `runCatching → null`, so restore falls back to a clean cold
+  start instead of crashing. Guidance: evolve the `@Serializable` snapshot
+  deliberately; consider `Json { ignoreUnknownKeys = true }` for additive
+  changes; treat restore as best-effort.
+- **Payload size:** Android `Bundle` has a ~500 KB `TransactionTooLarge`
+  ceiling. The projection model structurally encourages "few fields"; the
+  README states the limit.
+
+## 9. Platform behavior
+
+| Target | Rotation | Process death |
+|---|---|---|
+| Android | ✅ registry retained | ✅ → savedInstanceState |
+| iOS (Compose MP) | ✅ | ✅ state restoration |
+| Desktop / JS / wasm | ✅ in-process | n/a (no OS restore concept) — degrades gracefully |
+
+One mechanism, both survival levels, no platform branching in our code. If
+no `SaveableStateRegistry` is present (`LocalSaveableStateRegistry.current
+== null`), the anchor is a no-op (no persistence) — safe default.
+
+## 10. Edge cases
+
+- **Null registry** — guarded with `?`; degrades to no persistence.
+- **Key collisions** — `registerProvider` throws on duplicate keys within
+  a registry; positional auto-key disambiguates single-anchor use; lists /
+  multiple anchors / nav require an explicit `key`. Documented.
+- **Multiple anchors** — each persists its own key; recommend a single
+  root anchor for a whole-store snapshot.
+- **Decode failure** — cold start (see §8).
+
+## 11. Testing strategy
+
+- **commonTest** — `StateSaver` round-trip: `encodeToString` →
+  `decodeFromString` reproduces the snapshot; `restore(save(state))`
+  produces the expected action. No Compose needed (the value type holds no
+  composition state).
+- **jvmTest (desktop `compose.uiTest`)** — `StateRestorationTester`
+  emulates save → restore. Assert:
+  1. after restoration the store was rehydrated via the dispatched action;
+  2. a child `fieldState` shows the **restored** value, not the initial
+     value — i.e. the clobber is actually solved;
+  3. cold start dispatches **no** rehydrate action (spy/record dispatches).
+  Runs on the JVM/desktop host — no Android device required.
+
+## 12. Out of scope / future
+
+- **Reducer-combinator ergonomics** — a `withRehydrate(reducer) { snap,
+  state -> … }` that removes the user-written action by intercepting an
+  internal rehydrate action. Nicer, but couples the snapshot type into
+  store setup; deferred (YAGNI for v1).
+- **Per-field saveable bindings** — `saveableField(prop, …)`; rejected for
+  v1 (fragments ownership, N write-backs; same dispatch cost as the
+  snapshot without the centralization).
+- **Long-term disk persistence** — separate concern/module.
+- **Zero-flash-on-restore variant** — documented, not shipped.

--- a/docs/superpowers/specs/2026-06-09-redux-kotlin-compose-saveable-design.md
+++ b/docs/superpowers/specs/2026-06-09-redux-kotlin-compose-saveable-design.md
@@ -315,12 +315,12 @@ Beyond the source + tests, shipping a new published module requires:
   guards it thereafter.
 - **`redux-kotlin-bom`** — add the new module as a constrained dependency
   so BOM consumers get an aligned version.
-- **`redux-kotlin-bundle-compose` membership — decision required.**
-  `bundle-compose` is currently multimodel-centric (`redux-kotlin-bundle`
-  + `redux-kotlin-compose-multimodel`). Saveable composes with any
-  `Store<S>`, so including it is natural but is a product call: include vs
-  leave it à-la-carte. **Recommend include** (saved-state is a baseline
-  expectation for the Compose bundle). Confirm before implementation.
+- **`redux-kotlin-bundle-compose` membership — DECIDED: include.**
+  `bundle-compose` is multimodel-centric today (`redux-kotlin-bundle` +
+  `redux-kotlin-compose-multimodel`); add
+  `api(project(":redux-kotlin-compose-saveable"))` so saved-state ships as
+  a baseline of the Compose bundle. (Saveable composes with any `Store<S>`
+  incl. `ModelState`, so this is consistent.)
 - **Docs** — module entry in `CLAUDE.md` / `docs/agent/_fragments/
   modules.md`, and a short usage page on the docs site.
 

--- a/docs/superpowers/specs/2026-06-09-redux-kotlin-compose-saveable-design.md
+++ b/docs/superpowers/specs/2026-06-09-redux-kotlin-compose-saveable-design.md
@@ -115,10 +115,11 @@ public class StateSaver<S, Snapshot : Any>(
  * screen).
  *
  * On a real restore (rotation or process death) the saved snapshot is
- * decoded and dispatched via [StateSaver.restore] exactly once, before
- * downstream bindings re-sample the store. On cold start nothing is
- * dispatched. While mounted, the latest projection is provided to the
- * registry and serialized only when the platform actually saves.
+ * decoded and dispatched via [StateSaver.restore] exactly once, so
+ * downstream bindings observe the rehydrated store (a single stale frame
+ * is possible before they re-sample). On cold start nothing is dispatched.
+ * While mounted, the latest projection is provided to the registry and
+ * serialized only when the platform actually saves.
  *
  * Returns [Unit]; named to pair with [fieldState]/[selectorState].
  *
@@ -165,28 +166,35 @@ public fun <S, Snapshot : Any> Store<S>.rememberSaveableState(
 ) {
     val store = this
     val registry = LocalSaveableStateRegistry.current
-    val finalKey = key ?: currentCompositeKeyHash.toString(radix = 36) // KMP-safe radix
+    // Positional key derived from the composite-key-hash API the pinned
+    // Compose version exposes (`currentCompositeKeyHash`; newer Compose may
+    // name it `currentCompositeKeyHashCode`). KMP-safe radix.
+    val finalKey = key ?: currentCompositeKeyHash.toString(radix = 36)
 
-    // Consume during composition (what rememberSaveable does internally).
-    // Defensive decode: schema drift across app versions → null → treated
-    // as a cold start instead of a crash.
-    val restored: Snapshot? = remember(store, finalKey) {
-        (registry?.consumeRestored(finalKey) as? String)?.let { encoded ->
-            runCatching { saver.json.decodeFromString(saver.serializer, encoded) }
-                .getOrNull()
-        }
-    }
-
+    // One effect does both halves; nothing here is used as a composition
+    // value, so consuming at commit (rather than during composition) is
+    // fine and removes the extra `remember`.
     DisposableEffect(store, registry, finalKey) {
-        // Dispatch ONLY on a real restore. Cold start dispatches nothing.
+        // Restore: consume the saved value (if any) and write it back into
+        // the store via dispatch — ONLY on a real restore. Cold start
+        // consumes null and dispatches nothing. Defensive decode: schema
+        // drift across app versions → null → treated as a cold start
+        // instead of a crash.
+        val restored = (registry?.consumeRestored(finalKey) as? String)?.let { encoded ->
+            runCatching { saver.json.decodeFromString(saver.serializer, encoded) }.getOrNull()
+        }
         if (restored != null) {
             store.dispatch(saver.restore(restored))
         }
-        // Provider is invoked by the platform at save time and samples
+        // Save: provider is invoked by the platform at save time and samples
         // store.state THEN — no steady-state subscription, no per-dispatch
-        // work, serialization only when actually saving.
+        // work, serialization only when actually saving. Defensive: a
+        // throwing save()/encode returns null (skip this save cycle) so it
+        // can never crash performSave.
         val entry = registry?.registerProvider(finalKey) {
-            saver.json.encodeToString(saver.serializer, saver.save(store.state))
+            runCatching {
+                saver.json.encodeToString(saver.serializer, saver.save(store.state))
+            }.getOrNull()
         }
         onDispose { entry?.unregister() }
     }
@@ -203,6 +211,9 @@ Three load-bearing properties:
    rehydrated store, not stale initial state.
 3. **Zero steady-state cost.** No subscription, no `MutableState` holder;
    `save()` + `encode` run only at save time (≈ once per backgrounding).
+   Both the restore decode and the save encode are wrapped in
+   `runCatching` so neither a corrupt restore nor a failing save can crash
+   the app.
 
 **Ordering / one-frame flash.** The rehydrate dispatch runs at commit
 (`DisposableEffect`). On restore there can be a single stale frame before
@@ -234,8 +245,11 @@ library adds no threading machinery of its own.
 - **Schema drift** (saved snapshot no longer matches the type): decode is
   wrapped in `runCatching → null`, so restore falls back to a clean cold
   start instead of crashing. Guidance: evolve the `@Serializable` snapshot
-  deliberately; consider `Json { ignoreUnknownKeys = true }` for additive
-  changes; treat restore as best-effort.
+  deliberately; pass `Json { ignoreUnknownKeys = true }` (via
+  `StateSaver.json`) for additive changes; for breaking changes include a
+  `version` field in the snapshot and ignore/branch on mismatch in
+  `restore`. Treat restore as best-effort — a dropped snapshot only means a
+  cold start, never a crash.
 - **Payload size:** Android `Bundle` has a ~500 KB `TransactionTooLarge`
   ceiling. The projection model structurally encourages "few fields"; the
   README states the limit.
@@ -258,25 +272,67 @@ no `SaveableStateRegistry` is present (`LocalSaveableStateRegistry.current
 - **Key collisions** — `registerProvider` throws on duplicate keys within
   a registry; positional auto-key disambiguates single-anchor use; lists /
   multiple anchors / nav require an explicit `key`. Documented.
+- **Auto-key stability** — the positional key is only stable across
+  process death if the call-site composition structure is identical on
+  restore (the same assumption `rememberSaveable` makes). For anchors
+  under conditional/dynamic structure, pass an explicit `key`.
 - **Multiple anchors** — each persists its own key; recommend a single
   root anchor for a whole-store snapshot.
 - **Decode failure** — cold start (see §8).
 
 ## 11. Testing strategy
 
-- **commonTest** — `StateSaver` round-trip: `encodeToString` →
+- **commonTest — `StateSaver` round-trip.** `encodeToString` →
   `decodeFromString` reproduces the snapshot; `restore(save(state))`
-  produces the expected action. No Compose needed (the value type holds no
-  composition state).
-- **jvmTest (desktop `compose.uiTest`)** — `StateRestorationTester`
-  emulates save → restore. Assert:
-  1. after restoration the store was rehydrated via the dispatched action;
-  2. a child `fieldState` shows the **restored** value, not the initial
-     value — i.e. the clobber is actually solved;
-  3. cold start dispatches **no** rehydrate action (spy/record dispatches).
-  Runs on the JVM/desktop host — no Android device required.
+  produces the expected action; a corrupt/old encoded string decodes to
+  `null`. No Compose needed (the value type holds no composition state).
+- **commonTest — manual registry round-trip (primary mechanism test).**
+  Drive the documented `SaveableStateRegistry` contract directly, no UI
+  harness: construct a registry, register the provider, call
+  `performSave()` to collect the encoded map, build a *second* registry
+  seeded with that map (simulating process death), and run the anchor's
+  restore path. Assert against a real `createStore`:
+  1. restore dispatches the rehydrate action and the store holds the
+     restored value;
+  2. **cold start** (empty restored map) dispatches **nothing** (record
+     dispatches via a spy middleware/subscriber);
+  3. a throwing `save()` yields a `null` provider value (no crash).
+  Deterministic and host-independent — this is where the correctness
+  guarantees are pinned.
+- **jvmTest (desktop `compose.uiTest`) — integration.**
+  `StateRestorationTester` (available in `ui-test` `commonMain`) emulates
+  save → restore through a real composition; assert a child `fieldState`
+  shows the **restored** value, not the initial one — i.e. the clobber is
+  solved end-to-end. Runs on the JVM/desktop host; no Android device.
 
-## 12. Out of scope / future
+## 12. Build & integration deliverables
+
+Beyond the source + tests, shipping a new published module requires:
+
+- **`settings.gradle.kts`** — `include(":redux-kotlin-compose-saveable")`.
+- **Public-API dump** — run `./gradlew apiDump` and commit the generated
+  `redux-kotlin-compose-saveable/api/*.api`; `apiCheck` (part of `build`)
+  guards it thereafter.
+- **`redux-kotlin-bom`** — add the new module as a constrained dependency
+  so BOM consumers get an aligned version.
+- **`redux-kotlin-bundle-compose` membership — decision required.**
+  `bundle-compose` is currently multimodel-centric (`redux-kotlin-bundle`
+  + `redux-kotlin-compose-multimodel`). Saveable composes with any
+  `Store<S>`, so including it is natural but is a product call: include vs
+  leave it à-la-carte. **Recommend include** (saved-state is a baseline
+  expectation for the Compose bundle). Confirm before implementation.
+- **Docs** — module entry in `CLAUDE.md` / `docs/agent/_fragments/
+  modules.md`, and a short usage page on the docs site.
+
+### Note: works with `ModelState` / multimodel
+
+The API is single-`Store<S>`, but `S` is unconstrained — including
+`ModelState`. The projection `save: (S) -> Snapshot` reads whatever fields
+matter (across models), and `restore` dispatches a single action the
+reducer applies. No multimodel-specific variant is needed; the
+`bundle-compose` (multimodel) audience is served by the same two symbols.
+
+## 13. Out of scope / future
 
 - **Reducer-combinator ergonomics** — a `withRehydrate(reducer) { snap,
   state -> … }` that removes the user-written action by intercepting an

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+compose-runtime-saveable = { module = "org.jetbrains.compose.runtime:runtime-saveable", version.ref = "compose-multiplatform" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }

--- a/redux-kotlin-bom/build.gradle.kts
+++ b/redux-kotlin-bom/build.gradle.kts
@@ -22,5 +22,6 @@ dependencies {
         api("$g:redux-kotlin-routing-codegen:$v")
         api("$g:redux-kotlin-bundle:$v")
         api("$g:redux-kotlin-bundle-compose:$v")
+        api("$g:redux-kotlin-compose-saveable:$v")
     }
 }

--- a/redux-kotlin-bundle-compose/README.md
+++ b/redux-kotlin-bundle-compose/README.md
@@ -1,6 +1,7 @@
 # redux-kotlin-bundle-compose
 
-`redux-kotlin-bundle` **plus** Compose `State<T>` bindings
-(`redux-kotlin-compose` + `redux-kotlin-compose-multimodel`) in one dependency.
+`redux-kotlin-bundle` **plus** Compose `State<T>` bindings + snapshot persistence
+(`redux-kotlin-compose` + `redux-kotlin-compose-multimodel` + `redux-kotlin-compose-saveable`)
+in one dependency.
 Use this instead of `redux-kotlin-bundle` for Jetpack/Multiplatform Compose apps.
 It pulls the Compose runtime; non-Compose projects should use `redux-kotlin-bundle`.

--- a/redux-kotlin-bundle-compose/build.gradle.kts
+++ b/redux-kotlin-bundle-compose/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
             dependencies {
                 api(project(":redux-kotlin-bundle"))
                 api(project(":redux-kotlin-compose-multimodel"))
+                api(project(":redux-kotlin-compose-saveable"))
                 implementation(compose.runtime)
             }
         }

--- a/redux-kotlin-compose-saveable/api/jvm/redux-kotlin-compose-saveable.api
+++ b/redux-kotlin-compose-saveable/api/jvm/redux-kotlin-compose-saveable.api
@@ -1,0 +1,14 @@
+public final class org/reduxkotlin/compose/saveable/RememberSaveableStateKt {
+	public static final fun rememberSaveableState (Lorg/reduxkotlin/TypedStore;Lorg/reduxkotlin/compose/saveable/StateSaver;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class org/reduxkotlin/compose/saveable/StateSaver {
+	public static final field $stable I
+	public fun <init> (Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlinx/serialization/json/Json;)V
+	public synthetic fun <init> (Lkotlinx/serialization/KSerializer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getJson ()Lkotlinx/serialization/json/Json;
+	public final fun getRestore ()Lkotlin/jvm/functions/Function1;
+	public final fun getSave ()Lkotlin/jvm/functions/Function1;
+	public final fun getSerializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/redux-kotlin-compose-saveable/api/redux-kotlin-compose-saveable.klib.api
+++ b/redux-kotlin-compose-saveable/api/redux-kotlin-compose-saveable.klib.api
@@ -1,0 +1,25 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, js, linuxX64, macosArm64, mingwX64, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <org.reduxkotlin:redux-kotlin-compose-saveable>
+final class <#A: kotlin/Any?, #B: kotlin/Any> org.reduxkotlin.compose.saveable/StateSaver { // org.reduxkotlin.compose.saveable/StateSaver|null[0]
+    constructor <init>(kotlinx.serialization/KSerializer<#B>, kotlin/Function1<#A, #B>, kotlin/Function1<#B, kotlin/Any>, kotlinx.serialization.json/Json = ...) // org.reduxkotlin.compose.saveable/StateSaver.<init>|<init>(kotlinx.serialization.KSerializer<1:1>;kotlin.Function1<1:0,1:1>;kotlin.Function1<1:1,kotlin.Any>;kotlinx.serialization.json.Json){}[0]
+
+    final val json // org.reduxkotlin.compose.saveable/StateSaver.json|{}json[0]
+        final fun <get-json>(): kotlinx.serialization.json/Json // org.reduxkotlin.compose.saveable/StateSaver.json.<get-json>|<get-json>(){}[0]
+    final val restore // org.reduxkotlin.compose.saveable/StateSaver.restore|{}restore[0]
+        final fun <get-restore>(): kotlin/Function1<#B, kotlin/Any> // org.reduxkotlin.compose.saveable/StateSaver.restore.<get-restore>|<get-restore>(){}[0]
+    final val save // org.reduxkotlin.compose.saveable/StateSaver.save|{}save[0]
+        final fun <get-save>(): kotlin/Function1<#A, #B> // org.reduxkotlin.compose.saveable/StateSaver.save.<get-save>|<get-save>(){}[0]
+    final val serializer // org.reduxkotlin.compose.saveable/StateSaver.serializer|{}serializer[0]
+        final fun <get-serializer>(): kotlinx.serialization/KSerializer<#B> // org.reduxkotlin.compose.saveable/StateSaver.serializer.<get-serializer>|<get-serializer>(){}[0]
+}
+
+final val org.reduxkotlin.compose.saveable/org_reduxkotlin_compose_saveable_StateSaver$stableprop // org.reduxkotlin.compose.saveable/org_reduxkotlin_compose_saveable_StateSaver$stableprop|#static{}org_reduxkotlin_compose_saveable_StateSaver$stableprop[0]
+
+final fun <#A: kotlin/Any?, #B: kotlin/Any> (org.reduxkotlin/TypedStore<#A, kotlin/Any>).org.reduxkotlin.compose.saveable/rememberSaveableState(org.reduxkotlin.compose.saveable/StateSaver<#A, #B>, kotlin/String?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // org.reduxkotlin.compose.saveable/rememberSaveableState|rememberSaveableState@org.reduxkotlin.TypedStore<0:0,kotlin.Any>(org.reduxkotlin.compose.saveable.StateSaver<0:0,0:1>;kotlin.String?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){0§<kotlin.Any?>;1§<kotlin.Any>}[0]
+final fun org.reduxkotlin.compose.saveable/org_reduxkotlin_compose_saveable_StateSaver$stableprop_getter(): kotlin/Int // org.reduxkotlin.compose.saveable/org_reduxkotlin_compose_saveable_StateSaver$stableprop_getter|org_reduxkotlin_compose_saveable_StateSaver$stableprop_getter(){}[0]

--- a/redux-kotlin-compose-saveable/build.gradle.kts
+++ b/redux-kotlin-compose-saveable/build.gradle.kts
@@ -1,0 +1,45 @@
+plugins {
+    id("convention.library-mpp-loved")
+    alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
+    id("convention.publishing-mpp")
+}
+
+val hasAndroidSdk: Boolean = run {
+    val localProps = rootProject.file("local.properties")
+    val hasSdkInLocalProperties = localProps.exists() && localProps.readText().lineSequence().any {
+        it.trim().startsWith("sdk.dir=") && it.substringAfter("sdk.dir=").isNotBlank()
+    }
+    val hasSdkInEnv =
+        !System.getenv("ANDROID_HOME").isNullOrBlank() ||
+            !System.getenv("ANDROID_SDK_ROOT").isNullOrBlank()
+    hasSdkInLocalProperties || hasSdkInEnv
+}
+
+kotlin {
+    if (hasAndroidSdk) {
+        android {
+            namespace = "org.reduxkotlin.compose.saveable"
+        }
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":redux-kotlin-compose"))
+                implementation(compose.runtime)
+                implementation(libs.compose.runtime.saveable)
+                implementation(libs.kotlinx.serialization.json)
+            }
+        }
+        named("jvmTest") {
+            dependencies {
+                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+                implementation(compose.uiTest)
+                implementation(compose.foundation)
+                implementation(compose.desktop.currentOs)
+            }
+        }
+    }
+}

--- a/redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/RememberSaveableState.kt
+++ b/redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/RememberSaveableState.kt
@@ -2,10 +2,13 @@ package org.reduxkotlin.compose.saveable
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.currentCompositeKeyHash
+import androidx.compose.runtime.currentCompositeKeyHashCode
 import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
 import androidx.compose.runtime.saveable.SaveableStateRegistry
 import org.reduxkotlin.Store
+
+// Alphanumeric encoding; Int/Long.toString(radix) is defined on all KMP targets.
+private const val KEY_RADIX = 36
 
 /**
  * Anchors saveable persistence for [this] store to the enclosing
@@ -31,7 +34,7 @@ import org.reduxkotlin.Store
 public fun <S, Snapshot : Any> Store<S>.rememberSaveableState(saver: StateSaver<S, Snapshot>, key: String? = null) {
     val store = this
     val registry = LocalSaveableStateRegistry.current
-    val finalKey = key ?: currentCompositeKeyHash.toString(radix = 36)
+    val finalKey = key ?: currentCompositeKeyHashCode.toString(radix = KEY_RADIX)
     DisposableEffect(store, registry, finalKey) {
         val entry = wireSaveable(store, registry, finalKey, saver)
         onDispose { entry?.unregister() }

--- a/redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/RememberSaveableState.kt
+++ b/redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/RememberSaveableState.kt
@@ -25,6 +25,15 @@ private const val KEY_RADIX = 36
  * The persisted store must accept main-thread reads and dispatch (the
  * Compose-facing store: concurrent/threadsafe, or main-confined).
  *
+ * Example:
+ * ```
+ * @Composable
+ * fun App(store: Store<AppState>) {
+ *     store.rememberSaveableState(uiSaver)
+ *     // … screen content; child fieldState bindings see the rehydrated store
+ * }
+ * ```
+ *
  * [saver] describes the snapshot projection and restore action.
  * [key] is a stable registry key required when multiple anchors exist, inside
  * lists, or across navigation where positional keys collide. Defaults to the

--- a/redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/RememberSaveableState.kt
+++ b/redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/RememberSaveableState.kt
@@ -2,7 +2,7 @@ package org.reduxkotlin.compose.saveable
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.currentCompositeKeyHashCode
+import androidx.compose.runtime.currentCompositeKeyHash
 import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
 import androidx.compose.runtime.saveable.SaveableStateRegistry
 import org.reduxkotlin.Store
@@ -34,7 +34,7 @@ private const val KEY_RADIX = 36
 public fun <S, Snapshot : Any> Store<S>.rememberSaveableState(saver: StateSaver<S, Snapshot>, key: String? = null) {
     val store = this
     val registry = LocalSaveableStateRegistry.current
-    val finalKey = key ?: currentCompositeKeyHashCode.toString(radix = KEY_RADIX)
+    val finalKey = key ?: currentCompositeKeyHash.toString(KEY_RADIX)
     DisposableEffect(store, registry, finalKey) {
         val entry = wireSaveable(store, registry, finalKey, saver)
         onDispose { entry?.unregister() }

--- a/redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/RememberSaveableState.kt
+++ b/redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/RememberSaveableState.kt
@@ -1,0 +1,62 @@
+package org.reduxkotlin.compose.saveable
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.currentCompositeKeyHash
+import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
+import androidx.compose.runtime.saveable.SaveableStateRegistry
+import org.reduxkotlin.Store
+
+/**
+ * Anchors saveable persistence for [this] store to the enclosing
+ * [SaveableStateRegistry]. Place it **once** per persisted scope (typically
+ * near the root, or once per screen).
+ *
+ * On a real restore (rotation or process death) the saved snapshot is decoded
+ * and dispatched via [StateSaver.restore] exactly once, so downstream bindings
+ * observe the rehydrated store (a single stale frame is possible before they
+ * re-sample). On cold start nothing is dispatched. The latest projection is
+ * provided to the registry and serialized only when the platform actually
+ * saves — there is no steady-state subscription.
+ *
+ * The persisted store must accept main-thread reads and dispatch (the
+ * Compose-facing store: concurrent/threadsafe, or main-confined).
+ *
+ * [saver] describes the snapshot projection and restore action.
+ * [key] is a stable registry key required when multiple anchors exist, inside
+ * lists, or across navigation where positional keys collide. Defaults to the
+ * call-site composite key.
+ */
+@Composable
+public fun <S, Snapshot : Any> Store<S>.rememberSaveableState(saver: StateSaver<S, Snapshot>, key: String? = null) {
+    val store = this
+    val registry = LocalSaveableStateRegistry.current
+    val finalKey = key ?: currentCompositeKeyHash.toString(radix = 36)
+    DisposableEffect(store, registry, finalKey) {
+        val entry = wireSaveable(store, registry, finalKey, saver)
+        onDispose { entry?.unregister() }
+    }
+}
+
+/**
+ * Non-composable core: consume any restored snapshot and dispatch the restore
+ * action exactly once (only on a real restore), then register the save
+ * provider. Extracted so the correctness path is testable without a
+ * composition. Returns the provider entry to unregister on dispose.
+ */
+internal fun <S, Snapshot : Any> wireSaveable(
+    store: Store<S>,
+    registry: SaveableStateRegistry?,
+    key: String,
+    saver: StateSaver<S, Snapshot>,
+): SaveableStateRegistry.Entry? {
+    val restored = (registry?.consumeRestored(key) as? String)?.let { encoded ->
+        runCatching { saver.json.decodeFromString(saver.serializer, encoded) }.getOrNull()
+    }
+    if (restored != null) {
+        store.dispatch(saver.restore(restored))
+    }
+    return registry?.registerProvider(key) {
+        runCatching { saver.json.encodeToString(saver.serializer, saver.save(store.state)) }.getOrNull()
+    }
+}

--- a/redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/StateSaver.kt
+++ b/redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/StateSaver.kt
@@ -10,6 +10,18 @@ import kotlinx.serialization.json.Json
  *
  * Holds no Compose state — its serialization round-trip is unit-testable
  * without a composition. Reuse one instance across screens.
+ *
+ * Example:
+ * ```
+ * @Serializable
+ * data class UiSnapshot(val tab: Int, val query: String)
+ *
+ * val uiSaver = StateSaver(
+ *     serializer = UiSnapshot.serializer(),
+ *     save = { s: AppState -> UiSnapshot(s.tab, s.query) },
+ *     restore = { RehydrateUi(it.tab, it.query) }, // your reducer applies this action
+ * )
+ * ```
  */
 public class StateSaver<S, Snapshot : Any>(
     /** Serializer for the [Snapshot] type (e.g. `MySnapshot.serializer()`). */

--- a/redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/StateSaver.kt
+++ b/redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/StateSaver.kt
@@ -1,0 +1,23 @@
+package org.reduxkotlin.compose.saveable
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+
+/**
+ * Describes how a slice of store state [S] is projected to a small
+ * serializable [Snapshot], and how a restored snapshot is turned back into
+ * an action the store's reducer applies.
+ *
+ * Holds no Compose state — its serialization round-trip is unit-testable
+ * without a composition. Reuse one instance across screens.
+ */
+public class StateSaver<S, Snapshot : Any>(
+    /** Serializer for the [Snapshot] type (e.g. `MySnapshot.serializer()`). */
+    public val serializer: KSerializer<Snapshot>,
+    /** Projects current state to the minimal snapshot worth persisting. */
+    public val save: (S) -> Snapshot,
+    /** Turns a restored snapshot into an action the reducer applies. */
+    public val restore: (Snapshot) -> Any,
+    /** JSON codec; override to tune (e.g. `Json { ignoreUnknownKeys = true }`). */
+    public val json: Json = Json,
+)

--- a/redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/RegistryRoundTripTest.kt
+++ b/redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/RegistryRoundTripTest.kt
@@ -1,0 +1,68 @@
+package org.reduxkotlin.compose.saveable
+
+import androidx.compose.runtime.saveable.SaveableStateRegistry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RegistryRoundTripTest {
+
+    @Test
+    fun restore_rehydrates_a_fresh_store() {
+        // Phase 1: a source store with non-initial state, register the provider.
+        val source = newTestStore(TestState(tab = 5, query = "x"))
+        val registry1 = SaveableStateRegistry(restoredValues = null) { true }
+        wireSaveable(source, registry1, "k", testSaver)
+        val saved = registry1.performSave()
+
+        // Phase 2: a brand-new store (simulating process death) seeded with the
+        // saved values. Restore must dispatch the rehydrate action.
+        val fresh = newTestStore(TestState())
+        val registry2 = SaveableStateRegistry(restoredValues = saved) { true }
+        wireSaveable(fresh, registry2, "k", testSaver)
+
+        assertEquals(TestState(tab = 5, query = "x"), fresh.state)
+    }
+
+    @Test
+    fun cold_start_dispatches_nothing() {
+        val store = newTestStore(TestState(tab = 9))
+        var notified = 0
+        val unsubscribe = store.subscribe { notified++ }
+
+        val registry = SaveableStateRegistry(restoredValues = null) { true } // empty == cold start
+        wireSaveable(store, registry, "k", testSaver)
+
+        unsubscribe()
+        assertEquals(0, notified)
+        assertEquals(TestState(tab = 9), store.state)
+    }
+
+    @Test
+    fun corrupt_snapshot_is_ignored_as_cold_start() {
+        val store = newTestStore(TestState(tab = 9))
+        var notified = 0
+        val unsubscribe = store.subscribe { notified++ }
+
+        val registry = SaveableStateRegistry(restoredValues = mapOf("k" to listOf("not-json"))) { true }
+        wireSaveable(store, registry, "k", testSaver)
+
+        unsubscribe()
+        assertEquals(0, notified)
+        assertEquals(TestState(tab = 9), store.state)
+    }
+
+    @Test
+    fun failing_save_does_not_crash_perform_save() {
+        val store = newTestStore(TestState(tab = 1))
+        val throwingSaver = StateSaver<TestState, UiSnapshot>(
+            serializer = UiSnapshot.serializer(),
+            save = { error("boom") },
+            restore = { RehydrateUi(it.tab, it.query) },
+        )
+        val registry = SaveableStateRegistry(restoredValues = null) { true }
+        wireSaveable(store, registry, "k", throwingSaver)
+
+        val saved = registry.performSave() // must not throw
+        assertEquals(null, saved["k"]?.firstOrNull())
+    }
+}

--- a/redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/StateSaverTest.kt
+++ b/redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/StateSaverTest.kt
@@ -1,0 +1,21 @@
+package org.reduxkotlin.compose.saveable
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StateSaverTest {
+
+    @Test
+    fun encode_then_decode_roundtrips_snapshot() {
+        val snapshot = testSaver.save(TestState(tab = 4, query = "hi"))
+        val encoded = testSaver.json.encodeToString(testSaver.serializer, snapshot)
+        val decoded = testSaver.json.decodeFromString(testSaver.serializer, encoded)
+        assertEquals(snapshot, decoded)
+    }
+
+    @Test
+    fun restore_builds_expected_action() {
+        val action = testSaver.restore(UiSnapshot(tab = 4, query = "hi"))
+        assertEquals(RehydrateUi(4, "hi"), action)
+    }
+}

--- a/redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/TestFixtures.kt
+++ b/redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/TestFixtures.kt
@@ -21,8 +21,7 @@ internal val testReducer: (TestState, Any) -> TestState = { state, action ->
     }
 }
 
-internal fun newTestStore(initial: TestState = TestState()): Store<TestState> =
-    createStore(testReducer, initial)
+internal fun newTestStore(initial: TestState = TestState()): Store<TestState> = createStore(testReducer, initial)
 
 internal val testSaver: StateSaver<TestState, UiSnapshot> = StateSaver(
     serializer = UiSnapshot.serializer(),

--- a/redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/TestFixtures.kt
+++ b/redux-kotlin-compose-saveable/src/commonTest/kotlin/org/reduxkotlin/compose/saveable/TestFixtures.kt
@@ -1,0 +1,31 @@
+package org.reduxkotlin.compose.saveable
+
+import kotlinx.serialization.Serializable
+import org.reduxkotlin.Store
+import org.reduxkotlin.createStore
+
+internal data class TestState(val tab: Int = 0, val query: String = "")
+
+internal data class SetTab(val tab: Int)
+
+internal data class RehydrateUi(val tab: Int, val query: String)
+
+@Serializable
+internal data class UiSnapshot(val tab: Int, val query: String)
+
+internal val testReducer: (TestState, Any) -> TestState = { state, action ->
+    when (action) {
+        is SetTab -> state.copy(tab = action.tab)
+        is RehydrateUi -> state.copy(tab = action.tab, query = action.query)
+        else -> state
+    }
+}
+
+internal fun newTestStore(initial: TestState = TestState()): Store<TestState> =
+    createStore(testReducer, initial)
+
+internal val testSaver: StateSaver<TestState, UiSnapshot> = StateSaver(
+    serializer = UiSnapshot.serializer(),
+    save = { state -> UiSnapshot(state.tab, state.query) },
+    restore = { snapshot -> RehydrateUi(snapshot.tab, snapshot.query) },
+)

--- a/redux-kotlin-compose-saveable/src/jvmTest/kotlin/org/reduxkotlin/compose/saveable/SaveableIntegrationTest.kt
+++ b/redux-kotlin-compose-saveable/src/jvmTest/kotlin/org/reduxkotlin/compose/saveable/SaveableIntegrationTest.kt
@@ -1,0 +1,86 @@
+package org.reduxkotlin.compose.saveable
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
+import androidx.compose.runtime.saveable.SaveableStateRegistry
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import org.reduxkotlin.compose.fieldState
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class SaveableIntegrationTest {
+
+    /**
+     * Verifies that [rememberSaveableState] wires into the enclosing
+     * [SaveableStateRegistry]: after a click mutates the store and a manual
+     * save+restore cycle runs, a fresh store rehydrated from the snapshot
+     * reflects the post-click value.
+     *
+     * [StateRestorationTester.emulateSaveAndRestore] is not implemented on
+     * the desktop/JVM Compose target (it throws [NotImplementedError]) so
+     * this test exercises the same registry round-trip directly via
+     * [SaveableStateRegistry] and [LocalSaveableStateRegistry], which is the
+     * exact mechanism the composable delegates to.
+     */
+    @Test
+    fun child_binding_shows_restored_value_after_state_restoration() = runComposeUiTest {
+        // Phase 1: set up a registry, mount the composable, click to mutate state.
+        val registry1 = SaveableStateRegistry(restoredValues = null) { true }
+
+        setContent {
+            CompositionLocalProvider(LocalSaveableStateRegistry provides registry1) {
+                val store = remember { newTestStore(TestState()) }
+                store.rememberSaveableState(testSaver, key = "root")
+                Column {
+                    BasicText(
+                        text = store.fieldState(TestState::tab).value.toString(),
+                        modifier = Modifier.testTag("tab"),
+                    )
+                    BasicText(
+                        text = "set",
+                        modifier = Modifier
+                            .testTag("set")
+                            .clickable { store.dispatch(SetTab(7)) },
+                    )
+                }
+            }
+        }
+
+        onNodeWithTag("tab").assertTextEquals("0")
+        onNodeWithTag("set").performClick()
+        onNodeWithTag("tab").assertTextEquals("7")
+
+        // Phase 2: capture the saved values from the registry.
+        val saved = registry1.performSave()
+
+        // Phase 3: new registry seeded with the saved values + new store (process death).
+        // A fresh store starts at tab=0; only the anchor can produce tab=7.
+        val registry2 = SaveableStateRegistry(restoredValues = saved) { true }
+        var freshStore: org.reduxkotlin.Store<TestState>? = null
+        setContent {
+            CompositionLocalProvider(LocalSaveableStateRegistry provides registry2) {
+                val store = remember { newTestStore(TestState()).also { freshStore = it } }
+                store.rememberSaveableState(testSaver, key = "root")
+                Column {
+                    BasicText(
+                        text = store.fieldState(TestState::tab).value.toString(),
+                        modifier = Modifier.testTag("tab2"),
+                    )
+                }
+            }
+        }
+
+        // The button was not clicked again; only rehydration can produce "7".
+        onNodeWithTag("tab2").assertTextEquals("7")
+    }
+}

--- a/redux-kotlin-compose-saveable/src/jvmTest/kotlin/org/reduxkotlin/compose/saveable/SaveableIntegrationTest.kt
+++ b/redux-kotlin-compose-saveable/src/jvmTest/kotlin/org/reduxkotlin/compose/saveable/SaveableIntegrationTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import org.reduxkotlin.compose.fieldState
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 @OptIn(ExperimentalTestApi::class)
 class SaveableIntegrationTest {
@@ -82,5 +83,7 @@ class SaveableIntegrationTest {
 
         // The button was not clicked again; only rehydration can produce "7".
         onNodeWithTag("tab2").assertTextEquals("7")
+        // Also assert the store itself rehydrated — proves dispatch happened, not just render.
+        assertEquals(TestState(tab = 7, query = ""), freshStore!!.state)
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,6 +31,7 @@ include(
     ":redux-kotlin-compose",
     ":redux-kotlin-multimodel-granular",
     ":redux-kotlin-compose-multimodel",
+    ":redux-kotlin-compose-saveable",
     ":redux-kotlin-devtools-core",
     ":redux-kotlin-devtools-bridge",
     ":redux-kotlin-devtools-remote",

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,2 +1,5 @@
 .now
 .vercel
+node_modules
+build
+.docusaurus

--- a/website/docs/advanced/Compose.md
+++ b/website/docs/advanced/Compose.md
@@ -140,6 +140,120 @@ import org.reduxkotlin.compose.multimodel.fieldStateOf
 val displayName by store.fieldStateOf(LoggedInUserModel::class) { it.displayName }
 ```
 
+## Saving state across rotation & process death
+
+`redux-kotlin-compose-saveable` persists a slice of store state so it
+survives Android **configuration changes / rotation** and **process
+death**, restoring it when the app relaunches. It rides Compose's
+`SaveableStateRegistry` (the machinery behind `rememberSaveable`), so one
+mechanism covers both; on platforms without OS state restoration (desktop /
+JS / wasm) it is a safe no-op.
+
+```kotlin
+implementation("org.reduxkotlin:redux-kotlin-compose-saveable:<version>")
+```
+
+### Why a singleton store isn't enough
+
+A store held as a process/DI singleton already survives rotation — the
+process lives. But on **process death** the OS recreates the process, the
+singleton is rebuilt from its *initial* state, and that state is lost.
+And because the bindings above are one-directional (`store → State`),
+restoring a value only in a Composable would be **overwritten** by the
+store's initial state on the next subscription. The fix is to write the
+restored value back into the store the only way a store can change — by
+`dispatch`ing an action.
+
+### 1. Describe what to save with `StateSaver`
+
+A `StateSaver` is three things: a `@Serializable` snapshot of just the
+fields worth keeping (keep it small — it goes into the platform's saved
+instance state), a `save` projection from state, and a `restore` function
+that turns a decoded snapshot into an action your reducer applies.
+
+```kotlin
+import kotlinx.serialization.Serializable
+import org.reduxkotlin.compose.saveable.StateSaver
+
+@Serializable
+data class UiSnapshot(val tab: Int, val query: String)
+
+// An action your reducer handles:
+data class RehydrateUi(val tab: Int, val query: String)
+
+val uiSaver = StateSaver(
+    serializer = UiSnapshot.serializer(),
+    save = { s: AppState -> UiSnapshot(s.tab, s.query) },
+    restore = { RehydrateUi(it.tab, it.query) },
+)
+```
+
+The reducer applies the restore action like any other:
+
+```kotlin
+fun appReducer(state: AppState, action: Any): AppState = when (action) {
+    is RehydrateUi -> state.copy(tab = action.tab, query = action.query)
+    // … other cases
+    else -> state
+}
+```
+
+### 2. Anchor it with `rememberSaveableState`
+
+Place the anchor **once** per persisted scope — typically near the root,
+or once per screen:
+
+```kotlin
+import org.reduxkotlin.compose.saveable.rememberSaveableState
+
+@Composable
+fun App(store: Store<AppState>) {
+    store.rememberSaveableState(uiSaver)
+    // child fieldState / selectorState bindings observe the rehydrated store
+    Screen(store)
+}
+```
+
+On a real restore the snapshot is decoded and `RehydrateUi` is dispatched
+exactly once, before the bindings settle. On a normal cold start nothing is
+dispatched. The snapshot is serialized only when the platform actually
+saves (e.g. when the app is backgrounded) — there is no per-dispatch cost.
+
+### Lists, navigation & multiple anchors
+
+The anchor derives a key from its call-site position. If you persist
+several independent scopes, place anchors inside a list, or move across a
+navigation graph where positions can collide, pass an explicit, stable
+`key`:
+
+```kotlin
+store.rememberSaveableState(detailSaver, key = "board-$boardId")
+```
+
+### Versioning & failures
+
+Restore is **best-effort**: if a saved snapshot can't be decoded (e.g. a
+new app version ships an incompatible `UiSnapshot`), it is dropped and the
+app starts cold rather than crashing. For additive changes pass a lenient
+codec via `StateSaver(json = Json { ignoreUnknownKeys = true })`; for
+breaking changes, add a `version` field to the snapshot and branch on it
+inside `restore`.
+
+### Threading & platforms
+
+The snapshot is read and the restore action dispatched on the **main
+thread**, so the persisted store must accept main-thread reads and dispatch
+— the Compose-facing store (the concurrent/threadsafe bundle store, or a
+main-confined store). On Android the snapshot rides `savedInstanceState`
+(rotation + process death); iOS uses state restoration; desktop, JS and
+wasm have no OS restore concept, so the anchor is a no-op there.
+
+:::tip Bundled
+`redux-kotlin-compose-saveable` ships inside
+[`redux-kotlin-bundle-compose`](../introduction/ecosystem) — if you use the
+Compose bundle you already have it.
+:::
+
 ## Lifecycle and threading
 
 Each binding subscribes inside a `DisposableEffect` and unsubscribes in

--- a/website/docs/ai-agents/BuildingWithAI.md
+++ b/website/docs/ai-agents/BuildingWithAI.md
@@ -48,6 +48,7 @@ implementation("org.reduxkotlin:redux-kotlin:0.6.1")
 - `redux-kotlin-multimodel-granular` — granular subscriptions for `ModelState`.
 - `redux-kotlin-compose` — Compose `State<T>` bindings (`fieldState`, `selectorState`, `StableStore`).
 - `redux-kotlin-compose-multimodel` — Compose bindings for `ModelState`.
+- `redux-kotlin-compose-saveable` — `StateSaver` + `Store<S>.rememberSaveableState` store-anchored snapshot persistence (rotation + process death) via `SaveableStateRegistry`.
 
 Full module → public-API index:
 https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/api-map.md

--- a/website/docs/introduction/Ecosystem.md
+++ b/website/docs/introduction/Ecosystem.md
@@ -30,6 +30,7 @@ All share the core's group id `org.reduxkotlin` and version.
 | `redux-kotlin-multimodel-granular` | [Granular subscriptions for `ModelState`](../advanced/granular-subscriptions#multi-model-stores) — `subscribeTo(Model::field)` / `subscribeToModel(...)`. |
 | `redux-kotlin-compose` | [Compose integration](../advanced/compose-integration) — bind store fields to Compose `State<T>` with `fieldState` / `selectorState`. |
 | `redux-kotlin-compose-multimodel` | Compose `fieldState(Model::field)` bindings for `ModelState` stores. |
+| `redux-kotlin-compose-saveable` | `StateSaver` + `rememberSaveableState` store-anchored snapshot persistence for Compose (survives rotation + process death) via Compose `SaveableStateRegistry`. |
 
 ## Community
 

--- a/website/node_modules
+++ b/website/node_modules
@@ -1,0 +1,1 @@
+/Users/patrick/workspace/redux-kotlin/website/node_modules

--- a/website/node_modules
+++ b/website/node_modules
@@ -1,1 +1,0 @@
-/Users/patrick/workspace/redux-kotlin/website/node_modules


### PR DESCRIPTION
## Summary
New companion module **`redux-kotlin-compose-saveable`** that persists Redux store state across Android **rotation + process death** using Compose's `SaveableStateRegistry`, with a minimal serialized snapshot.

- **`StateSaver<S, Snapshot>`** — value type: serializer + `save` projection (only the fields worth keeping) + `restore` action factory. No Compose state; serialization is unit-testable on its own.
- **`Store<S>.rememberSaveableState(saver, key?)`** — anchor composable. On a real restore it decodes and dispatches `restore` exactly once (fixing the *clobber* — one-directional bindings would otherwise overwrite the restored value with the store's initial state); on cold start it dispatches nothing. A registry provider serializes the projection only at save time (zero steady-state cost). Both decode and encode are wrapped in `runCatching` so corrupt restore or a throwing `save()` degrade to a clean cold start, never a crash.

Added to **`redux-kotlin-bundle-compose`** and **`redux-kotlin-bom`**.

## Design & plan
- Spec: `docs/superpowers/specs/2026-06-09-redux-kotlin-compose-saveable-design.md`
- Plan: `docs/superpowers/plans/2026-06-09-redux-kotlin-compose-saveable.md`

## Implementation notes (deviations, all reviewed)
- Integration test drives the real composable via `SaveableStateRegistry` + `CompositionLocalProvider` instead of `StateRestorationTester` — the latter's restore is `NotImplementedError` on desktop skiko in Compose 1.11.0. It still simulates process death (fresh second store) and asserts the rehydrated value end-to-end.
- Kept the (deprecated) `currentCompositeKeyHash` for the positional key: `currentCompositeKeyHashCode` is typed `Any` in CMP 1.11.0 common metadata, so `.toString(radix)` doesn't compile in commonMain.
- KDoc uses inline `[param]` prose (detekt rejects `@param` on extension functions).

## Agent-knowledge integration
Module registered across all discoverability surfaces: `_fragments/modules.md` → assembled into `AGENTS.md` / `AGENTS-external.md` / `BuildingWithAI.md`; `api-map.md` row; `CLAUDE.md`; bundle-compose README; website `Ecosystem.md`. Gates pass: `assemble-agent-knowledge.sh --check`, `check-agent-refs.sh`, `check-site-agent-links.sh`.

## Test plan
- [x] `./gradlew :redux-kotlin-compose-saveable:jvmTest` — 7 tests green (StateSaver round-trip, registry round-trip incl. cold-start/corrupt/throwing-save, end-to-end integration)
- [x] `./gradlew :redux-kotlin-compose-saveable:checkKotlinAbi` — committed ABI dump matches (`StateSaver` + `rememberSaveableState`; `wireSaveable` internal)
- [x] `./gradlew detektAll` — clean
- [ ] CI: full cross-platform (native/iOS + JS browser) matrix — not runnable on this host

## Deferred (follow-up)
- A "Saveable persistence" page/section on the docs site (`website/docs/advanced/Compose.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)