### PR TITLE
feat(taskflow): saveable UI-state persistence (nav + filter across process death)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-taskflow-saveable-ui-persistence.md
+++ b/docs/superpowers/plans/2026-06-10-taskflow-saveable-ui-persistence.md
@@ -1,0 +1,523 @@
+# TaskFlow Saveable UI-State Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the active account's volatile UI state (navigation stack + board filter) survive Android process death and configuration changes via a Compose `rememberSaveable` snapshot layered on top of the existing SQLDelight durable store.
+
+**Architecture:** A small `@Serializable` `UiSnapshot` DTO captures only volatile UI state (nav stack as `RouteDto`, filter fields). At save time a custom Compose `Saver` reads the live per-account concurrent store (lock-free `getState` mirror) and serializes the snapshot into the Activity's `SavedStateRegistry`. On restore, the JSON is parsed and replayed once via a `RestoreUiState` action that the per-account routing wires into the `NavModel` and `FilterModel` slots inline (no reducer changes). Board content reloads automatically through the existing `BoardLifecycleEffect`, which keys on `nav.activeBoardId`. SQLDelight remains the sole authority for domain data and `activeAccountId`.
+
+**Tech Stack:** Kotlin Multiplatform, Compose Multiplatform (`rememberSaveable`, `Saver`), kotlinx.serialization JSON (already a `commonMain` dep), redux-kotlin bundle (`createConcurrentModelStore`, `getModel<T>()`), redux-kotlin routing (`RoutingBuilder.on<T>`).
+
+**Scope boundaries (confirmed):**
+- TaskFlow sample only. No published-module changes, no new module, no `apiDump`.
+- Snapshot carries ONLY: nav stack + filter. It does NOT carry `activeAccountId` (SQLDelight owns it — putting it here races the disk load and double-builds the account store) nor `authMode` (login flow resets fine).
+- All new symbols are `internal` (every call site is in the same `composeApp` module) to keep the public surface flat and avoid the `explicitApi` KDoc gate churn on `public` decls.
+- **Out of scope (documented fast-follow):** eliminating the rotation spinner / avoiding the full per-account store + coroutine rebuild on configuration change. The manifest has no `android:configChanges`, so the Activity (and `remember { createAppStore() }`) is recreated on every rotation. `rememberSaveable` restores the *snapshot* but not the *live store instance*; truly skipping that rebuild needs live-store retention (a retained holder / ViewModel), which is a separate decision.
+
+**Key facts verified in code (do not re-derive):**
+- `Route` (`core/AccountEntities.kt:64-94`) is a clean sealed interface, all fields are value-class ids + an enum — trivially serializable. Variants: `BoardList`/`Profile`/`Settings` (`data object`), `Board(boardId: BoardId)`, `CardDetail(cardId: CardId, mode: Mode)` where `Mode = {View, Edit}`, `ComposeCard(columnId: ColumnId)`.
+- Id value classes (`core/Ids.kt`): `AccountId(v: String)`, `BoardId(v: String)`, `ColumnId(v: String)`, `CardId(v: String)`, `LabelId(v: String)` — string accessor is `.v`.
+- `NavModel(stack: PersistentList<Route>)` (`core/AccountEntities.kt:40`). `FilterModel(query: String, assignee: AccountId?, labelIds: PersistentSet<LabelId>)` (`feature/board/BoardSliceModels.kt:10`).
+- `Action` base interface: `org.reduxkotlin.sample.taskflow.core.Action`.
+- Per-account store built in `createAccountStore` / `declareAccountModels` (`app/AccountStore.kt:136-251`). Slots are routed by EXACT leaf action class via `on<T> { s, a -> ... }`; a slot can register a handler for any action and return the next slice directly.
+- `ActiveAccount` composable (`app/App.kt:179-226`) builds the store via `remember(activeId) { registry.getOrCreate(activeId, SeedData.accountDetail(activeId)) }` and is the single place the active account's store + nav are in composition.
+- `BoardLifecycleEffect` keys on `nav.activeBoardId` — restoring the nav stack to `[BoardList, Board(id)]` reloads the board automatically; no explicit board-load dispatch needed in restore.
+- The existing `LocalStore.saveNav` / `loadNav` (`infra/data/local/SqlDelightLocalStore.kt:135,194`) are implemented but **never called** (dead code). This plan does not wire them; the Saveable layer supersedes them for the active account. Leave them as-is.
+- `getModel<T>()` IS available on `Store<ModelState>` in this codebase (e.g. `app/App.kt:215`, `app/AccountStore.kt:146`). Reads go through the concurrent store's lock-free mirror.
+
+---
+
+## File Structure
+
+- **Create** `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt`
+  Responsibility: the `UiSnapshot`/`RouteDto` DTOs, `Route`↔`RouteDto` + model↔snapshot mapping, JSON encode/decode, the `RestoreUiState` action, the live-store bridge (`encodeUiSnapshot`/`decodeUiSnapshot`), and the `RestoreUiStateEffect` composable + `RestoreSlot` holder.
+- **Modify** `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt`
+  Add `on<RestoreUiState>` handlers to the `NavModel` and `FilterModel` slots in `declareAccountModels`.
+- **Modify** `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt`
+  Call `RestoreUiStateEffect(accountStore, activeId)` inside `ActiveAccount`.
+- **Create** `examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotTest.kt`
+  Round-trip codec tests + a store-level test that dispatching `RestoreUiState` updates the nav + filter slots.
+
+---
+
+### Task 1: UiSnapshot DTOs + JSON codec (pure, no store)
+
+**Files:**
+- Create: `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt`
+- Test: `examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `UiSnapshotTest.kt`:
+
+```kotlin
+package org.reduxkotlin.sample.taskflow.app.persistence
+
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
+import org.reduxkotlin.sample.taskflow.core.AccountId
+import org.reduxkotlin.sample.taskflow.core.BoardId
+import org.reduxkotlin.sample.taskflow.core.CardId
+import org.reduxkotlin.sample.taskflow.core.ColumnId
+import org.reduxkotlin.sample.taskflow.core.LabelId
+import org.reduxkotlin.sample.taskflow.core.NavModel
+import org.reduxkotlin.sample.taskflow.core.Route
+import org.reduxkotlin.sample.taskflow.feature.board.FilterModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UiSnapshotTest {
+
+    @Test
+    fun fullStackAndFilterRoundTripThroughJson() {
+        val nav = NavModel(
+            persistentListOf(
+                Route.BoardList,
+                Route.Board(BoardId("b1")),
+                Route.CardDetail(CardId("c9"), Route.CardDetail.Mode.Edit),
+            ),
+        )
+        val filter = FilterModel(
+            query = "urgent",
+            assignee = AccountId("a3"),
+            labelIds = persistentSetOf(LabelId("l1"), LabelId("l2")),
+        )
+
+        val json = encodeUiSnapshot(nav, filter)
+        val restored = decodeUiSnapshot(json)
+
+        assertEquals(nav, restored.nav)
+        assertEquals(filter, restored.filter)
+    }
+
+    @Test
+    fun composeCardAndDefaultsRoundTrip() {
+        val nav = NavModel(persistentListOf(Route.Settings, Route.ComposeCard(ColumnId("col2"))))
+        val filter = FilterModel()
+
+        val restored = decodeUiSnapshot(encodeUiSnapshot(nav, filter))
+
+        assertEquals(nav, restored.nav)
+        assertEquals(filter, restored.filter)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :examples:taskflow:composeApp:jvmTest --tests "org.reduxkotlin.sample.taskflow.app.persistence.UiSnapshotTest"`
+Expected: FAIL — `encodeUiSnapshot` / `decodeUiSnapshot` / `RestoreUiState` unresolved.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `UiSnapshot.kt` (codec + action only for now; store bridge + composable added in later tasks but defined here together to keep the file cohesive — only the codec is exercised by Task 1's test):
+
+```kotlin
+package org.reduxkotlin.sample.taskflow.app.persistence
+
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentSet
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.reduxkotlin.sample.taskflow.core.AccountId
+import org.reduxkotlin.sample.taskflow.core.Action
+import org.reduxkotlin.sample.taskflow.core.BoardId
+import org.reduxkotlin.sample.taskflow.core.CardId
+import org.reduxkotlin.sample.taskflow.core.ColumnId
+import org.reduxkotlin.sample.taskflow.core.LabelId
+import org.reduxkotlin.sample.taskflow.core.NavModel
+import org.reduxkotlin.sample.taskflow.core.Route
+import org.reduxkotlin.sample.taskflow.feature.board.FilterModel
+
+/**
+ * Action that replays a restored [UiSnapshot] into the per-account store. Routed inline onto the
+ * [NavModel] and [FilterModel] slots in `declareAccountModels` — it is never handled by a reducer.
+ */
+internal data class RestoreUiState(val nav: NavModel, val filter: FilterModel) : Action
+
+/** Serializable mirror of [Route] (value-class ids flattened to their `.v` strings). */
+@Serializable
+internal sealed interface RouteDto {
+    /** @see Route.BoardList */
+    @Serializable @SerialName("boardList") data object BoardList : RouteDto
+
+    /** @see Route.Board */
+    @Serializable @SerialName("board") data class Board(val boardId: String) : RouteDto
+
+    /** @see Route.Profile */
+    @Serializable @SerialName("profile") data object Profile : RouteDto
+
+    /** @see Route.Settings */
+    @Serializable @SerialName("settings") data object Settings : RouteDto
+
+    /** @see Route.CardDetail */
+    @Serializable @SerialName("cardDetail") data class CardDetail(val cardId: String, val edit: Boolean) : RouteDto
+
+    /** @see Route.ComposeCard */
+    @Serializable @SerialName("composeCard") data class ComposeCard(val columnId: String) : RouteDto
+}
+
+/** Serializable volatile-UI snapshot of the active account: nav stack + filter only. */
+@Serializable
+internal data class UiSnapshot(
+    val stack: List<RouteDto>,
+    val filterQuery: String,
+    val filterAssignee: String?,
+    val filterLabelIds: List<String>,
+)
+
+private val snapshotJson = Json { classDiscriminator = "t" }
+
+private fun Route.toDto(): RouteDto = when (this) {
+    is Route.BoardList -> RouteDto.BoardList
+    is Route.Board -> RouteDto.Board(boardId.v)
+    is Route.Profile -> RouteDto.Profile
+    is Route.Settings -> RouteDto.Settings
+    is Route.CardDetail -> RouteDto.CardDetail(cardId.v, mode == Route.CardDetail.Mode.Edit)
+    is Route.ComposeCard -> RouteDto.ComposeCard(columnId.v)
+}
+
+private fun RouteDto.toRoute(): Route = when (this) {
+    is RouteDto.BoardList -> Route.BoardList
+    is RouteDto.Board -> Route.Board(BoardId(boardId))
+    is RouteDto.Profile -> Route.Profile
+    is RouteDto.Settings -> Route.Settings
+    is RouteDto.CardDetail ->
+        Route.CardDetail(CardId(cardId), if (edit) Route.CardDetail.Mode.Edit else Route.CardDetail.Mode.View)
+    is RouteDto.ComposeCard -> Route.ComposeCard(ColumnId(columnId))
+}
+
+/** Serializes [nav] + [filter] to a JSON snapshot string. */
+internal fun encodeUiSnapshot(nav: NavModel, filter: FilterModel): String {
+    val snapshot = UiSnapshot(
+        stack = nav.stack.map { it.toDto() },
+        filterQuery = filter.query,
+        filterAssignee = filter.assignee?.v,
+        filterLabelIds = filter.labelIds.map { it.v },
+    )
+    return snapshotJson.encodeToString(UiSnapshot.serializer(), snapshot)
+}
+
+/**
+ * Parses a JSON snapshot into a [RestoreUiState]. An empty restored stack falls back to the
+ * [NavModel] default (`[BoardList]`) so a malformed/empty snapshot can never strand the user on a
+ * blank stack.
+ */
+internal fun decodeUiSnapshot(json: String): RestoreUiState {
+    val snapshot = snapshotJson.decodeFromString(UiSnapshot.serializer(), json)
+    val stack = snapshot.stack.map { it.toRoute() }.toPersistentList()
+    val nav = if (stack.isEmpty()) NavModel() else NavModel(stack)
+    val filter = FilterModel(
+        query = snapshot.filterQuery,
+        assignee = snapshot.filterAssignee?.let { AccountId(it) },
+        labelIds = snapshot.filterLabelIds.map { LabelId(it) }.toPersistentSet(),
+    )
+    return RestoreUiState(nav, filter)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :examples:taskflow:composeApp:jvmTest --tests "org.reduxkotlin.sample.taskflow.app.persistence.UiSnapshotTest"`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt \
+        examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotTest.kt
+git commit -m "feat(taskflow): UiSnapshot DTO + JSON codec for saveable UI state"
+```
+
+---
+
+### Task 2: Route `RestoreUiState` into the nav + filter slots
+
+**Files:**
+- Modify: `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt:198-232`
+- Test: `examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `UiSnapshotTest.kt` (uses the routing DSL directly so the test stays pure — it mirrors how `declareAccountModels` wires the two slots, without building the whole account store):
+
+```kotlin
+    @Test
+    fun restoreUiStateReplacesNavAndFilterSlots() {
+        val target = decodeUiSnapshot(
+            encodeUiSnapshot(
+                NavModel(persistentListOf(Route.BoardList, Route.Board(BoardId("b7")))),
+                FilterModel(query = "q"),
+            ),
+        )
+
+        // Apply the two inline handlers exactly as declareAccountModels wires them.
+        val navAfter: NavModel = (target as RestoreUiState).nav
+        val filterAfter: FilterModel = target.filter
+
+        assertEquals(BoardId("b7"), navAfter.activeBoardId)
+        assertEquals("q", filterAfter.query)
+    }
+```
+
+> NOTE: This test pins the contract the routing relies on (the action carries the exact next slices). The wiring itself is verified end-to-end in Task 4's store-level test.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :examples:taskflow:composeApp:jvmTest --tests "org.reduxkotlin.sample.taskflow.app.persistence.UiSnapshotTest"`
+Expected: PASS for the codec tests, and this new test FAILS only if `RestoreUiState` isn't `internal`-visible to the test (same module/source-set → it compiles). If it already passes, proceed — the behavioral wiring is added next and covered in Task 4.
+
+- [ ] **Step 3: Add the routing wiring**
+
+In `AccountStore.kt`, add the import near the other feature imports:
+
+```kotlin
+import org.reduxkotlin.sample.taskflow.app.persistence.RestoreUiState
+```
+
+In `declareAccountModels`, add one handler to the `NavModel` slot (after the existing `on<CancelCreateCard>` line at `:205`):
+
+```kotlin
+        on<RestoreUiState> { _, a -> a.nav }
+```
+
+And one to the `FilterModel` slot (after the existing `on<BoardClosed>` line at `:231`):
+
+```kotlin
+        on<RestoreUiState> { _, a -> a.filter }
+```
+
+- [ ] **Step 4: Run test + compile to verify**
+
+Run: `./gradlew :examples:taskflow:composeApp:compileKotlinJvm :examples:taskflow:composeApp:jvmTest --tests "org.reduxkotlin.sample.taskflow.app.persistence.UiSnapshotTest"`
+Expected: compiles; all `UiSnapshotTest` tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt \
+        examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotTest.kt
+git commit -m "feat(taskflow): route RestoreUiState onto nav + filter slots"
+```
+
+---
+
+### Task 3: Live-store bridge + end-to-end store restore test
+
+**Files:**
+- Modify: `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt`
+- Test: `examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotStoreTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `UiSnapshotStoreTest.kt` in **jvmTest** (it builds a real account store; mirror the setup pattern in `app/AccountRegistryTest.kt` for the `rootStore` / `localStore` / scope fixtures — reuse its in-memory `LocalStore` test double and root-store helper):
+
+```kotlin
+package org.reduxkotlin.sample.taskflow.app.persistence
+
+import kotlinx.coroutines.test.runTest
+import org.reduxkotlin.sample.taskflow.core.BoardId
+import org.reduxkotlin.sample.taskflow.core.NavModel
+import org.reduxkotlin.sample.taskflow.core.Route
+import org.reduxkotlin.sample.taskflow.feature.board.FilterModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UiSnapshotStoreTest {
+
+    @Test
+    fun encodeFromLiveStoreThenDecodeRestoresNavAndFilter() = runTest {
+        // Build a per-account store via the same fixtures AccountRegistryTest uses.
+        val handle = newTestAccountStore() // helper from the shared test fixtures (see note)
+        val store = handle.store
+
+        // Drive it to a non-default nav + filter through real actions.
+        store.dispatch(org.reduxkotlin.sample.taskflow.app.nav.Navigate(Route.Board(BoardId("b1"))))
+        store.dispatch(org.reduxkotlin.sample.taskflow.feature.board.SetFilterQuery("hello"))
+
+        // Snapshot the live store, then restore into a fresh store.
+        val json = encodeUiSnapshot(store)
+
+        val fresh = newTestAccountStore().store
+        fresh.dispatch(decodeUiSnapshot(json))
+
+        assertEquals(BoardId("b1"), fresh.getModel<NavModel>().activeBoardId)
+        assertEquals("hello", fresh.getModel<FilterModel>().query)
+    }
+}
+```
+
+> NOTE: `newTestAccountStore()` — if `AccountRegistryTest` already exposes a fixture helper, reuse it; otherwise extract its store-building setup into a small `TestAccountStore.kt` under `jvmTest/.../app/` and call it from both. Do NOT duplicate the wiring inline (DRY).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :examples:taskflow:composeApp:jvmTest --tests "org.reduxkotlin.sample.taskflow.app.persistence.UiSnapshotStoreTest"`
+Expected: FAIL — `encodeUiSnapshot(store)` overload does not exist yet.
+
+- [ ] **Step 3: Add the live-store bridge overload**
+
+Append to `UiSnapshot.kt` (and add the imports):
+
+```kotlin
+import org.reduxkotlin.Store
+import org.reduxkotlin.multimodel.ModelState
+
+/** Reads the live per-account [store]'s [NavModel] + [FilterModel] (lock-free) into a snapshot string. */
+internal fun encodeUiSnapshot(store: Store<ModelState>): String =
+    encodeUiSnapshot(store.getModel<NavModel>(), store.getModel<FilterModel>())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :examples:taskflow:composeApp:jvmTest --tests "org.reduxkotlin.sample.taskflow.app.persistence.UiSnapshotStoreTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt \
+        examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/
+git commit -m "feat(taskflow): encode UI snapshot from live concurrent store"
+```
+
+---
+
+### Task 4: Compose Saveable wiring in `ActiveAccount`
+
+**Files:**
+- Modify: `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt`
+- Modify: `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt:179-200`
+
+- [ ] **Step 1: Add the `RestoreSlot` + `RestoreUiStateEffect` composable**
+
+Append to `UiSnapshot.kt` (add imports):
+
+```kotlin
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+
+/** One-shot carrier for a restored snapshot JSON; [consume] returns it exactly once. */
+internal class RestoreSlot(private var pending: String?) {
+    /** Returns the pending snapshot JSON once (then null), so restore replays exactly once. */
+    internal fun consume(): String? {
+        val p = pending
+        pending = null
+        return p
+    }
+}
+
+/**
+ * Persists the active account's volatile UI (nav + filter) across process death / config change.
+ *
+ * At save time the [Saver] reads [accountStore] directly (lock-free `getState` mirror) and serializes
+ * the current snapshot into the Activity `SavedStateRegistry`. On restore, the JSON is parked in a
+ * [RestoreSlot] and replayed exactly once from a [LaunchedEffect] (off the composition/dispatch path)
+ * via [RestoreUiState]. Board content reloads via the existing `BoardLifecycleEffect`.
+ *
+ * @param accountStore the active account's store.
+ * @param key the active account id — re-scopes the saved slot per account.
+ */
+@Composable
+internal fun RestoreUiStateEffect(accountStore: Store<ModelState>, key: Any) {
+    val slot = rememberSaveable(
+        key,
+        saver = Saver(
+            save = { encodeUiSnapshot(accountStore) },
+            restore = { json -> RestoreSlot(json) },
+        ),
+    ) { RestoreSlot(null) }
+
+    LaunchedEffect(key) {
+        val json = slot.consume() ?: return@LaunchedEffect
+        accountStore.dispatch(decodeUiSnapshot(json))
+    }
+}
+```
+
+- [ ] **Step 2: Call it from `ActiveAccount`**
+
+In `App.kt`, add the import:
+
+```kotlin
+import org.reduxkotlin.sample.taskflow.app.persistence.RestoreUiStateEffect
+```
+
+In `ActiveAccount`, immediately after `val accountStore = handle.store` (`App.kt:182`), add:
+
+```kotlin
+    // Restore volatile UI (nav + filter) saved across process death / config change (§ saveable plan).
+    RestoreUiStateEffect(accountStore = accountStore, key = activeId)
+```
+
+- [ ] **Step 3: Compile (all targets the host can run)**
+
+Run: `./gradlew :examples:taskflow:composeApp:compileKotlinJvm`
+Expected: BUILD SUCCESSFUL. (If the host has the Android SDK: also `:examples:taskflow:composeApp:compileDebugKotlinAndroid`.)
+
+- [ ] **Step 4: Manual verify — Android process death**
+
+This is Compose-on-Android behavior; verify on a device/emulator (TDD unit coverage lives in Tasks 1-3):
+1. Build & install the Android app: `./gradlew :examples:taskflow:androidApp:installDebug`.
+2. Log in, open a board, drill into a card (Edit mode), set a filter query.
+3. Enable **Settings → Developer options → Don't keep activities** (or `adb shell am kill org.reduxkotlin.sample.taskflow` while backgrounded).
+4. Background the app (Home), then return.
+5. Expected: the same board + card detail (back in **View** mode — Edit isn't persisted by design) and the filter query are restored, not reset to the board list.
+6. Also test rotation (config change): the nav + filter survive (a brief driver-init spinner on rotation is expected and out of scope — note it, don't fix it here).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt \
+        examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt
+git commit -m "feat(taskflow): wire rememberSaveable UI restore into ActiveAccount"
+```
+
+---
+
+### Task 5: Gate, lint, and docs
+
+**Files:**
+- Modify: `examples/taskflow/ARCHITECTURE.md` (persistence section — add a short note on the Saveable UI layer vs SQLDelight durable layer)
+
+- [ ] **Step 1: Full lint + build gate**
+
+Run: `./gradlew detektAll`
+Expected: PASS. The pre-commit hook runs `detektAll --auto-correct`; if it rewrites formatting, re-stage and amend. Add KDoc to any `internal`/`public` decl detekt flags (the `RouteDto` variants already carry `@see` KDocs).
+
+Run: `./gradlew :examples:taskflow:composeApp:jvmTest`
+Expected: PASS (all `UiSnapshot*` tests).
+
+- [ ] **Step 2: Document the layer split**
+
+In `examples/taskflow/ARCHITECTURE.md`, under the persistence/offline section, add a paragraph:
+
+> **Volatile UI persistence (Saveable).** Domain data is durable via SQLDelight (`LocalStore`). The active account's *volatile* UI — the nav stack and board filter — is additionally snapshotted into the Android `SavedStateRegistry` via `RestoreUiStateEffect` (`app/persistence/UiSnapshot.kt`) so it survives process death and configuration changes. The snapshot carries UI state only; `activeAccountId` and all domain data stay owned by SQLDelight (single source of truth — restoring `activeAccountId` from two places would race the disk load). Restoring the nav stack reloads the board through the existing `BoardLifecycleEffect`. CardDetail **Edit** mode is intentionally restored as **View**.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/taskflow/ARCHITECTURE.md
+git commit -m "docs(taskflow): document saveable UI-persistence layer"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Volatile UI survives process death → Tasks 1-4 (snapshot, route, bridge, Compose wiring). ✅
+- Nav stack persisted (currently dead `saveNav`) → Task 1 `RouteDto` + Task 4 wiring. ✅
+- Filter persisted → Tasks 1-4. ✅
+- `activeAccountId` NOT double-sourced → enforced by omitting it from `UiSnapshot` (documented Task 5). ✅
+- Restore replayed once, off the dispatch path → `RestoreSlot.consume()` + `LaunchedEffect` (Task 4). ✅
+- Threading: snapshot read is lock-free mirror; restore dispatch from `LaunchedEffect` → Task 3/4. ✅
+- Board reload after restore → relies on existing `BoardLifecycleEffect` (verified Task 4 manual). ✅
+- Out-of-scope rotation-spinner / live-store retention → documented, not implemented. ✅
+
+**Placeholder scan:** No TBD/TODO. The only deferred detail is `newTestAccountStore()` in Task 3, with explicit instruction to reuse/extract from `AccountRegistryTest` (the executor must read that file) — this is a real fixture decision, not a code placeholder.
+
+**Type consistency:** `RestoreUiState(nav: NavModel, filter: FilterModel)` used identically in Tasks 1-4. `encodeUiSnapshot` has two overloads — `(NavModel, FilterModel)` (Task 1) and `(Store<ModelState>)` (Task 3) — both return `String`, consistent. `decodeUiSnapshot(String): RestoreUiState` consistent. Id accessor `.v` matches `core/Ids.kt`. `getModel<T>()` matches existing call sites.

--- a/examples/taskflow/ARCHITECTURE.md
+++ b/examples/taskflow/ARCHITECTURE.md
@@ -625,6 +625,17 @@ erDiagram
   account ||--o{ pending_op : queues
 ```
 
+### Volatile UI persistence (Saveable)
+
+Domain data is durable via SQLDelight (`LocalStore`). The active account's *volatile* UI — the
+navigation stack and board filter — is additionally snapshotted into the Android
+`SavedStateRegistry` via `RestoreUiStateEffect` (`app/persistence/UiSnapshot.kt`) so it
+survives process death and configuration changes. The snapshot carries UI state only;
+`activeAccountId` and all domain data stay owned by SQLDelight (single source of truth —
+restoring `activeAccountId` from two places would race the disk load). Restoring the nav stack
+reloads the board through the existing board-lifecycle effect. CardDetail **Edit** mode is
+intentionally restored as **View**.
+
 ---
 
 ## 12. The bot collaborator

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt
@@ -23,7 +23,9 @@ import org.reduxkotlin.sample.taskflow.app.nav.EnterEditMode
 import org.reduxkotlin.sample.taskflow.app.nav.Navigate
 import org.reduxkotlin.sample.taskflow.app.nav.OpenCard
 import org.reduxkotlin.sample.taskflow.app.nav.navReducer
+import org.reduxkotlin.sample.taskflow.app.persistence.RestoreUiState
 import org.reduxkotlin.sample.taskflow.core.AccountDetail
+import org.reduxkotlin.sample.taskflow.core.AccountId
 import org.reduxkotlin.sample.taskflow.core.AddCard
 import org.reduxkotlin.sample.taskflow.core.AppSettingsModel
 import org.reduxkotlin.sample.taskflow.core.CardMoveRequested
@@ -203,6 +205,7 @@ private fun RoutingBuilder.declareAccountModels(detail: AccountDetail) {
         on<CloseCard> { s, a -> navReducer(s, a) }
         on<StartCreateCard> { s, a -> navReducer(s, a) }
         on<CancelCreateCard> { s, a -> navReducer(s, a) }
+        on<RestoreUiState> { _, a -> a.nav }
     }
     model(BoardListModel()) {
         on<LoadBoardListSucceeded> { s, a -> boardListReducer(s, a) }
@@ -211,24 +214,13 @@ private fun RoutingBuilder.declareAccountModels(detail: AccountDetail) {
     model(CollaboratorsModel(seedCollaborators(detail))) {
         on<EditProfile> { s, a -> collaboratorsReducer(s, a, selfId) }
     }
-    model(BoardModel()) {
-        on<LoadBoardSucceeded> { s, a -> boardReducer(s, a, selfId) }
-        on<CardMoveRequested> { s, a -> boardReducer(s, a, selfId) }
-        on<AddCard> { s, a -> boardReducer(s, a, selfId) }
-        on<AddColumn> { s, a -> boardReducer(s, a, selfId) }
-        on<EditCard> { s, a -> boardReducer(s, a, selfId) }
-        on<DeleteCard> { s, a -> boardReducer(s, a, selfId) }
-        on<CardOpFailed> { s, a -> boardReducer(s, a, selfId) }
-        on<BotMovedCard> { s, a -> boardReducer(s, a, selfId) }
-        on<BotAddedCard> { s, a -> boardReducer(s, a, selfId) }
-        on<BoardClosed> { s, a -> boardReducer(s, a, selfId) }
-        on<BoardRestored> { s, a -> boardReducer(s, a, selfId) }
-    }
+    declareBoardModel(selfId)
     model(FilterModel()) {
         on<SetFilterQuery> { s, a -> filterReducer(s, a) }
         on<SetFilterAssignee> { s, a -> filterReducer(s, a) }
         on<ToggleFilterLabel> { s, a -> filterReducer(s, a) }
         on<BoardClosed> { s, a -> filterReducer(s, a) }
+        on<RestoreUiState> { _, a -> a.filter }
     }
     model(UndoModel()) {
         on<PushUndo> { s, a -> undoModelReducer(s, a) }
@@ -247,6 +239,23 @@ private fun RoutingBuilder.declareAccountModels(detail: AccountDetail) {
     }
     model(ActivityModel()) {
         on<RecordActivity> { s, a -> activityReducer(s, a) }
+    }
+}
+
+/** Routes all board-level actions through [boardReducer] for the given [selfId] account. */
+private fun RoutingBuilder.declareBoardModel(selfId: AccountId) {
+    model(BoardModel()) {
+        on<LoadBoardSucceeded> { s, a -> boardReducer(s, a, selfId) }
+        on<CardMoveRequested> { s, a -> boardReducer(s, a, selfId) }
+        on<AddCard> { s, a -> boardReducer(s, a, selfId) }
+        on<AddColumn> { s, a -> boardReducer(s, a, selfId) }
+        on<EditCard> { s, a -> boardReducer(s, a, selfId) }
+        on<DeleteCard> { s, a -> boardReducer(s, a, selfId) }
+        on<CardOpFailed> { s, a -> boardReducer(s, a, selfId) }
+        on<BotMovedCard> { s, a -> boardReducer(s, a, selfId) }
+        on<BotAddedCard> { s, a -> boardReducer(s, a, selfId) }
+        on<BoardClosed> { s, a -> boardReducer(s, a, selfId) }
+        on<BoardRestored> { s, a -> boardReducer(s, a, selfId) }
     }
 }
 

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt
@@ -128,16 +128,27 @@ public fun App() {
 private fun AppShell(appStore: Store<ModelState>, localStore: LocalStore) {
     val registry = remember(localStore) { AccountRegistry(appStore, localStore) }
 
+    // `booted` gates the first paint until the account directory has been read from disk. Without it,
+    // the root store's default `activeAccountId == null` paints LoginScreen for the whole disk-load
+    // window (≈200 ms) before rehydration lands — a flash on every cold start / process-death restore.
+    var booted by remember(localStore) { mutableStateOf(false) }
+
     // Bootstrap once: ensure seed data, then rehydrate the account directory + active id (§13e).
     LaunchedEffect(localStore) {
         localStore.ensureSeeded()
         val activeId = localStore.loadActiveAccountId()
         val accounts = localStore.loadAccounts()
         appStore.dispatch(LoadAccountsSucceeded(accounts, activeId))
+        booted = true
     }
 
     val theme by rememberStableStore(appStore).value.fieldStateOf(AppSettingsModel::class) { it.theme }
-    val activeId by rememberStableStore(appStore).value.fieldStateOf(AccountsModel::class) { it.activeAccountId }
+
+    // Subscribe to activeAccountId so login / logout / account-switch recompose. The value itself is
+    // read synchronously at the decision site (below) rather than from this State: the concurrent
+    // store posts subscriber callbacks asynchronously, so this State lags the just-dispatched value by
+    // a frame — reading it directly would flash LoginScreen for a frame on a process-death restore.
+    val activeIdSignal = rememberStableStore(appStore).value.fieldStateOf(AccountsModel::class) { it.activeAccountId }
 
     TaskFlowTheme(theme = theme) {
         CompositionLocalProvider(
@@ -152,13 +163,24 @@ private fun AppShell(appStore: Store<ModelState>, localStore: LocalStore) {
             // via their default `windowInsets`. Screens must NOT reapply safeDrawing at their
             // root or insets would be applied twice.
             Surface(modifier = Modifier.fillMaxSize()) {
-                val id = activeId
-                if (id == null) {
-                    LoginScreen(appStore)
-                } else {
-                    // Persist the active account id for process-death rehydration (§13e).
-                    LaunchedEffect(id) { localStore.saveActiveAccountId(id) }
-                    ActiveAccount(appStore = appStore, registry = registry, activeId = id)
+                val id = run {
+                    activeIdSignal.value // touch the State to subscribe (recompose on change)
+                    appStore.getModel<AccountsModel>().activeAccountId // authoritative, lag-free read
+                }
+                when {
+                    // Hold the first paint until the directory is loaded — no LoginScreen flash before
+                    // the persisted active id rehydrates (folds into the existing driver splash).
+                    !booted -> Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+
+                    id == null -> LoginScreen(appStore)
+
+                    else -> {
+                        // Persist the active account id for process-death rehydration (§13e).
+                        LaunchedEffect(id) { localStore.saveActiveAccountId(id) }
+                        ActiveAccount(appStore = appStore, registry = registry, activeId = id)
+                    }
                 }
             }
         }

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt
@@ -183,16 +183,15 @@ private fun ActiveAccount(appStore: Store<ModelState>, registry: AccountRegistry
     val accountStore = handle.store
 
     // Restore volatile UI (nav + filter) saved across process death / config change (saveable plan).
-    // `applied` is false only while a saved snapshot is still pending, so we can withhold the first
-    // paint and never flash the default [BoardList] before the saved stack lands.
-    val applied = rememberUiRestore(accountStore = accountStore, key = activeId)
+    // Applied SYNCHRONOUSLY here, BEFORE the nav read below — the concurrent store's subscriber
+    // callbacks are async (Handler.post), so dispatching from an effect would let the default
+    // [BoardList] nav paint for a frame; a synchronous apply makes the first nav read already correct.
+    rememberUiRestore(accountStore = accountStore, key = activeId)
 
     val nav by rememberStableStore(accountStore).value.fieldStateOf(NavModel::class) { it }
 
     // Lifecycle effects key on the *active board* (the lowest Board in the stack), not the top of
     // the stack — so drilling into CardDetail/ComposeCard keeps the board loaded and the sync ticking.
-    // Declared above the restore gate so the board loads lazily in the background while the spinner
-    // shows (the add-card overlay paints over it; board/card top screens use their own skeletons).
     BoardLifecycleEffect(
         accountStore = accountStore,
         registry = registry,
@@ -200,15 +199,6 @@ private fun ActiveAccount(appStore: Store<ModelState>, registry: AccountRegistry
         activeBoardId = nav.activeBoardId,
     )
     PeriodicSyncEffect(appStore = appStore, accountStore = accountStore, activeBoardId = nav.activeBoardId)
-
-    if (!applied) {
-        // Restore pending: hold the first paint (folds into the existing driver spinner) so the
-        // restored stack appears directly — no [BoardList] / half-loaded board flash in between.
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            CircularProgressIndicator()
-        }
-        return
-    }
 
     var showSwitcher by remember { mutableStateOf(false) }
 

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt
@@ -36,7 +36,7 @@ import org.reduxkotlin.multimodel.ModelState
 import org.reduxkotlin.sample.taskflow.app.nav.AdaptiveNav
 import org.reduxkotlin.sample.taskflow.app.nav.Back
 import org.reduxkotlin.sample.taskflow.app.nav.Navigate
-import org.reduxkotlin.sample.taskflow.app.persistence.RestoreUiStateEffect
+import org.reduxkotlin.sample.taskflow.app.persistence.rememberUiRestore
 import org.reduxkotlin.sample.taskflow.core.AccountId
 import org.reduxkotlin.sample.taskflow.core.AppSettingsModel
 import org.reduxkotlin.sample.taskflow.core.BoardId
@@ -183,12 +183,16 @@ private fun ActiveAccount(appStore: Store<ModelState>, registry: AccountRegistry
     val accountStore = handle.store
 
     // Restore volatile UI (nav + filter) saved across process death / config change (saveable plan).
-    RestoreUiStateEffect(accountStore = accountStore, key = activeId)
+    // `applied` is false only while a saved snapshot is still pending, so we can withhold the first
+    // paint and never flash the default [BoardList] before the saved stack lands.
+    val applied = rememberUiRestore(accountStore = accountStore, key = activeId)
 
     val nav by rememberStableStore(accountStore).value.fieldStateOf(NavModel::class) { it }
 
     // Lifecycle effects key on the *active board* (the lowest Board in the stack), not the top of
     // the stack — so drilling into CardDetail/ComposeCard keeps the board loaded and the sync ticking.
+    // Declared above the restore gate so the board loads lazily in the background while the spinner
+    // shows (the add-card overlay paints over it; board/card top screens use their own skeletons).
     BoardLifecycleEffect(
         accountStore = accountStore,
         registry = registry,
@@ -196,6 +200,15 @@ private fun ActiveAccount(appStore: Store<ModelState>, registry: AccountRegistry
         activeBoardId = nav.activeBoardId,
     )
     PeriodicSyncEffect(appStore = appStore, accountStore = accountStore, activeBoardId = nav.activeBoardId)
+
+    if (!applied) {
+        // Restore pending: hold the first paint (folds into the existing driver spinner) so the
+        // restored stack appears directly — no [BoardList] / half-loaded board flash in between.
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+        }
+        return
+    }
 
     var showSwitcher by remember { mutableStateOf(false) }
 

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt
@@ -36,6 +36,7 @@ import org.reduxkotlin.multimodel.ModelState
 import org.reduxkotlin.sample.taskflow.app.nav.AdaptiveNav
 import org.reduxkotlin.sample.taskflow.app.nav.Back
 import org.reduxkotlin.sample.taskflow.app.nav.Navigate
+import org.reduxkotlin.sample.taskflow.app.persistence.RestoreUiStateEffect
 import org.reduxkotlin.sample.taskflow.core.AccountId
 import org.reduxkotlin.sample.taskflow.core.AppSettingsModel
 import org.reduxkotlin.sample.taskflow.core.BoardId
@@ -180,6 +181,9 @@ private fun AppShell(appStore: Store<ModelState>, localStore: LocalStore) {
 private fun ActiveAccount(appStore: Store<ModelState>, registry: AccountRegistry, activeId: AccountId) {
     val handle = remember(activeId) { registry.getOrCreate(activeId, SeedData.accountDetail(activeId)) }
     val accountStore = handle.store
+
+    // Restore volatile UI (nav + filter) saved across process death / config change (saveable plan).
+    RestoreUiStateEffect(accountStore = accountStore, key = activeId)
 
     val nav by rememberStableStore(accountStore).value.fieldStateOf(NavModel::class) { it }
 

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
@@ -134,7 +134,7 @@ internal fun decodeUiSnapshot(json: String): RestoreUiState {
 /** One-shot carrier for a restored snapshot JSON; [consume] returns it exactly once. */
 internal class RestoreSlot(private var pending: String?) {
     /** Returns the pending snapshot JSON once (then null), so restore replays exactly once. */
-    internal fun consume(): String? {
+    fun consume(): String? {
         val p = pending
         pending = null
         return p
@@ -150,7 +150,9 @@ internal class RestoreSlot(private var pending: String?) {
  * via [RestoreUiState]. Board content reloads via the existing board-lifecycle effect.
  *
  * @param accountStore the active account's store.
- * @param key the active account id — re-scopes the saved slot per account.
+ * @param key the active account id — scopes the saved slot per account via [rememberSaveable].
+ *   The [LaunchedEffect] keys on the [RestoreSlot] instance itself so an in-place
+ *   [rememberSaveable] restore (where [key] is unchanged) still triggers the effect.
  */
 @Composable
 internal fun RestoreUiStateEffect(accountStore: Store<ModelState>, key: Any) {
@@ -162,7 +164,7 @@ internal fun RestoreUiStateEffect(accountStore: Store<ModelState>, key: Any) {
         ),
     ) { RestoreSlot(null) }
 
-    LaunchedEffect(key) {
+    LaunchedEffect(slot) {
         val json = slot.consume() ?: return@LaunchedEffect
         accountStore.dispatch(decodeUiSnapshot(json))
     }

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
@@ -102,12 +102,14 @@ internal fun encodeUiSnapshot(nav: NavModel, filter: FilterModel): String {
 }
 
 /**
- * Parses a JSON snapshot into a [RestoreUiState]. An empty restored stack falls back to the
- * [NavModel] default (`[BoardList]`) so a malformed/empty snapshot can never strand the user on a
- * blank stack.
+ * Parses a JSON snapshot into a [RestoreUiState]. Defensive: a malformed snapshot, or one whose
+ * stack decodes empty, falls back to the [NavModel] default (`[BoardList]`) + an empty [FilterModel]
+ * so a corrupt/truncated save can never strand the user on a blank stack.
  */
 internal fun decodeUiSnapshot(json: String): RestoreUiState {
-    val snapshot = snapshotJson.decodeFromString(UiSnapshot.serializer(), json)
+    val snapshot = runCatching { snapshotJson.decodeFromString(UiSnapshot.serializer(), json) }
+        .getOrNull()
+        ?: return RestoreUiState(NavModel(), FilterModel())
     val stack = snapshot.stack.map { it.toRoute() }.toPersistentList()
     val nav = if (stack.isEmpty()) NavModel() else NavModel(stack)
     val filter = FilterModel(

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
@@ -1,8 +1,6 @@
 package org.reduxkotlin.sample.taskflow.app.persistence
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -134,9 +132,6 @@ internal fun decodeUiSnapshot(json: String): RestoreUiState {
 
 /** One-shot carrier for a restored snapshot JSON; [consume] returns it exactly once. */
 internal class RestoreSlot(private var pending: String?) {
-    /** Non-consuming peek: true while a restored snapshot is still waiting to be applied. */
-    fun hasPending(): Boolean = pending != null
-
     /** Returns the pending snapshot JSON once (then null), so restore replays exactly once. */
     fun consume(): String? {
         val p = pending
@@ -146,27 +141,28 @@ internal class RestoreSlot(private var pending: String?) {
 }
 
 /**
- * Restores the active account's volatile UI (nav + filter) saved across process death / config
- * change, and reports whether that restore has been applied yet.
+ * Restores the active account's volatile UI (nav + filter) saved across process death / config change.
+ *
+ * **Call this BEFORE the caller first reads nav/filter** via `selectorState`/`fieldStateOf`. The
+ * snapshot is applied **synchronously during composition** (the concurrent-store `dispatch` is
+ * synchronous — state is updated before it returns), so the selector's initial `store.state` read
+ * already reflects the restored stack and the very first paint is correct.
+ *
+ * Why not a `LaunchedEffect`: the concurrent store delivers subscriber callbacks **asynchronously**
+ * (`notificationContext` = `Handler.post` on Android), so a `selectorState` only observes a
+ * post-dispatch change one main-looper message later. Dispatching the restore from an effect would
+ * therefore let the default `[BoardList]` nav paint for a frame before the saved stack lands — the
+ * intermittent board-list / board flash. Applying synchronously here closes that window entirely.
  *
  * At save time the [Saver] reads [accountStore] directly (lock-free `getState` mirror) and serializes
- * the snapshot into the Activity `SavedStateRegistry`. On restore the JSON is parked in a [RestoreSlot]
- * and replayed exactly once from a [LaunchedEffect] (off the composition/dispatch path) via
- * [RestoreUiState]; board content then reloads via the existing board-lifecycle effect.
- *
- * The returned flag lets the caller withhold the first account-UI paint until the restore has landed,
- * so the default `[BoardList]` nav never flashes before the saved stack settles. It is `true`
- * immediately when nothing is pending (a fresh launch / ordinary navigation is never gated) and flips
- * `true` once a pending snapshot has been dispatched.
+ * the snapshot into the Activity `SavedStateRegistry`. [consume] makes the replay happen exactly once
+ * per restored [RestoreSlot]; board content then reloads via the existing board-lifecycle effect.
  *
  * @param accountStore the active account's store.
- * @param key the active account id — scopes the saved slot per account via [rememberSaveable]. The
- *   [LaunchedEffect] keys on the [RestoreSlot] instance itself so an in-place restore (where [key] is
- *   unchanged) still triggers the effect.
- * @return `true` once the restore (if any) has been applied; `true` immediately when none is pending.
+ * @param key the active account id — scopes the saved slot per account via [rememberSaveable].
  */
 @Composable
-internal fun rememberUiRestore(accountStore: Store<ModelState>, key: Any): Boolean {
+internal fun rememberUiRestore(accountStore: Store<ModelState>, key: Any) {
     val slot = rememberSaveable(
         key,
         saver = Saver<RestoreSlot, String>(
@@ -175,13 +171,6 @@ internal fun rememberUiRestore(accountStore: Store<ModelState>, key: Any): Boole
         ),
     ) { RestoreSlot(null) }
 
-    // Gate (applied == false) only while a real snapshot is pending; re-evaluated per slot instance so
-    // an in-place restore (new slot) re-gates, while fresh launches / ordinary nav start applied.
-    val applied = remember(slot) { mutableStateOf(!slot.hasPending()) }
-
-    LaunchedEffect(slot) {
-        slot.consume()?.let { accountStore.dispatch(decodeUiSnapshot(it)) }
-        applied.value = true
-    }
-    return applied.value
+    // Apply once, synchronously, during composition — before nav/filter are first read (see KDoc).
+    remember(slot) { slot.consume()?.let { accountStore.dispatch(decodeUiSnapshot(it)) } }
 }

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
@@ -1,5 +1,9 @@
 package org.reduxkotlin.sample.taskflow.app.persistence
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.serialization.SerialName
@@ -125,4 +129,41 @@ internal fun decodeUiSnapshot(json: String): RestoreUiState {
         labelIds = snapshot.filterLabelIds.map { LabelId(it) }.toPersistentSet(),
     )
     return RestoreUiState(nav, filter)
+}
+
+/** One-shot carrier for a restored snapshot JSON; [consume] returns it exactly once. */
+internal class RestoreSlot(private var pending: String?) {
+    /** Returns the pending snapshot JSON once (then null), so restore replays exactly once. */
+    internal fun consume(): String? {
+        val p = pending
+        pending = null
+        return p
+    }
+}
+
+/**
+ * Persists the active account's volatile UI (nav + filter) across process death / config change.
+ *
+ * At save time the [Saver] reads [accountStore] directly (lock-free `getState` mirror) and serializes
+ * the current snapshot into the Activity `SavedStateRegistry`. On restore, the JSON is parked in a
+ * [RestoreSlot] and replayed exactly once from a [LaunchedEffect] (off the composition/dispatch path)
+ * via [RestoreUiState]. Board content reloads via the existing board-lifecycle effect.
+ *
+ * @param accountStore the active account's store.
+ * @param key the active account id — re-scopes the saved slot per account.
+ */
+@Composable
+internal fun RestoreUiStateEffect(accountStore: Store<ModelState>, key: Any) {
+    val slot = rememberSaveable(
+        key,
+        saver = Saver<RestoreSlot, String>(
+            save = { encodeUiSnapshot(accountStore) },
+            restore = { json -> RestoreSlot(json) },
+        ),
+    ) { RestoreSlot(null) }
+
+    LaunchedEffect(key) {
+        val json = slot.consume() ?: return@LaunchedEffect
+        accountStore.dispatch(decodeUiSnapshot(json))
+    }
 }

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
@@ -51,10 +51,15 @@ internal sealed interface RouteDto {
     @SerialName("settings")
     data object Settings : RouteDto
 
-    /** @see Route.CardDetail */
+    /**
+     * @see Route.CardDetail
+     *
+     * Note: edit mode is intentionally not persisted — CardDetail always restores to View mode.
+     * Edit is a transient inline-edit state with no durable buffer to recover.
+     */
     @Serializable
     @SerialName("cardDetail")
-    data class CardDetail(val cardId: String, val edit: Boolean) : RouteDto
+    data class CardDetail(val cardId: String) : RouteDto
 
     /** @see Route.ComposeCard */
     @Serializable
@@ -78,22 +83,16 @@ private fun Route.toDto(): RouteDto = when (this) {
     is Route.Board -> RouteDto.Board(boardId.v)
     is Route.Profile -> RouteDto.Profile
     is Route.Settings -> RouteDto.Settings
-    is Route.CardDetail -> RouteDto.CardDetail(cardId.v, mode == Route.CardDetail.Mode.Edit)
+    is Route.CardDetail -> RouteDto.CardDetail(cardId.v)
     is Route.ComposeCard -> RouteDto.ComposeCard(columnId.v)
 }
 
 private fun RouteDto.toRoute(): Route = when (this) {
     is RouteDto.BoardList -> Route.BoardList
-
     is RouteDto.Board -> Route.Board(BoardId(boardId))
-
     is RouteDto.Profile -> Route.Profile
-
     is RouteDto.Settings -> Route.Settings
-
-    is RouteDto.CardDetail ->
-        Route.CardDetail(CardId(cardId), if (edit) Route.CardDetail.Mode.Edit else Route.CardDetail.Mode.View)
-
+    is RouteDto.CardDetail -> Route.CardDetail(CardId(cardId), Route.CardDetail.Mode.View)
     is RouteDto.ComposeCard -> Route.ComposeCard(ColumnId(columnId))
 }
 

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
@@ -1,0 +1,119 @@
+package org.reduxkotlin.sample.taskflow.app.persistence
+
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentSet
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.reduxkotlin.sample.taskflow.core.AccountId
+import org.reduxkotlin.sample.taskflow.core.Action
+import org.reduxkotlin.sample.taskflow.core.BoardId
+import org.reduxkotlin.sample.taskflow.core.CardId
+import org.reduxkotlin.sample.taskflow.core.ColumnId
+import org.reduxkotlin.sample.taskflow.core.LabelId
+import org.reduxkotlin.sample.taskflow.core.NavModel
+import org.reduxkotlin.sample.taskflow.core.Route
+import org.reduxkotlin.sample.taskflow.feature.board.FilterModel
+
+/**
+ * Action that replays a restored [UiSnapshot] into the per-account store. Routed inline onto the
+ * [NavModel] and [FilterModel] slots in `declareAccountModels` — it is never handled by a reducer.
+ */
+internal data class RestoreUiState(val nav: NavModel, val filter: FilterModel) : Action
+
+/** Serializable mirror of [Route] (value-class ids flattened to their `.v` strings). */
+@Serializable
+internal sealed interface RouteDto {
+    /** @see Route.BoardList */
+    @Serializable
+    @SerialName("boardList")
+    data object BoardList : RouteDto
+
+    /** @see Route.Board */
+    @Serializable
+    @SerialName("board")
+    data class Board(val boardId: String) : RouteDto
+
+    /** @see Route.Profile */
+    @Serializable
+    @SerialName("profile")
+    data object Profile : RouteDto
+
+    /** @see Route.Settings */
+    @Serializable
+    @SerialName("settings")
+    data object Settings : RouteDto
+
+    /** @see Route.CardDetail */
+    @Serializable
+    @SerialName("cardDetail")
+    data class CardDetail(val cardId: String, val edit: Boolean) : RouteDto
+
+    /** @see Route.ComposeCard */
+    @Serializable
+    @SerialName("composeCard")
+    data class ComposeCard(val columnId: String) : RouteDto
+}
+
+/** Serializable volatile-UI snapshot of the active account: nav stack + filter only. */
+@Serializable
+internal data class UiSnapshot(
+    val stack: List<RouteDto>,
+    val filterQuery: String,
+    val filterAssignee: String?,
+    val filterLabelIds: List<String>,
+)
+
+private val snapshotJson = Json { classDiscriminator = "t" }
+
+private fun Route.toDto(): RouteDto = when (this) {
+    is Route.BoardList -> RouteDto.BoardList
+    is Route.Board -> RouteDto.Board(boardId.v)
+    is Route.Profile -> RouteDto.Profile
+    is Route.Settings -> RouteDto.Settings
+    is Route.CardDetail -> RouteDto.CardDetail(cardId.v, mode == Route.CardDetail.Mode.Edit)
+    is Route.ComposeCard -> RouteDto.ComposeCard(columnId.v)
+}
+
+private fun RouteDto.toRoute(): Route = when (this) {
+    is RouteDto.BoardList -> Route.BoardList
+
+    is RouteDto.Board -> Route.Board(BoardId(boardId))
+
+    is RouteDto.Profile -> Route.Profile
+
+    is RouteDto.Settings -> Route.Settings
+
+    is RouteDto.CardDetail ->
+        Route.CardDetail(CardId(cardId), if (edit) Route.CardDetail.Mode.Edit else Route.CardDetail.Mode.View)
+
+    is RouteDto.ComposeCard -> Route.ComposeCard(ColumnId(columnId))
+}
+
+/** Serializes [nav] + [filter] to a JSON snapshot string. */
+internal fun encodeUiSnapshot(nav: NavModel, filter: FilterModel): String {
+    val snapshot = UiSnapshot(
+        stack = nav.stack.map { it.toDto() },
+        filterQuery = filter.query,
+        filterAssignee = filter.assignee?.v,
+        filterLabelIds = filter.labelIds.map { it.v },
+    )
+    return snapshotJson.encodeToString(UiSnapshot.serializer(), snapshot)
+}
+
+/**
+ * Parses a JSON snapshot into a [RestoreUiState]. An empty restored stack falls back to the
+ * [NavModel] default (`[BoardList]`) so a malformed/empty snapshot can never strand the user on a
+ * blank stack.
+ */
+internal fun decodeUiSnapshot(json: String): RestoreUiState {
+    val snapshot = snapshotJson.decodeFromString(UiSnapshot.serializer(), json)
+    val stack = snapshot.stack.map { it.toRoute() }.toPersistentList()
+    val nav = if (stack.isEmpty()) NavModel() else NavModel(stack)
+    val filter = FilterModel(
+        query = snapshot.filterQuery,
+        assignee = snapshot.filterAssignee?.let { AccountId(it) },
+        labelIds = snapshot.filterLabelIds.map { LabelId(it) }.toPersistentSet(),
+    )
+    return RestoreUiState(nav, filter)
+}

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
@@ -5,6 +5,9 @@ import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import org.reduxkotlin.Store
+import org.reduxkotlin.multimodel.ModelState
+import org.reduxkotlin.sample.taskflow.app.getModel
 import org.reduxkotlin.sample.taskflow.core.AccountId
 import org.reduxkotlin.sample.taskflow.core.Action
 import org.reduxkotlin.sample.taskflow.core.BoardId
@@ -100,6 +103,10 @@ internal fun encodeUiSnapshot(nav: NavModel, filter: FilterModel): String {
     )
     return snapshotJson.encodeToString(UiSnapshot.serializer(), snapshot)
 }
+
+/** Reads the live per-account [store]'s [NavModel] + [FilterModel] (lock-free) into a snapshot string. */
+internal fun encodeUiSnapshot(store: Store<ModelState>): String =
+    encodeUiSnapshot(store.getModel<NavModel>(), store.getModel<FilterModel>())
 
 /**
  * Parses a JSON snapshot into a [RestoreUiState]. Defensive: a malformed snapshot, or one whose

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
@@ -2,6 +2,8 @@ package org.reduxkotlin.sample.taskflow.app.persistence
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import kotlinx.collections.immutable.toPersistentList
@@ -132,6 +134,9 @@ internal fun decodeUiSnapshot(json: String): RestoreUiState {
 
 /** One-shot carrier for a restored snapshot JSON; [consume] returns it exactly once. */
 internal class RestoreSlot(private var pending: String?) {
+    /** Non-consuming peek: true while a restored snapshot is still waiting to be applied. */
+    fun hasPending(): Boolean = pending != null
+
     /** Returns the pending snapshot JSON once (then null), so restore replays exactly once. */
     fun consume(): String? {
         val p = pending
@@ -141,20 +146,27 @@ internal class RestoreSlot(private var pending: String?) {
 }
 
 /**
- * Persists the active account's volatile UI (nav + filter) across process death / config change.
+ * Restores the active account's volatile UI (nav + filter) saved across process death / config
+ * change, and reports whether that restore has been applied yet.
  *
  * At save time the [Saver] reads [accountStore] directly (lock-free `getState` mirror) and serializes
- * the current snapshot into the Activity `SavedStateRegistry`. On restore, the JSON is parked in a
- * [RestoreSlot] and replayed exactly once from a [LaunchedEffect] (off the composition/dispatch path)
- * via [RestoreUiState]. Board content reloads via the existing board-lifecycle effect.
+ * the snapshot into the Activity `SavedStateRegistry`. On restore the JSON is parked in a [RestoreSlot]
+ * and replayed exactly once from a [LaunchedEffect] (off the composition/dispatch path) via
+ * [RestoreUiState]; board content then reloads via the existing board-lifecycle effect.
+ *
+ * The returned flag lets the caller withhold the first account-UI paint until the restore has landed,
+ * so the default `[BoardList]` nav never flashes before the saved stack settles. It is `true`
+ * immediately when nothing is pending (a fresh launch / ordinary navigation is never gated) and flips
+ * `true` once a pending snapshot has been dispatched.
  *
  * @param accountStore the active account's store.
- * @param key the active account id — scopes the saved slot per account via [rememberSaveable].
- *   The [LaunchedEffect] keys on the [RestoreSlot] instance itself so an in-place
- *   [rememberSaveable] restore (where [key] is unchanged) still triggers the effect.
+ * @param key the active account id — scopes the saved slot per account via [rememberSaveable]. The
+ *   [LaunchedEffect] keys on the [RestoreSlot] instance itself so an in-place restore (where [key] is
+ *   unchanged) still triggers the effect.
+ * @return `true` once the restore (if any) has been applied; `true` immediately when none is pending.
  */
 @Composable
-internal fun RestoreUiStateEffect(accountStore: Store<ModelState>, key: Any) {
+internal fun rememberUiRestore(accountStore: Store<ModelState>, key: Any): Boolean {
     val slot = rememberSaveable(
         key,
         saver = Saver<RestoreSlot, String>(
@@ -163,8 +175,13 @@ internal fun RestoreUiStateEffect(accountStore: Store<ModelState>, key: Any) {
         ),
     ) { RestoreSlot(null) }
 
+    // Gate (applied == false) only while a real snapshot is pending; re-evaluated per slot instance so
+    // an in-place restore (new slot) re-gates, while fresh launches / ordinary nav start applied.
+    val applied = remember(slot) { mutableStateOf(!slot.hasPending()) }
+
     LaunchedEffect(slot) {
-        val json = slot.consume() ?: return@LaunchedEffect
-        accountStore.dispatch(decodeUiSnapshot(json))
+        slot.consume()?.let { accountStore.dispatch(decodeUiSnapshot(it)) }
+        applied.value = true
     }
+    return applied.value
 }

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/CardDetailScreen.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/CardDetailScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -155,15 +156,18 @@ private fun CardDetailContainer(compact: Boolean, content: @Composable () -> Uni
 }
 
 /**
- * Create mode: a blank title field + a [MarkdownEditor] whose text lives in local `remember` (Rule C
- * — keystrokes never touch the store). Save is enabled only when the title is non-blank; it mints a
+ * Create mode: a blank title field + a [MarkdownEditor] whose text lives in local `rememberSaveable`
+ * (Rule C — keystrokes never touch the store; the draft rides the SavedStateRegistry so it survives
+ * process death / config change). Save is enabled only when the title is non-blank; it mints a
  * fresh card id + op id + clock at the dispatch site, dispatches [AddCard] into the target [columnId],
  * then [CancelCreateCard] to dismiss. Cancel dispatches [CancelCreateCard].
  */
 @Composable
 private fun CreateMode(store: Store<ModelState>, columnId: ColumnId) {
-    var title by remember { mutableStateOf("") }
-    var description by remember { mutableStateOf("") }
+    // rememberSaveable: the in-progress draft rides the SavedStateRegistry so it survives process
+    // death / config change (Rule C still holds — keystrokes stay local, never touch the store).
+    var title by rememberSaveable { mutableStateOf("") }
+    var description by rememberSaveable { mutableStateOf("") }
     val idGen = LocalIdGenerator.current
     val clock = LocalClock.current
 

--- a/examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotTest.kt
+++ b/examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotTest.kt
@@ -1,0 +1,50 @@
+package org.reduxkotlin.sample.taskflow.app.persistence
+
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
+import org.reduxkotlin.sample.taskflow.core.AccountId
+import org.reduxkotlin.sample.taskflow.core.BoardId
+import org.reduxkotlin.sample.taskflow.core.CardId
+import org.reduxkotlin.sample.taskflow.core.ColumnId
+import org.reduxkotlin.sample.taskflow.core.LabelId
+import org.reduxkotlin.sample.taskflow.core.NavModel
+import org.reduxkotlin.sample.taskflow.core.Route
+import org.reduxkotlin.sample.taskflow.feature.board.FilterModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UiSnapshotTest {
+
+    @Test
+    fun fullStackAndFilterRoundTripThroughJson() {
+        val nav = NavModel(
+            persistentListOf(
+                Route.BoardList,
+                Route.Board(BoardId("b1")),
+                Route.CardDetail(CardId("c9"), Route.CardDetail.Mode.Edit),
+            ),
+        )
+        val filter = FilterModel(
+            query = "urgent",
+            assignee = AccountId("a3"),
+            labelIds = persistentSetOf(LabelId("l1"), LabelId("l2")),
+        )
+
+        val json = encodeUiSnapshot(nav, filter)
+        val restored = decodeUiSnapshot(json)
+
+        assertEquals(nav, restored.nav)
+        assertEquals(filter, restored.filter)
+    }
+
+    @Test
+    fun composeCardAndDefaultsRoundTrip() {
+        val nav = NavModel(persistentListOf(Route.Settings, Route.ComposeCard(ColumnId("col2"))))
+        val filter = FilterModel()
+
+        val restored = decodeUiSnapshot(encodeUiSnapshot(nav, filter))
+
+        assertEquals(nav, restored.nav)
+        assertEquals(filter, restored.filter)
+    }
+}

--- a/examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotTest.kt
+++ b/examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotTest.kt
@@ -12,6 +12,7 @@ import org.reduxkotlin.sample.taskflow.core.Route
 import org.reduxkotlin.sample.taskflow.feature.board.FilterModel
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class UiSnapshotTest {
 
@@ -21,7 +22,7 @@ class UiSnapshotTest {
             persistentListOf(
                 Route.BoardList,
                 Route.Board(BoardId("b1")),
-                Route.CardDetail(CardId("c9"), Route.CardDetail.Mode.Edit),
+                Route.CardDetail(CardId("c9"), Route.CardDetail.Mode.View),
             ),
         )
         val filter = FilterModel(
@@ -75,5 +76,19 @@ class UiSnapshotTest {
         val action = decodeUiSnapshot(encodeUiSnapshot(nav, filter))
         assertEquals(BoardId("b7"), action.nav.activeBoardId)
         assertEquals("q", action.filter.query)
+    }
+
+    @Test
+    fun cardDetailEditModeRestoresAsView() {
+        val nav = NavModel(
+            persistentListOf(
+                Route.BoardList,
+                Route.Board(BoardId("b1")),
+                Route.CardDetail(CardId("c9"), Route.CardDetail.Mode.Edit),
+            ),
+        )
+        val restored = decodeUiSnapshot(encodeUiSnapshot(nav, FilterModel())).nav
+        val top = restored.stack.last()
+        assertTrue(top is Route.CardDetail && top.mode == Route.CardDetail.Mode.View)
     }
 }

--- a/examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotTest.kt
+++ b/examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotTest.kt
@@ -67,4 +67,13 @@ class UiSnapshotTest {
         assertEquals(NavModel(), restored.nav)
         assertEquals(FilterModel(), restored.filter)
     }
+
+    @Test
+    fun restoreUiStateCarriesExactNavAndFilterSlices() {
+        val nav = NavModel(persistentListOf(Route.BoardList, Route.Board(BoardId("b7"))))
+        val filter = FilterModel(query = "q")
+        val action = decodeUiSnapshot(encodeUiSnapshot(nav, filter))
+        assertEquals(BoardId("b7"), action.nav.activeBoardId)
+        assertEquals("q", action.filter.query)
+    }
 }

--- a/examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotTest.kt
+++ b/examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotTest.kt
@@ -47,4 +47,24 @@ class UiSnapshotTest {
         assertEquals(nav, restored.nav)
         assertEquals(filter, restored.filter)
     }
+
+    @Test
+    fun cardDetailViewModeRoundTrips() {
+        val nav = NavModel(
+            persistentListOf(
+                Route.BoardList,
+                Route.Board(BoardId("b2")),
+                Route.CardDetail(CardId("c1"), Route.CardDetail.Mode.View),
+            ),
+        )
+        val restored = decodeUiSnapshot(encodeUiSnapshot(nav, FilterModel()))
+        assertEquals(nav, restored.nav)
+    }
+
+    @Test
+    fun malformedJsonFallsBackToDefaults() {
+        val restored = decodeUiSnapshot("not json {{{")
+        assertEquals(NavModel(), restored.nav)
+        assertEquals(FilterModel(), restored.filter)
+    }
 }

--- a/examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotStoreTest.kt
+++ b/examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotStoreTest.kt
@@ -1,0 +1,64 @@
+package org.reduxkotlin.sample.taskflow.app.persistence
+
+import app.cash.sqldelight.async.coroutines.synchronous
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import org.reduxkotlin.concurrent.NotificationContext
+import org.reduxkotlin.sample.taskflow.app.createAccountStore
+import org.reduxkotlin.sample.taskflow.app.createAppStore
+import org.reduxkotlin.sample.taskflow.app.getModel
+import org.reduxkotlin.sample.taskflow.app.nav.Navigate
+import org.reduxkotlin.sample.taskflow.core.AccountId
+import org.reduxkotlin.sample.taskflow.core.BoardId
+import org.reduxkotlin.sample.taskflow.core.NavModel
+import org.reduxkotlin.sample.taskflow.core.Route
+import org.reduxkotlin.sample.taskflow.db.TaskFlowDb
+import org.reduxkotlin.sample.taskflow.feature.board.FilterModel
+import org.reduxkotlin.sample.taskflow.feature.board.SetFilterQuery
+import org.reduxkotlin.sample.taskflow.infra.SeedData
+import org.reduxkotlin.sample.taskflow.infra.data.local.LocalStore
+import org.reduxkotlin.sample.taskflow.infra.data.local.SqlDelightLocalStore
+import org.reduxkotlin.sample.taskflow.infra.db.taskFlowDb
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UiSnapshotStoreTest {
+
+    private val annId = AccountId("ann")
+
+    private fun newLocal(): LocalStore {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        TaskFlowDb.Schema.synchronous().create(driver)
+        return SqlDelightLocalStore(taskFlowDb(driver))
+    }
+
+    // Mirrors AccountRegistryTest's construction (test rootStore + in-memory LocalStore + inline
+    // notification), but builds the per-account store directly so the test can drive it and snapshot
+    // its live NavModel/FilterModel under virtual time.
+    private fun newAccountStore(scope: CoroutineScope) = createAccountStore(
+        detail = SeedData.accountDetail(annId),
+        rootStore = createAppStore(NotificationContext.Inline),
+        localStore = newLocal(),
+        notificationContext = NotificationContext.Inline,
+        scope = scope,
+    ).store
+
+    @Test
+    fun snapshot_round_trips_nav_and_filter_through_a_live_store() = runTest {
+        // Account stores launch long-lived sync/effect collectors; run them on backgroundScope so
+        // runTest auto-cancels them at body end (they never complete on their own).
+        val store = newAccountStore(backgroundScope)
+
+        store.dispatch(Navigate(Route.Board(BoardId("b1"))))
+        store.dispatch(SetFilterQuery("hello"))
+
+        val json = encodeUiSnapshot(store)
+
+        val fresh = newAccountStore(backgroundScope)
+        fresh.dispatch(decodeUiSnapshot(json))
+
+        assertEquals(BoardId("b1"), fresh.getModel<NavModel>().activeBoardId)
+        assertEquals("hello", fresh.getModel<FilterModel>().query)
+    }
+}


### PR DESCRIPTION
## Summary
Adds a Compose `rememberSaveable` UI-state persistence layer to the TaskFlow sample, layered on top of the existing SQLDelight durable store. The active account's **volatile** UI — navigation stack + board filter — is snapshotted into the Android `SavedStateRegistry` so it survives **process death** and **configuration changes**. SQLDelight remains the single source of truth for domain data and `activeAccountId`.

Motivated by a review that found TaskFlow's nav state was effectively lost on restart (the `LocalStore.saveNav/loadNav` methods exist but are dead/unwired).

### What's in it
- `app/persistence/UiSnapshot.kt` — `@Serializable` `UiSnapshot`/`RouteDto` DTOs, JSON codec (`encodeUiSnapshot`/`decodeUiSnapshot`), `RestoreUiState` action, live-store bridge, and the `RestoreUiStateEffect` composable (`rememberSaveable` + custom `Saver` + one-shot `RestoreSlot`, restore replayed once from a `LaunchedEffect`).
- `app/AccountStore.kt` — routes `RestoreUiState` inline onto the `NavModel` + `FilterModel` slots (no reducer changes). Extracted `declareBoardModel` to stay under the detekt LongMethod limit (behavior-preserving).
- `app/App.kt` — wires `RestoreUiStateEffect(accountStore, key = activeId)` into `ActiveAccount`.
- `ARCHITECTURE.md` — documents the volatile-UI vs SQLDelight-durable layer split.

### Design decisions
- Snapshot carries **only** nav stack + filter — never `activeAccountId` (SQLDelight owns it; double-sourcing would race the disk load) nor domain data.
- Snapshot read at save time is a lock-free concurrent-store mirror read on the main thread; restore dispatch is off the composition/dispatch path via `LaunchedEffect`.
- `LaunchedEffect` keys on the `RestoreSlot` instance so an in-place `rememberSaveable` restore fires even when `activeId` is unchanged.
- `CardDetail` is restored in **View** mode — Edit holds a transient inline-edit buffer that isn't snapshotted (matches the prior `loadNav` "always restore to view" intent).
- Malformed/empty snapshots fall back to a safe default (`NavModel()` + empty `FilterModel`).

### Out of scope (documented fast-follow)
Eliminating the rotation spinner / avoiding the full per-account store + coroutine rebuild on config change — the manifest has no `android:configChanges`, so the Activity is recreated on rotation. `rememberSaveable` restores the *snapshot* but not the *live store instance*; truly skipping that rebuild needs live-store retention (retained holder / ViewModel), a separate decision.

Plan: `docs/superpowers/plans/2026-06-10-taskflow-saveable-ui-persistence.md`

## Test Plan
- [x] `./gradlew :examples:taskflow:composeApp:jvmTest` — codec round-trip (full stack, ComposeCard, CardDetail View, Edit→View, malformed fallback) + live-store→fresh-store restore. Green.
- [x] `./gradlew detektAll` — green.
- [x] `compileKotlinJvm` + `compileAndroidMain` — green.
- [ ] **Manual (device):** enable Don't-Keep-Activities (or `adb shell am kill org.reduxkotlin.sample.taskflow` while backgrounded); open a board → card → set a filter → background → return; verify board + card (View) + filter restored, not reset to the board list. Also verify rotation preserves nav + filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)