### PR TITLE
feat(taskflow): adopt library saveable persistence + lag-free bindings + coalescing notify

### DIFF
--- a/docs/superpowers/plans/2026-06-10-taskflow-saveable-library-integration.md
+++ b/docs/superpowers/plans/2026-06-10-taskflow-saveable-library-integration.md
@@ -1,0 +1,363 @@
+# TaskFlow — adopt the saveable/binding APIs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`).
+
+**Goal:** Re-implement TaskFlow's volatile-UI persistence on the new library APIs (replacing #331's hand-rolled approach): `StateSaver` + `Store.rememberSaveableState` (now flash-free via Solution 1), `coalescingNotificationContext`, and the lag-free bindings — and remove dead/legacy paths.
+
+**Architecture:** Per-account nav+filter persist via a single `StateSaver<ModelState, UiSnapshot>` and one `accountStore.rememberSaveableState(accountUiSaver, key="account-ui-<id>")` in `ActiveAccount`. The library applies the restore synchronously in composition (Solution 1) → no flash. `mainNotificationContext` actuals use `coalescingNotificationContext` (inline on main, else post) → no async-notify lag for any subscriber. The root store keeps a `booted` gate + a plain lag-free `fieldStateOf` for `activeAccountId` (durable in SQLDelight, single-sourced). CardDetail draft survives via `rememberSaveable`. Dead `saveNav`/`loadNav` removed.
+
+**Tech Stack:** redux-kotlin-compose-saveable (`StateSaver`, `rememberSaveableState`), redux-kotlin-concurrent (`coalescingNotificationContext`), lag-free `fieldStateOf`/`selectorState`, kotlinx.serialization. All already available via `redux-kotlin-bundle-compose` (already a dep). Branch `feat/taskflow-saveable-integration` stacked on `feat/concurrent-binding-consistency` (PR #332). examples/taskflow = `convention.control` (no apiDump/explicitApi gate, but detekt KDoc still applies to public decls — keep new symbols `internal`).
+
+**Verified facts:**
+- `StateSaver<S, Snapshot>(serializer, save: (S)->Snapshot, restore: (Snapshot)->Any, json=Json)`. `Store<S>.rememberSaveableState(saver, key: String?=null)` — restores synchronously in composition (Solution 1), registers save provider.
+- `coalescingNotificationContext(isOnTargetThread: ()->Boolean, post: (()->Unit)->Unit): NotificationContext` (redux-kotlin-concurrent).
+- `ModelState.get<reified M>()` reads a slot (throws if undeclared). Routing: `model(NavModel()) { on<A> { s,a -> ... } }`.
+- `Route` (core/AccountEntities.kt): BoardList/Profile/Settings (data object), Board(boardId: BoardId), CardDetail(cardId: CardId, mode: Mode{View,Edit}), ComposeCard(columnId: ColumnId). Ids: `value class X(val v: String)`.
+- `NavModel(stack: PersistentList<Route>)`; `FilterModel(query: String, assignee: AccountId?, labelIds: PersistentSet<LabelId>)`.
+- Current actuals: Android `Handler.post` (always), iOS `dispatch_async` (always), JVM coalesces manually (EDT), wasmJs inline.
+- `saveNav`/`loadNav` defined in LocalStore + SqlDelightLocalStore + re-exposed in SyncRepository, but UNUSED — verify then remove.
+
+---
+
+### Task 1: coalescing NotificationContext actuals
+
+**Files:** Modify the 4 `Notification.<platform>.kt` actuals under `examples/taskflow/composeApp/src/{androidMain,iosMain,jvmMain,wasmJsMain}/.../infra/platform/`.
+
+- [ ] **Step 1: Android** — replace body with:
+```kotlin
+public actual fun mainNotificationContext(): NotificationContext {
+    val handler = Handler(Looper.getMainLooper())
+    return coalescingNotificationContext(
+        isOnTargetThread = { Looper.myLooper() == Looper.getMainLooper() },
+        post = { block -> handler.post(block) },
+    )
+}
+```
+Add import `org.reduxkotlin.concurrent.coalescingNotificationContext`. Update KDoc to mention inline-on-main.
+
+- [ ] **Step 2: iOS** — replace body with:
+```kotlin
+public actual fun mainNotificationContext(): NotificationContext = coalescingNotificationContext(
+    isOnTargetThread = { NSThread.isMainThread() },
+    post = { block -> dispatch_async(dispatch_get_main_queue()) { block() } },
+)
+```
+Add imports `platform.Foundation.NSThread` and `org.reduxkotlin.concurrent.coalescingNotificationContext` (keep the darwin imports). Update KDoc.
+
+- [ ] **Step 3: JVM** — refactor the manual coalesce to the helper:
+```kotlin
+public actual fun mainNotificationContext(): NotificationContext = coalescingNotificationContext(
+    isOnTargetThread = { SwingUtilities.isEventDispatchThread() },
+    post = { block -> SwingUtilities.invokeLater(block) },
+)
+```
+Add import. (wasmJs stays inline — no change.)
+
+- [ ] **Step 4: Compile**
+Run: `./gradlew :examples:taskflow:composeApp:compileKotlinJvm` → BUILD SUCCESSFUL. If Android SDK present: `:examples:taskflow:composeApp:compileAndroidMain`. iOS: `:examples:taskflow:composeApp:compileKotlinIosSimulatorArm64` (host-gated; if it fails on SDK env, report, don't treat as code failure).
+Run: `./gradlew detektAll` → clean.
+
+- [ ] **Step 5: Commit**
+```bash
+git add examples/taskflow/composeApp/src/androidMain examples/taskflow/composeApp/src/iosMain examples/taskflow/composeApp/src/jvmMain
+git commit -m "refactor(taskflow): main NotificationContext via coalescingNotificationContext (inline on main)"
+```
+
+---
+
+### Task 2: StateSaver + UiSnapshot codec + RestoreUiState routing
+
+**Files:**
+- Create: `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt`
+- Modify: `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt` (route `RestoreUiState`)
+- Test: `examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotSaverTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+```kotlin
+package org.reduxkotlin.sample.taskflow.app.persistence
+
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
+import org.reduxkotlin.sample.taskflow.core.AccountId
+import org.reduxkotlin.sample.taskflow.core.BoardId
+import org.reduxkotlin.sample.taskflow.core.CardId
+import org.reduxkotlin.sample.taskflow.core.LabelId
+import org.reduxkotlin.sample.taskflow.core.NavModel
+import org.reduxkotlin.sample.taskflow.core.Route
+import org.reduxkotlin.sample.taskflow.feature.board.FilterModel
+import org.reduxkotlin.multimodel.ModelState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class UiSnapshotSaverTest {
+    @Test
+    fun saverRoundTripsNavAndFilterThroughJson() {
+        val nav = NavModel(persistentListOf(Route.BoardList, Route.Board(BoardId("b1")), Route.CardDetail(CardId("c9"))))
+        val filter = FilterModel(query = "urgent", assignee = AccountId("a3"), labelIds = persistentSetOf(LabelId("l1")))
+        val ms = ModelState.of(nav, filter)
+
+        val snap = accountUiSaver.save(ms)
+        val json = accountUiSaver.json.encodeToString(accountUiSaver.serializer, snap)
+        val decoded = accountUiSaver.json.decodeFromString(accountUiSaver.serializer, json)
+        val action = accountUiSaver.restore(decoded) as RestoreUiState
+
+        assertEquals(BoardId("b1"), action.nav.activeBoardId)
+        assertEquals("urgent", action.filter.query)
+        assertEquals(AccountId("a3"), action.filter.assignee)
+    }
+
+    @Test
+    fun cardDetailRestoresInViewMode() {
+        val nav = NavModel(persistentListOf(Route.BoardList, Route.Board(BoardId("b1")), Route.CardDetail(CardId("c9"), Route.CardDetail.Mode.Edit)))
+        val ms = ModelState.of(nav, FilterModel())
+        val action = accountUiSaver.restore(accountUiSaver.save(ms)) as RestoreUiState
+        val top = action.nav.stack.last()
+        assertTrue(top is Route.CardDetail && top.mode == Route.CardDetail.Mode.View)
+    }
+}
+```
+(`ModelState.of(nav, filter)` builds a 2-slot state; `accountUiSaver.save` reads those slots.)
+
+- [ ] **Step 2: Run; expect FAIL**
+`./gradlew :examples:taskflow:composeApp:jvmTest --tests "*UiSnapshotSaverTest"` → FAIL (unresolved `accountUiSaver`/`RestoreUiState`).
+
+- [ ] **Step 3: Create UiSnapshot.kt**
+```kotlin
+package org.reduxkotlin.sample.taskflow.app.persistence
+
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentSet
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.reduxkotlin.compose.saveable.StateSaver
+import org.reduxkotlin.multimodel.ModelState
+import org.reduxkotlin.sample.taskflow.core.AccountId
+import org.reduxkotlin.sample.taskflow.core.Action
+import org.reduxkotlin.sample.taskflow.core.BoardId
+import org.reduxkotlin.sample.taskflow.core.CardId
+import org.reduxkotlin.sample.taskflow.core.ColumnId
+import org.reduxkotlin.sample.taskflow.core.LabelId
+import org.reduxkotlin.sample.taskflow.core.NavModel
+import org.reduxkotlin.sample.taskflow.core.Route
+import org.reduxkotlin.sample.taskflow.feature.board.FilterModel
+
+/** Action that replays a restored [UiSnapshot]; routed onto the NavModel + FilterModel slots. */
+internal data class RestoreUiState(val nav: NavModel, val filter: FilterModel) : Action
+
+/** Serializable mirror of [Route] (value-class ids flattened to `.v` strings). */
+@Serializable
+internal sealed interface RouteDto {
+    /** @see Route.BoardList */
+    @Serializable @SerialName("boardList") data object BoardList : RouteDto
+
+    /** @see Route.Board */
+    @Serializable @SerialName("board") data class Board(val boardId: String) : RouteDto
+
+    /** @see Route.Profile */
+    @Serializable @SerialName("profile") data object Profile : RouteDto
+
+    /** @see Route.Settings */
+    @Serializable @SerialName("settings") data object Settings : RouteDto
+
+    /** @see Route.CardDetail — edit mode is intentionally not persisted (always restores to View). */
+    @Serializable @SerialName("cardDetail") data class CardDetail(val cardId: String) : RouteDto
+
+    /** @see Route.ComposeCard */
+    @Serializable @SerialName("composeCard") data class ComposeCard(val columnId: String) : RouteDto
+}
+
+/** Serializable volatile-UI snapshot of the active account: nav stack + filter only. */
+@Serializable
+internal data class UiSnapshot(
+    val stack: List<RouteDto>,
+    val filterQuery: String,
+    val filterAssignee: String?,
+    val filterLabelIds: List<String>,
+)
+
+private fun Route.toDto(): RouteDto = when (this) {
+    is Route.BoardList -> RouteDto.BoardList
+    is Route.Board -> RouteDto.Board(boardId.v)
+    is Route.Profile -> RouteDto.Profile
+    is Route.Settings -> RouteDto.Settings
+    is Route.CardDetail -> RouteDto.CardDetail(cardId.v)
+    is Route.ComposeCard -> RouteDto.ComposeCard(columnId.v)
+}
+
+private fun RouteDto.toRoute(): Route = when (this) {
+    is RouteDto.BoardList -> Route.BoardList
+    is RouteDto.Board -> Route.Board(BoardId(boardId))
+    is RouteDto.Profile -> Route.Profile
+    is RouteDto.Settings -> Route.Settings
+    is RouteDto.CardDetail -> Route.CardDetail(CardId(cardId), Route.CardDetail.Mode.View)
+    is RouteDto.ComposeCard -> Route.ComposeCard(ColumnId(columnId))
+}
+
+/**
+ * The per-account volatile-UI saver (nav stack + board filter). One stateless instance, reused across
+ * accounts. Restore overlays the saved nav/filter via a [RestoreUiState] action; CardDetail restores
+ * in View mode. The library applies restore synchronously in composition, so there is no stale frame.
+ */
+internal val accountUiSaver: StateSaver<ModelState, UiSnapshot> = StateSaver(
+    serializer = UiSnapshot.serializer(),
+    save = { ms ->
+        val nav = ms.get<NavModel>()
+        val filter = ms.get<FilterModel>()
+        UiSnapshot(
+            stack = nav.stack.map { it.toDto() },
+            filterQuery = filter.query,
+            filterAssignee = filter.assignee?.v,
+            filterLabelIds = filter.labelIds.map { it.v },
+        )
+    },
+    restore = { snap ->
+        val stack = snap.stack.map { it.toRoute() }.toPersistentList()
+        val nav = if (stack.isEmpty()) NavModel() else NavModel(stack)
+        val filter = FilterModel(
+            query = snap.filterQuery,
+            assignee = snap.filterAssignee?.let { AccountId(it) },
+            labelIds = snap.filterLabelIds.map { LabelId(it) }.toPersistentSet(),
+        )
+        RestoreUiState(nav, filter)
+    },
+    json = Json { classDiscriminator = "t" },
+)
+```
+
+- [ ] **Step 4: Route RestoreUiState in AccountStore.kt**
+Add import `org.reduxkotlin.sample.taskflow.app.persistence.RestoreUiState`. In `declareAccountModels`, in the `model(NavModel()) { ... }` block add `on<RestoreUiState> { _, a -> a.nav }`, and in `model(FilterModel()) { ... }` add `on<RestoreUiState> { _, a -> a.filter }`. (If adding lines pushes `declareAccountModels` past the detekt LongMethod limit, extract a helper as needed.)
+
+- [ ] **Step 5: Run + detekt**
+`./gradlew :examples:taskflow:composeApp:jvmTest --tests "*UiSnapshotSaverTest"` → PASS.
+`./gradlew detektAll` → clean.
+
+- [ ] **Step 6: Commit**
+```bash
+git add examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotSaverTest.kt
+git commit -m "feat(taskflow): per-account UI StateSaver (nav+filter) + RestoreUiState routing"
+```
+
+---
+
+### Task 3: Wire rememberSaveableState + booted gate + lag-free activeId (App.kt)
+
+**Files:** Modify `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt`.
+
+- [ ] **Step 1: ActiveAccount** — read it first. After `val accountStore = handle.store` and BEFORE `val nav by ...fieldStateOf(NavModel::class)`, add:
+```kotlin
+    // Persist + restore this account's volatile UI (nav + filter) across process death / config change.
+    // The library applies the restore synchronously in composition (before the nav read below), so the
+    // first frame already shows the restored stack. Account-scoped key: the default composite key would
+    // collide across accounts at this same call site.
+    accountStore.rememberSaveableState(accountUiSaver, key = "account-ui-${activeId.v}")
+```
+Add imports `org.reduxkotlin.compose.saveable.rememberSaveableState` and `org.reduxkotlin.sample.taskflow.app.persistence.accountUiSaver`.
+
+- [ ] **Step 2: AppShell booted gate + lag-free activeId** — read AppShell. Add a `booted` flag set after the bootstrap dispatch, gate the first paint, and read activeId via a plain (now lag-free) `fieldStateOf`:
+```kotlin
+    var booted by remember(localStore) { mutableStateOf(false) }
+    LaunchedEffect(localStore) {
+        localStore.ensureSeeded()
+        val activeId = localStore.loadActiveAccountId()
+        val accounts = localStore.loadAccounts()
+        appStore.dispatch(LoadAccountsSucceeded(accounts, activeId))
+        booted = true
+    }
+    val theme by rememberStableStore(appStore).value.fieldStateOf(AppSettingsModel::class) { it.theme }
+    val activeId by rememberStableStore(appStore).value.fieldStateOf(AccountsModel::class) { it.activeAccountId }
+    // ... inside the root Surface:
+    when {
+        !booted -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
+        activeId == null -> LoginScreen(appStore)
+        else -> {
+            LaunchedEffect(activeId) { localStore.saveActiveAccountId(activeId!!) }
+            ActiveAccount(appStore = appStore, registry = registry, activeId = activeId!!)
+        }
+    }
+```
+Match the existing AppShell structure exactly (theme/Surface/CompositionLocalProvider). The lag-free `fieldStateOf` + coalescing context mean `activeId` is current right after the dispatch; the `booted` gate only covers the disk-load window (no Login flash). Keep `Box`/`CircularProgressIndicator`/`Alignment`/`Modifier.fillMaxSize` imports (already used by the splash branch).
+
+- [ ] **Step 3: Compile**
+`./gradlew :examples:taskflow:composeApp:compileKotlinJvm` → BUILD SUCCESSFUL. `./gradlew detektAll` → clean.
+
+- [ ] **Step 4: Commit**
+```bash
+git add examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt
+git commit -m "feat(taskflow): rememberSaveableState restore + booted gate + lag-free activeId"
+```
+
+---
+
+### Task 4: CardDetail create-draft survives via rememberSaveable
+
+**Files:** Modify `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/CardDetailScreen.kt` (the `CreateMode` composable).
+
+- [ ] **Step 1** — read `CreateMode`. Change the two draft fields from `remember` to `rememberSaveable`:
+```kotlin
+    var title by rememberSaveable { mutableStateOf("") }
+    var description by rememberSaveable { mutableStateOf("") }
+```
+Add import `androidx.compose.runtime.saveable.rememberSaveable`. Update the KDoc/comment to note the draft rides the SavedStateRegistry (Rule C still holds — keystrokes stay local).
+
+- [ ] **Step 2: Compile + detekt**
+`./gradlew :examples:taskflow:composeApp:compileKotlinJvm` → SUCCESSFUL. `./gradlew detektAll` → clean.
+
+- [ ] **Step 3: Commit**
+```bash
+git add examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/CardDetailScreen.kt
+git commit -m "feat(taskflow): persist new-card draft via rememberSaveable"
+```
+
+---
+
+### Task 5: Remove dead saveNav/loadNav
+
+**Files:** `infra/data/local/LocalStore.kt`, `infra/data/local/SqlDelightLocalStore.kt`, `infra/data/sync/SyncRepository.kt` (and the SQLDelight `.sq` query if `selectNav`/`upsertNav` exist only for this).
+
+- [ ] **Step 1: Verify dead** — run `grep -rn "saveNav\|loadNav" examples/taskflow/composeApp/src` and confirm the ONLY occurrences are the declarations/impls + the SyncRepository pass-throughs, with NO real callers. If anything calls them, STOP and report (do not remove).
+
+- [ ] **Step 2: Remove** the `saveNav`/`loadNav` from the `LocalStore` interface, their `override` impls in `SqlDelightLocalStore`, and the pass-throughs in `SyncRepository`. If the `.sq` file has `selectNav`/`upsertNav`/an `account_nav` table used ONLY by these (verify via grep), leave the table (data) but remove now-unused generated query usages only if they cause unused warnings; prefer minimal removal — do not drop the table/migration. Keep `ROUTE_*` constants only if still referenced.
+
+- [ ] **Step 3: Compile + test**
+`./gradlew :examples:taskflow:composeApp:compileKotlinJvm :examples:taskflow:composeApp:jvmTest` → SUCCESSFUL. `./gradlew detektAll` → clean.
+
+- [ ] **Step 4: Commit**
+```bash
+git add -A examples/taskflow/composeApp/src
+git commit -m "chore(taskflow): remove dead saveNav/loadNav (superseded by saveable UI persistence)"
+```
+
+---
+
+### Task 6: Docs + full gate + on-device verification
+
+**Files:** `examples/taskflow/ARCHITECTURE.md`.
+
+- [ ] **Step 1: Docs** — update the persistence section: volatile UI (nav+filter) now persists via `redux-kotlin-compose-saveable` (`StateSaver` + `rememberSaveableState`, account-scoped key) with synchronous restore (no flash); main-thread notifications via `coalescingNotificationContext`; `activeAccountId`/domain stay in SQLDelight; CardDetail Edit restores as View; new-card draft via `rememberSaveable`.
+
+- [ ] **Step 2: Full gate**
+`./gradlew :examples:taskflow:composeApp:jvmTest` → PASS. `./gradlew detektAll` → PASS. `./gradlew :examples:taskflow:composeApp:compileKotlinJvm` (+ `compileAndroidMain` if SDK present) → SUCCESSFUL.
+
+- [ ] **Step 3: On-device verification (Android emulator/device)**
+Build + install: `./gradlew :examples:taskflow:androidApp:installDebug`.
+Verify the full restore matrix (toggle bot OFF in Settings first):
+  1. Open a board → drill into a card → set a filter query → background → `adb shell am kill org.reduxkotlin.sample.taskflow` → reopen. Expect: spinner → restored screen (board + card in **View** + filter), NO Login/board-list/board-detail flash.
+  2. Add-card draft: open add-card, type a title + description → background → `am kill` → reopen. Expect: add-card with the typed draft restored.
+  3. Cold start (fresh) still shows board list (no crash).
+Capture logcat/screens as needed. Report what was observed.
+
+- [ ] **Step 4: Commit + finish**
+```bash
+git add examples/taskflow/ARCHITECTURE.md
+git commit -m "docs(taskflow): document library-based saveable UI persistence"
+```
+
+---
+
+## Self-Review
+- Coalescing notify (A) → Task 1. StateSaver+routing (B core) → Task 2. rememberSaveableState placement + booted gate + lag-free activeId cleanup → Task 3. Draft → Task 4. Dead-code cleanup → Task 5. Docs+gate+device → Task 6.
+- No new published-module API (TaskFlow is convention.control). Library deps already present via redux-kotlin-bundle-compose.
+- Flash-free guaranteed by Solution 1 (sync restore) + lag-free bindings + coalescing context — verified on device in Task 6.
+- Types: `accountUiSaver: StateSaver<ModelState, UiSnapshot>`, `RestoreUiState(nav, filter)` consistent across Tasks 2/3. Key `"account-ui-${activeId.v}"` in Task 3.

--- a/examples/taskflow/ARCHITECTURE.md
+++ b/examples/taskflow/ARCHITECTURE.md
@@ -625,6 +625,28 @@ erDiagram
   account ||--o{ pending_op : queues
 ```
 
+### Volatile UI persistence (`redux-kotlin-compose-saveable`)
+
+Domain data and `activeAccountId` are durable in SQLDelight — the single source of truth.
+The active account's *volatile* UI state (nav stack + board filter) persists across process
+death via `redux-kotlin-compose-saveable`:
+
+- A single `accountUiSaver: StateSaver<ModelState, UiSnapshot>` (`app/persistence/UiSnapshot.kt`)
+  maps the relevant `ModelState` slots to a `@Parcelize` / `@Serializable` snapshot.
+- `ActiveAccount` calls `accountStore.rememberSaveableState(accountUiSaver, key = "account-ui-<id>")`.
+  The library restores the snapshot **synchronously during composition** (before the nav
+  binding reads the stack), so the correct route is present on the first frame — no flash
+  or one-frame-wrong-screen.
+- Restore overlays the nav stack and filter via a `RestoreUiState` action routed onto those
+  slots. `CardDetail` always restores in **View** mode (Edit is transient UI state, Rule C).
+- The new-card draft survives via plain `rememberSaveable` (Compose-local, no store
+  involvement — Rule C).
+- `AppShell` gates the first paint behind a `booted` flag until the account directory loads
+  from SQLDelight, preventing a Login-screen flash for returning users. `activeAccountId` is
+  read via `fieldStateOf` (lock-free, lag-free).
+- Subscriber callbacks use `coalescingNotificationContext` (inline when already on main,
+  otherwise posts to main) so bindings never lag a dispatch.
+
 ---
 
 ## 12. The bot collaborator

--- a/examples/taskflow/composeApp/src/androidMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/Notification.android.kt
+++ b/examples/taskflow/composeApp/src/androidMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/Notification.android.kt
@@ -3,14 +3,18 @@ package org.reduxkotlin.sample.taskflow.infra.platform
 import android.os.Handler
 import android.os.Looper
 import org.reduxkotlin.concurrent.NotificationContext
+import org.reduxkotlin.concurrent.coalescingNotificationContext
 
 /**
- * Android [mainNotificationContext]: posts subscriber callbacks to the main looper so they run
- * on the UI thread.
+ * Android [mainNotificationContext]: runs callbacks inline when already on the main looper,
+ * else posts — avoids a stale frame for main-thread dispatches.
  *
  * @return a [NotificationContext] backed by a main-[Looper] [Handler].
  */
 public actual fun mainNotificationContext(): NotificationContext {
     val handler = Handler(Looper.getMainLooper())
-    return NotificationContext { block -> handler.post(block) }
+    return coalescingNotificationContext(
+        isOnTargetThread = { Looper.myLooper() == Looper.getMainLooper() },
+        post = { block -> handler.post(block) },
+    )
 }

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/AccountStore.kt
@@ -23,7 +23,9 @@ import org.reduxkotlin.sample.taskflow.app.nav.EnterEditMode
 import org.reduxkotlin.sample.taskflow.app.nav.Navigate
 import org.reduxkotlin.sample.taskflow.app.nav.OpenCard
 import org.reduxkotlin.sample.taskflow.app.nav.navReducer
+import org.reduxkotlin.sample.taskflow.app.persistence.RestoreUiState
 import org.reduxkotlin.sample.taskflow.core.AccountDetail
+import org.reduxkotlin.sample.taskflow.core.AccountId
 import org.reduxkotlin.sample.taskflow.core.AddCard
 import org.reduxkotlin.sample.taskflow.core.AppSettingsModel
 import org.reduxkotlin.sample.taskflow.core.CardMoveRequested
@@ -203,6 +205,7 @@ private fun RoutingBuilder.declareAccountModels(detail: AccountDetail) {
         on<CloseCard> { s, a -> navReducer(s, a) }
         on<StartCreateCard> { s, a -> navReducer(s, a) }
         on<CancelCreateCard> { s, a -> navReducer(s, a) }
+        on<RestoreUiState> { _, a -> a.nav }
     }
     model(BoardListModel()) {
         on<LoadBoardListSucceeded> { s, a -> boardListReducer(s, a) }
@@ -211,6 +214,16 @@ private fun RoutingBuilder.declareAccountModels(detail: AccountDetail) {
     model(CollaboratorsModel(seedCollaborators(detail))) {
         on<EditProfile> { s, a -> collaboratorsReducer(s, a, selfId) }
     }
+    declareBoardModels(selfId)
+}
+
+/**
+ * Declares the board-side model slots: [BoardModel], [FilterModel], [UndoModel], [SyncModel], and
+ * [ActivityModel]. Extracted to keep [declareAccountModels] within the line-length budget.
+ *
+ * @param selfId the owning account; forwarded to reducers that need it.
+ */
+private fun RoutingBuilder.declareBoardModels(selfId: AccountId) {
     model(BoardModel()) {
         on<LoadBoardSucceeded> { s, a -> boardReducer(s, a, selfId) }
         on<CardMoveRequested> { s, a -> boardReducer(s, a, selfId) }
@@ -229,6 +242,7 @@ private fun RoutingBuilder.declareAccountModels(detail: AccountDetail) {
         on<SetFilterAssignee> { s, a -> filterReducer(s, a) }
         on<ToggleFilterLabel> { s, a -> filterReducer(s, a) }
         on<BoardClosed> { s, a -> filterReducer(s, a) }
+        on<RestoreUiState> { _, a -> a.filter }
     }
     model(UndoModel()) {
         on<PushUndo> { s, a -> undoModelReducer(s, a) }

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt
@@ -3,7 +3,9 @@ package org.reduxkotlin.sample.taskflow.app
 import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
@@ -22,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.window.Dialog
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.coroutines.delay
@@ -144,6 +147,19 @@ private fun AppShell(appStore: Store<ModelState>, localStore: LocalStore) {
     val theme by rememberStableStore(appStore).value.fieldStateOf(AppSettingsModel::class) { it.theme }
     val activeId by rememberStableStore(appStore).value.fieldStateOf(AccountsModel::class) { it.activeAccountId }
 
+    // Hold the first content paint until the window insets have been dispatched. On a process-death
+    // restore the OS delivers `systemBars` insets a frame AFTER the first composition, so edge-to-edge
+    // content (e.g. the restored add-card screen) would draw once at inset 0 and then snap down when
+    // the status-bar inset resolves. Latch on the first non-zero status-bar inset; a short fallback
+    // covers configs with no status bar (desktop / some landscape) so the splash can never hang.
+    val statusBarTop = WindowInsets.systemBars.getTop(LocalDensity.current)
+    var insetsReady by remember(localStore) { mutableStateOf(false) }
+    LaunchedEffect(statusBarTop) { if (statusBarTop > 0) insetsReady = true }
+    LaunchedEffect(localStore) {
+        delay(INSETS_DISPATCH_FALLBACK_MS)
+        insetsReady = true
+    }
+
     TaskFlowTheme(theme = theme) {
         CompositionLocalProvider(
             LocalIdGenerator provides DefaultIdGenerator(),
@@ -159,9 +175,10 @@ private fun AppShell(appStore: Store<ModelState>, localStore: LocalStore) {
             Surface(modifier = Modifier.fillMaxSize()) {
                 val id = activeId
                 when {
-                    !booted -> Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        CircularProgressIndicator()
-                    }
+                    !booted || !insetsReady ->
+                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator()
+                        }
 
                     id == null -> LoginScreen(appStore)
 
@@ -404,6 +421,9 @@ private fun OverlayWithPredictiveBack(
 }
 
 private enum class PredictiveBackKind { Pop, ModeFlip }
+
+/** Fallback wait before revealing content if no status-bar inset ever arrives (insetless configs). */
+private const val INSETS_DISPATCH_FALLBACK_MS = 150L
 
 private const val OVERLAY_BACK_SCALE = 0.05f
 private const val OVERLAY_BACK_ALPHA = 0.4f

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt
@@ -30,12 +30,14 @@ import kotlinx.coroutines.launch
 import org.reduxkotlin.Store
 import org.reduxkotlin.compose.multimodel.fieldStateOf
 import org.reduxkotlin.compose.rememberStableStore
+import org.reduxkotlin.compose.saveable.rememberSaveableState
 import org.reduxkotlin.devtools.inapp.InAppConfig
 import org.reduxkotlin.devtools.inapp.ReduxDevToolsHost
 import org.reduxkotlin.multimodel.ModelState
 import org.reduxkotlin.sample.taskflow.app.nav.AdaptiveNav
 import org.reduxkotlin.sample.taskflow.app.nav.Back
 import org.reduxkotlin.sample.taskflow.app.nav.Navigate
+import org.reduxkotlin.sample.taskflow.app.persistence.accountUiSaver
 import org.reduxkotlin.sample.taskflow.core.AccountId
 import org.reduxkotlin.sample.taskflow.core.AppSettingsModel
 import org.reduxkotlin.sample.taskflow.core.BoardId
@@ -126,6 +128,9 @@ public fun App() {
 @Composable
 private fun AppShell(appStore: Store<ModelState>, localStore: LocalStore) {
     val registry = remember(localStore) { AccountRegistry(appStore, localStore) }
+    // Gate the first paint until the account directory is loaded — otherwise the read below sees
+    // the empty initial AccountsModel and flashes Login during the disk read.
+    var booted by remember(localStore) { mutableStateOf(false) }
 
     // Bootstrap once: ensure seed data, then rehydrate the account directory + active id (§13e).
     LaunchedEffect(localStore) {
@@ -133,6 +138,7 @@ private fun AppShell(appStore: Store<ModelState>, localStore: LocalStore) {
         val activeId = localStore.loadActiveAccountId()
         val accounts = localStore.loadAccounts()
         appStore.dispatch(LoadAccountsSucceeded(accounts, activeId))
+        booted = true
     }
 
     val theme by rememberStableStore(appStore).value.fieldStateOf(AppSettingsModel::class) { it.theme }
@@ -152,12 +158,18 @@ private fun AppShell(appStore: Store<ModelState>, localStore: LocalStore) {
             // root or insets would be applied twice.
             Surface(modifier = Modifier.fillMaxSize()) {
                 val id = activeId
-                if (id == null) {
-                    LoginScreen(appStore)
-                } else {
-                    // Persist the active account id for process-death rehydration (§13e).
-                    LaunchedEffect(id) { localStore.saveActiveAccountId(id) }
-                    ActiveAccount(appStore = appStore, registry = registry, activeId = id)
+                when {
+                    !booted -> Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+
+                    id == null -> LoginScreen(appStore)
+
+                    else -> {
+                        // Persist the active account id for process-death rehydration (§13e).
+                        LaunchedEffect(id) { localStore.saveActiveAccountId(id) }
+                        ActiveAccount(appStore = appStore, registry = registry, activeId = id)
+                    }
                 }
             }
         }
@@ -180,6 +192,12 @@ private fun AppShell(appStore: Store<ModelState>, localStore: LocalStore) {
 private fun ActiveAccount(appStore: Store<ModelState>, registry: AccountRegistry, activeId: AccountId) {
     val handle = remember(activeId) { registry.getOrCreate(activeId, SeedData.accountDetail(activeId)) }
     val accountStore = handle.store
+
+    // Persist + restore this account's volatile UI (nav + filter) across process death / config change.
+    // The library applies the restore synchronously in composition (before the nav read below), so the
+    // first frame already shows the restored stack. Account-scoped key — the default composite key
+    // collides across accounts at this same call site.
+    accountStore.rememberSaveableState(accountUiSaver, key = "account-ui-${activeId.v}")
 
     val nav by rememberStableStore(accountStore).value.fieldStateOf(NavModel::class) { it }
 

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt
@@ -1,0 +1,147 @@
+package org.reduxkotlin.sample.taskflow.app.persistence
+
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentSet
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.reduxkotlin.compose.saveable.StateSaver
+import org.reduxkotlin.multimodel.ModelState
+import org.reduxkotlin.sample.taskflow.core.AccountId
+import org.reduxkotlin.sample.taskflow.core.Action
+import org.reduxkotlin.sample.taskflow.core.BoardId
+import org.reduxkotlin.sample.taskflow.core.CardId
+import org.reduxkotlin.sample.taskflow.core.ColumnId
+import org.reduxkotlin.sample.taskflow.core.LabelId
+import org.reduxkotlin.sample.taskflow.core.NavModel
+import org.reduxkotlin.sample.taskflow.core.Route
+import org.reduxkotlin.sample.taskflow.feature.board.FilterModel
+
+/**
+ * Action dispatched when a persisted [UiSnapshot] is restored into the account store.
+ * Each model slot's handler replaces its slice with the restored data.
+ *
+ * @property nav restored navigation stack model.
+ * @property filter restored filter model.
+ */
+internal data class RestoreUiState(val nav: NavModel, val filter: FilterModel) : Action
+
+/**
+ * Serializable DTO representing a single navigation destination.
+ * Produced by [Route.toDto] and converted back via [RouteDto.toRoute].
+ *
+ * [CardDetail] always restores in [Route.CardDetail.Mode.View] — the mode field is dropped.
+ */
+@Serializable
+internal sealed class RouteDto {
+
+    /** DTO for [Route.BoardList]. */
+    @Serializable
+    @SerialName("bl")
+    data object BoardList : RouteDto()
+
+    /** DTO for [Route.Profile]. */
+    @Serializable
+    @SerialName("pr")
+    data object Profile : RouteDto()
+
+    /** DTO for [Route.Settings]. */
+    @Serializable
+    @SerialName("se")
+    data object Settings : RouteDto()
+
+    /**
+     * DTO for [Route.Board].
+     *
+     * @property boardId raw board id string.
+     */
+    @Serializable
+    @SerialName("bo")
+    data class Board(val boardId: String) : RouteDto()
+
+    /**
+     * DTO for [Route.CardDetail]. Mode is omitted; restores as [Route.CardDetail.Mode.View].
+     *
+     * @property cardId raw card id string.
+     */
+    @Serializable
+    @SerialName("cd")
+    data class CardDetail(val cardId: String) : RouteDto()
+
+    /**
+     * DTO for [Route.ComposeCard].
+     *
+     * @property columnId raw column id string.
+     */
+    @Serializable
+    @SerialName("cc")
+    data class ComposeCard(val columnId: String) : RouteDto()
+}
+
+/**
+ * Minimal serializable snapshot of per-account UI state: the navigation stack and board filter.
+ *
+ * @property stack list of [RouteDto] entries representing the persisted nav stack.
+ * @property filterQuery persisted search query string.
+ * @property filterAssignee persisted assignee id string, or null.
+ * @property filterLabelIds persisted label id strings.
+ */
+@Serializable
+internal data class UiSnapshot(
+    val stack: List<RouteDto>,
+    val filterQuery: String,
+    val filterAssignee: String?,
+    val filterLabelIds: List<String>,
+)
+
+/** Maps a [Route] to its [RouteDto] counterpart. */
+private fun Route.toDto(): RouteDto = when (this) {
+    is Route.BoardList -> RouteDto.BoardList
+    is Route.Profile -> RouteDto.Profile
+    is Route.Settings -> RouteDto.Settings
+    is Route.Board -> RouteDto.Board(boardId.v)
+    is Route.CardDetail -> RouteDto.CardDetail(cardId.v)
+    is Route.ComposeCard -> RouteDto.ComposeCard(columnId.v)
+}
+
+/** Maps a [RouteDto] back to a [Route]. [RouteDto.CardDetail] always restores as [Route.CardDetail.Mode.View]. */
+private fun RouteDto.toRoute(): Route = when (this) {
+    is RouteDto.BoardList -> Route.BoardList
+    is RouteDto.Profile -> Route.Profile
+    is RouteDto.Settings -> Route.Settings
+    is RouteDto.Board -> Route.Board(BoardId(boardId))
+    is RouteDto.CardDetail -> Route.CardDetail(CardId(cardId), Route.CardDetail.Mode.View)
+    is RouteDto.ComposeCard -> Route.ComposeCard(ColumnId(columnId))
+}
+
+/**
+ * Per-account [StateSaver] that snapshots the [NavModel] stack and [FilterModel] into a
+ * JSON-serializable [UiSnapshot], and restores them via a [RestoreUiState] action.
+ *
+ * [Route.CardDetail] is always restored in [Route.CardDetail.Mode.View] so an interrupted
+ * edit session never re-opens in edit mode.
+ */
+internal val accountUiSaver: StateSaver<ModelState, UiSnapshot> = StateSaver(
+    serializer = UiSnapshot.serializer(),
+    save = { ms ->
+        val nav = ms.get<NavModel>()
+        val filter = ms.get<FilterModel>()
+        UiSnapshot(
+            stack = nav.stack.map { it.toDto() },
+            filterQuery = filter.query,
+            filterAssignee = filter.assignee?.v,
+            filterLabelIds = filter.labelIds.map { it.v },
+        )
+    },
+    restore = { snap ->
+        val stack = snap.stack.map { it.toRoute() }.toPersistentList()
+        val nav = if (stack.isEmpty()) NavModel() else NavModel(stack)
+        val filter = FilterModel(
+            query = snap.filterQuery,
+            assignee = snap.filterAssignee?.let { AccountId(it) },
+            labelIds = snap.filterLabelIds.map { LabelId(it) }.toPersistentSet(),
+        )
+        RestoreUiState(nav, filter)
+    },
+    json = Json { classDiscriminator = "t" },
+)

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/CardDetailScreen.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/board/CardDetailScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -155,15 +156,18 @@ private fun CardDetailContainer(compact: Boolean, content: @Composable () -> Uni
 }
 
 /**
- * Create mode: a blank title field + a [MarkdownEditor] whose text lives in local `remember` (Rule C
- * — keystrokes never touch the store). Save is enabled only when the title is non-blank; it mints a
+ * Create mode: a blank title field + a [MarkdownEditor] whose text lives in [rememberSaveable] (Rule C
+ * — keystrokes never touch the store). The in-progress draft survives process death and config changes
+ * via the SavedStateRegistry. Save is enabled only when the title is non-blank; it mints a
  * fresh card id + op id + clock at the dispatch site, dispatches [AddCard] into the target [columnId],
  * then [CancelCreateCard] to dismiss. Cancel dispatches [CancelCreateCard].
  */
 @Composable
 private fun CreateMode(store: Store<ModelState>, columnId: ColumnId) {
-    var title by remember { mutableStateOf("") }
-    var description by remember { mutableStateOf("") }
+    // rememberSaveable: the in-progress draft rides the SavedStateRegistry so it survives process
+    // death / config change (Rule C still holds — keystrokes stay local, never touch the store).
+    var title by rememberSaveable { mutableStateOf("") }
+    var description by rememberSaveable { mutableStateOf("") }
     val idGen = LocalIdGenerator.current
     val clock = LocalClock.current
 

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/local/LocalStore.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/local/LocalStore.kt
@@ -13,7 +13,6 @@ import org.reduxkotlin.sample.taskflow.core.Card
 import org.reduxkotlin.sample.taskflow.core.CardId
 import org.reduxkotlin.sample.taskflow.core.Column
 import org.reduxkotlin.sample.taskflow.core.ColumnId
-import org.reduxkotlin.sample.taskflow.core.NavModel
 import org.reduxkotlin.sample.taskflow.core.OpId
 import org.reduxkotlin.sample.taskflow.infra.data.remote.RemoteChange
 import org.reduxkotlin.sample.taskflow.infra.data.remote.SyncOp
@@ -45,9 +44,6 @@ public interface LocalStore {
     /** Reassembles the full normalized [Board] for [boardId], or null if absent. */
     public suspend fun loadBoard(boardId: BoardId): Board?
 
-    /** The persisted nav state for [accountId] (defaults if never saved). */
-    public suspend fun loadNav(accountId: AccountId): NavModel
-
     /** Collaborators referenceable on [accountId]'s cards, by id (includes self + bot). */
     public suspend fun loadCollaborators(accountId: AccountId): PersistentMap<AccountId, AccountSummary>
 
@@ -61,9 +57,6 @@ public interface LocalStore {
 
     /** Persists the active [accountId] (or clears it when null). */
     public suspend fun saveActiveAccountId(accountId: AccountId?)
-
-    /** Persists [nav] for [accountId]. */
-    public suspend fun saveNav(accountId: AccountId, nav: NavModel)
 
     /** Moves [cardId] within [boardId] to [toColumn] at [toIndex], re-sequencing the column. */
     public suspend fun moveCard(boardId: BoardId, cardId: CardId, toColumn: ColumnId, toIndex: Int)

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/local/SqlDelightLocalStore.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/local/SqlDelightLocalStore.kt
@@ -5,7 +5,6 @@ import app.cash.sqldelight.async.coroutines.awaitAsOne
 import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.PersistentMap
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 import org.reduxkotlin.sample.taskflow.core.AccountId
@@ -23,9 +22,7 @@ import org.reduxkotlin.sample.taskflow.core.ColumnId
 import org.reduxkotlin.sample.taskflow.core.FakeServiceConfig
 import org.reduxkotlin.sample.taskflow.core.Label
 import org.reduxkotlin.sample.taskflow.core.LabelId
-import org.reduxkotlin.sample.taskflow.core.NavModel
 import org.reduxkotlin.sample.taskflow.core.OpId
-import org.reduxkotlin.sample.taskflow.core.Route
 import org.reduxkotlin.sample.taskflow.core.Theme
 import org.reduxkotlin.sample.taskflow.db.TaskFlowDb
 import org.reduxkotlin.sample.taskflow.infra.SeedData
@@ -39,11 +36,6 @@ private const val ATTACHMENT_KIND_IMAGE = "image"
 private const val ATTACHMENT_KIND_LINK = "link"
 private const val ACTIVITY_LIMIT = 50L
 private const val ARGB_MASK = 0xFFFFFFFFL
-
-private const val ROUTE_BOARD_LIST = "BoardList"
-private const val ROUTE_BOARD = "Board"
-private const val ROUTE_PROFILE = "Profile"
-private const val ROUTE_SETTINGS = "Settings"
 
 /**
  * The durable [LocalStore], backed by the generated SQLDelight [TaskFlowDb]. Instant reads/writes
@@ -132,31 +124,6 @@ public class SqlDelightLocalStore(private val db: TaskFlowDb) : LocalStore {
         return Board(boardId = boardRow.id, columns = columns, cards = cards)
     }
 
-    override suspend fun loadNav(accountId: AccountId): NavModel {
-        val row = q.selectNav(accountId).awaitAsOneOrNull() ?: return NavModel()
-        // Reconstruct the stack from the persisted (route_tag, boardId, openCardId) triple.
-        // Board(id) sits on top of BoardList so back from a board returns to the list (matches the
-        // in-memory navReducer's Navigate(Board) rule). An open card pushes a CardDetail(View) frame.
-        // We do not persist edit mode (always restore to view) or the transient ComposeCard state.
-        val base: PersistentList<Route> = when (row.route) {
-            ROUTE_BOARD ->
-                row.boardId
-                    ?.let { persistentListOf<Route>(Route.BoardList, Route.Board(it)) }
-                    ?: persistentListOf<Route>(Route.BoardList)
-
-            ROUTE_PROFILE -> persistentListOf<Route>(Route.Profile)
-
-            ROUTE_SETTINGS -> persistentListOf<Route>(Route.Settings)
-
-            else -> persistentListOf<Route>(Route.BoardList)
-        }
-        val stack = row.openCardId
-            ?.takeIf { row.route == ROUTE_BOARD && row.boardId != null }
-            ?.let { base.add(Route.CardDetail(it)) }
-            ?: base
-        return NavModel(stack)
-    }
-
     override suspend fun loadCollaborators(accountId: AccountId): PersistentMap<AccountId, AccountSummary> =
         q.selectCollaborators(accountId).awaitAsList()
             .associate { it.id to AccountSummary(it.id, it.displayName, it.email, it.avatarUrl) }
@@ -189,37 +156,6 @@ public class SqlDelightLocalStore(private val db: TaskFlowDb) : LocalStore {
     override suspend fun saveActiveAccountId(accountId: AccountId?) {
         if (q.selectSettings().awaitAsOneOrNull() == null) saveSettings(AppSettingsModel())
         q.setActiveAccountId(accountId)
-    }
-
-    override suspend fun saveNav(accountId: AccountId, nav: NavModel) {
-        // Persist the lowest-level destination (the most-recent TopLevel) + the active board id +
-        // any open card. Card-detail edit mode and the transient ComposeCard are intentionally
-        // dropped — those are session state, not durable nav.
-        val baseTopLevel = nav.stack.last { it is Route.TopLevel } as Route.TopLevel
-        val tag: String
-        val boardId: BoardId?
-        when (baseTopLevel) {
-            is Route.Board -> {
-                tag = ROUTE_BOARD
-                boardId = baseTopLevel.boardId
-            }
-
-            Route.BoardList -> {
-                tag = ROUTE_BOARD_LIST
-                boardId = null
-            }
-
-            Route.Profile -> {
-                tag = ROUTE_PROFILE
-                boardId = null
-            }
-
-            Route.Settings -> {
-                tag = ROUTE_SETTINGS
-                boardId = null
-            }
-        }
-        q.upsertNav(accountId, tag, boardId, nav.openCardId)
     }
 
     override suspend fun moveCard(boardId: BoardId, cardId: CardId, toColumn: ColumnId, toIndex: Int) {

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/sync/SyncRepository.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/data/sync/SyncRepository.kt
@@ -26,7 +26,6 @@ import org.reduxkotlin.sample.taskflow.core.ColumnId
 import org.reduxkotlin.sample.taskflow.core.DeleteCard
 import org.reduxkotlin.sample.taskflow.core.EditCard
 import org.reduxkotlin.sample.taskflow.core.InverseOp
-import org.reduxkotlin.sample.taskflow.core.NavModel
 import org.reduxkotlin.sample.taskflow.core.OpId
 import org.reduxkotlin.sample.taskflow.infra.data.local.LocalStore
 import org.reduxkotlin.sample.taskflow.infra.data.remote.RemoteApi
@@ -198,9 +197,6 @@ public class SyncRepository(
 
     /** Reassembles the full normalized [Board] for [boardId], or null if absent. */
     public suspend fun loadBoard(boardId: BoardId): Board? = local.loadBoard(boardId)
-
-    /** The persisted nav state for [accountId] (defaults if never saved). */
-    public suspend fun loadNav(accountId: AccountId): NavModel = local.loadNav(accountId)
 
     /** The newest-first activity feed for [accountId]. */
     public suspend fun loadActivity(accountId: AccountId): PersistentList<ActivityEntry> = local.loadActivity(accountId)

--- a/examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotSaverTest.kt
+++ b/examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshotSaverTest.kt
@@ -1,0 +1,51 @@
+package org.reduxkotlin.sample.taskflow.app.persistence
+
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
+import org.reduxkotlin.multimodel.ModelState
+import org.reduxkotlin.sample.taskflow.core.AccountId
+import org.reduxkotlin.sample.taskflow.core.BoardId
+import org.reduxkotlin.sample.taskflow.core.CardId
+import org.reduxkotlin.sample.taskflow.core.LabelId
+import org.reduxkotlin.sample.taskflow.core.NavModel
+import org.reduxkotlin.sample.taskflow.core.Route
+import org.reduxkotlin.sample.taskflow.feature.board.FilterModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class UiSnapshotSaverTest {
+    @Test
+    fun saverRoundTripsNavAndFilterThroughJson() {
+        val nav = NavModel(
+            persistentListOf(Route.BoardList, Route.Board(BoardId("b1")), Route.CardDetail(CardId("c9"))),
+        )
+        val filter = FilterModel(
+            query = "urgent",
+            assignee = AccountId("a3"),
+            labelIds = persistentSetOf(LabelId("l1")),
+        )
+        val ms = ModelState.of(nav, filter)
+        val snap = accountUiSaver.save(ms)
+        val json = accountUiSaver.json.encodeToString(accountUiSaver.serializer, snap)
+        val decoded = accountUiSaver.json.decodeFromString(accountUiSaver.serializer, json)
+        val action = accountUiSaver.restore(decoded) as RestoreUiState
+        assertEquals(BoardId("b1"), action.nav.activeBoardId)
+        assertEquals("urgent", action.filter.query)
+        assertEquals(AccountId("a3"), action.filter.assignee)
+    }
+
+    @Test
+    fun cardDetailRestoresInViewMode() {
+        val nav = NavModel(
+            persistentListOf(
+                Route.BoardList,
+                Route.Board(BoardId("b1")),
+                Route.CardDetail(CardId("c9"), Route.CardDetail.Mode.Edit),
+            ),
+        )
+        val action = accountUiSaver.restore(accountUiSaver.save(ModelState.of(nav, FilterModel()))) as RestoreUiState
+        val top = action.nav.stack.last()
+        assertTrue(top is Route.CardDetail && top.mode == Route.CardDetail.Mode.View)
+    }
+}

--- a/examples/taskflow/composeApp/src/iosMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/Notification.ios.kt
+++ b/examples/taskflow/composeApp/src/iosMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/Notification.ios.kt
@@ -1,15 +1,19 @@
 package org.reduxkotlin.sample.taskflow.infra.platform
 
 import org.reduxkotlin.concurrent.NotificationContext
+import org.reduxkotlin.concurrent.coalescingNotificationContext
+import platform.Foundation.NSThread
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 
 /**
- * iOS [mainNotificationContext]: dispatches subscriber callbacks asynchronously onto the
- * main dispatch queue so they run on the UI thread.
+ * iOS [mainNotificationContext]: runs callbacks inline when already on the main thread,
+ * else dispatches asynchronously onto the main queue — avoids a stale frame for
+ * main-thread dispatches.
  *
  * @return a [NotificationContext] backed by the main `dispatch_queue`.
  */
-public actual fun mainNotificationContext(): NotificationContext = NotificationContext { block ->
-    dispatch_async(dispatch_get_main_queue()) { block() }
-}
+public actual fun mainNotificationContext(): NotificationContext = coalescingNotificationContext(
+    isOnTargetThread = { NSThread.isMainThread() },
+    post = { block -> dispatch_async(dispatch_get_main_queue()) { block() } },
+)

--- a/examples/taskflow/composeApp/src/jvmMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/Notification.jvm.kt
+++ b/examples/taskflow/composeApp/src/jvmMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/Notification.jvm.kt
@@ -1,6 +1,7 @@
 package org.reduxkotlin.sample.taskflow.infra.platform
 
 import org.reduxkotlin.concurrent.NotificationContext
+import org.reduxkotlin.concurrent.coalescingNotificationContext
 import javax.swing.SwingUtilities
 
 /**
@@ -12,10 +13,7 @@ import javax.swing.SwingUtilities
  *
  * @return a [NotificationContext] that runs callbacks on the EDT.
  */
-public actual fun mainNotificationContext(): NotificationContext = NotificationContext { block ->
-    if (SwingUtilities.isEventDispatchThread()) {
-        block()
-    } else {
-        SwingUtilities.invokeLater(block)
-    }
-}
+public actual fun mainNotificationContext(): NotificationContext = coalescingNotificationContext(
+    isOnTargetThread = { SwingUtilities.isEventDispatchThread() },
+    post = { block -> SwingUtilities.invokeLater(block) },
+)


### PR DESCRIPTION
## Summary
Re-implements TaskFlow's volatile-UI persistence on the **library** APIs, replacing the hand-rolled approach from #331 (which is superseded — its files never reached master). Leverages every relevant new/merged API and removes dead paths.

**Stacked on #332** (`feat/concurrent-binding-consistency`) — depends on its `coalescingNotificationContext`, lag-free `selectorState`/`fieldState`, and the `rememberSaveableState` synchronous-restore fix (Solution 1, added in #332). Verified on Android emulator.

### What changed
- **`StateSaver` + `rememberSaveableState` (compose-saveable):** one `accountUiSaver: StateSaver<ModelState, UiSnapshot>` (`app/persistence/UiSnapshot.kt`) + a single `accountStore.rememberSaveableState(accountUiSaver, key = "account-ui-<id>")` in `ActiveAccount` (placed before the nav read; restore is applied synchronously in composition by #332's fix → **no flash**). Restore overlays nav/filter via a `RestoreUiState` action routed onto those slots; `CardDetail` restores in **View**.
- **`coalescingNotificationContext`:** Android + iOS `mainNotificationContext` now run subscriber callbacks inline on the main thread (else post); JVM refactored to the same helper. Kills the async-notify lag for all subscribers.
- **Lag-free bindings cleanup:** `AppShell` reads `activeAccountId` via a plain `fieldStateOf` (no manual `getModel` workaround) + a `booted` gate that holds the first paint until the directory loads (no Login flash). `activeAccountId`/domain stay durable in SQLDelight (single source of truth).
- **New-card draft** survives via `rememberSaveable` (Compose-local, Rule C).
- **Removed dead code:** `saveNav`/`loadNav` (LocalStore/SqlDelightLocalStore/SyncRepository) — superseded, zero callers.
- Net −100 lines vs the hand-rolled approach.

### On-device verification (Android emulator)
- **Cold start** → board list, no crash.
- **Process-death restore** (board + filter): set filter "cut", open board, `am kill`, reopen → restored directly to the board with the filter active. **No board-list/Login/board-detail flash** (screenshot in commits).
- **Add-card draft**: typed a title, `am kill`, reopen → restored to the add-card screen with the draft intact.

### Placement rationale (per review)
The `rememberSaveableState` one-liner lives in `ActiveAccount` (the per-account store owner), keyed `"account-ui-<accountId>"` (the default composite key collides across accounts at the same call site). The root store is **not** anchored — its persisted state is durable in SQLDelight.

Supersedes #331 (to be closed). Plan: `docs/superpowers/plans/2026-06-10-taskflow-saveable-library-integration.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)