### PR TITLE
docs: state persistence — website guide refresh, agent reference, taskflow links

### DIFF
--- a/.claude/skills/redux-kotlin/SKILL.md
+++ b/.claude/skills/redux-kotlin/SKILL.md
@@ -32,6 +32,7 @@ companion modules on one `Store<S>` contract. Recommended app organization is **
 | The 5 **platform shims** | [`platform-shims.md`](../../../docs/agent/references/platform-shims.md) |
 | **Modularization** | [`modularization.md`](../../../docs/agent/references/modularization.md) |
 | **Debugging** a running app (actions/state/diffs) | [`devtools.md`](../../../docs/agent/references/devtools.md) |
+| **Persisting/restoring state** (process death, `preloadedState`, saveable) | [`state-persistence.md`](../../../docs/agent/references/state-persistence.md) |
 
 ## Pointers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,6 @@ Canonical example: `examples/taskflow`.
 
 ## Deeper knowledge
 
-- **T1** per-concern guides → `docs/agent/references/` (all eight live: feature-slice, store-setup, compose-binding, effects-sync, testing, platform-shims, modularization, devtools — see `docs/agent/references/README.md`).
+- **T1** per-concern guides → `docs/agent/references/` (all ten live: feature-slice, store-setup, compose-binding, effects-sync, testing, platform-shims, modularization, devtools, store-consistency-model, state-persistence — see `docs/agent/references/README.md`).
 - Task → guide routing (decision table) → `docs/agent/references/README.md`.
 - **T2** → `examples/taskflow/ARCHITECTURE.md` (full architecture + design rules) and `docs/agent/api-map.md` (module → `.api` index).

--- a/docs/agent/AGENTS-external.md
+++ b/docs/agent/AGENTS-external.md
@@ -71,6 +71,8 @@ nav), and `ui` (theme, locals, widgets).
 - Platform shims (expect/actual) — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/platform-shims.md
 - Modularization (which module when) — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/modularization.md
 - DevTools debugging loop — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/devtools.md
+- Store consistency model (sync writes, async notify) — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/store-consistency-model.md
+- State persistence & restore (process death, preloadedState, saveable) — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/state-persistence.md
 
 ## Verify loop
 

--- a/docs/agent/references/README.md
+++ b/docs/agent/references/README.md
@@ -17,6 +17,7 @@ checked to resolve (path exists, symbol present). See [_template.md](./_template
 | The 5 platform shims | [platform-shims.md](./platform-shims.md) | ✅ |
 | Modularization | [modularization.md](./modularization.md) | ✅ |
 | Store consistency model | [store-consistency-model.md](./store-consistency-model.md) | ✅ |
+| State persistence & restore | [state-persistence.md](./state-persistence.md) | ✅ |
 
 Tiers: **T0** = rules card + module map + commands (assembled into `AGENTS.md`). **T1** = these guides.
 **T2** = [`examples/taskflow/ARCHITECTURE.md`](../../../examples/taskflow/ARCHITECTURE.md) + committed `.api` dumps.

--- a/docs/agent/references/state-persistence.md
+++ b/docs/agent/references/state-persistence.md
@@ -1,0 +1,145 @@
+---
+tier: T1
+concern: state-persistence
+derives_from:
+  - redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/StateSaver.kt → StateSaver
+  - redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/RememberSaveableState.kt → rememberSaveableState
+  - redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/CreateModelStore.kt → createModelStore
+  - redux-kotlin-bundle/src/commonMain/kotlin/org/reduxkotlin/bundle/StoreFactory.kt → createConcurrentModelStore
+  - redux-kotlin-multimodel/src/commonMain/kotlin/org/reduxkotlin/multimodel/ModelState.kt → withAll
+  - redux-kotlin-concurrent/src/commonMain/kotlin/org/reduxkotlin/concurrent/NotificationContext.kt → coalescingNotificationContext
+api_files:
+  - redux-kotlin-compose-saveable/api/redux-kotlin-compose-saveable.klib.api
+  - redux-kotlin-routing/api/redux-kotlin-routing.klib.api
+  - redux-kotlin-bundle/api/redux-kotlin-bundle.klib.api
+  - redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api
+  - redux-kotlin-concurrent/api/redux-kotlin-concurrent.klib.api
+rules: [C, E]
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: 75388a1, date: 2026-06-10 }
+---
+
+# State persistence & restore (process death, rotation, relaunch)
+
+> How to save store state and get it back with **no stale first frame**: `preloadedState` for state
+> you persist yourself, `redux-kotlin-compose-saveable` for state the OS saves, and what must never
+> be persisted at all.
+
+## The split — two mechanisms, by storage owner
+
+| State | Owner | Mechanism |
+|---|---|---|
+| Durable domain data (boards, session, settings) | You (db / files) | Load before store creation → `preloadedState` |
+| Volatile UI state (route, filter, selected tab) | The OS (saved-instance state) | `StateSaver` + `rememberSaveableState` |
+| Transient interaction state (edit mode, open overlay) | Nobody | Don't persist — restore neutral |
+| Text drafts local to one composable | Compose | Plain `rememberSaveable` (no store involvement, Rule C) |
+
+The invariant both library mechanisms enforce: **restore happens before the first read**, so the
+first frame renders rehydrated state. Never restore by dispatching after the UI is up — that paints
+the initial state first, then visibly jumps.
+
+## Rehydrate at construction — `preloadedState`
+
+For state you persist yourself, seed the store when you build it:
+
+- Core: `createStore(reducer, restoredState)`.
+- Routed `ModelState` stores:
+  `redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/CreateModelStore.kt → createModelStore`
+  and the bundle's
+  `redux-kotlin-bundle/src/commonMain/kotlin/org/reduxkotlin/bundle/StoreFactory.kt → createConcurrentModelStore`
+  take `preloadedState: ModelState?`. The restored models are overlaid onto the declared defaults via
+  `redux-kotlin-multimodel/src/commonMain/kotlin/org/reduxkotlin/multimodel/ModelState.kt → withAll`
+  — the preloaded key set must be a **subset** of the declared slots; slots you don't preload keep
+  their declared initial value.
+
+```kotlin
+createConcurrentModelStore(
+    preloadedState = ModelState.of(NavModel(restoredStack), FilterModel(restoredQuery)),
+) { /* model(...) declarations — every preloaded class must be declared */ }
+```
+
+Consistency background (sync writes, async notify) → [store-consistency-model.md](./store-consistency-model.md).
+
+## OS-saved snapshots — `redux-kotlin-compose-saveable`
+
+Two public symbols
+(`redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/StateSaver.kt → StateSaver`,
+`redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/RememberSaveableState.kt → rememberSaveableState`):
+
+- `StateSaver(serializer, save, restore, json)` — a `@Serializable` snapshot of *just the fields
+  worth keeping*, a `save` projection from state, and a `restore` that turns a decoded snapshot
+  into an **action** the reducer applies. Stateless and store-free: build one instance and reuse it
+  across scopes; the serialization round-trip is unit-testable without Compose.
+- `store.rememberSaveableState(saver, key?)` — the anchor. Place it **once per persisted scope**,
+  *above* every composable that reads the restored slice.
+
+Behavioral contract (all KDoc'd in the sources above):
+
+- **Synchronous restore.** On a real restore the snapshot is decoded and the restore action
+  dispatched *during composition of the anchor*, before any child binding reads the store — no
+  stale first frame on a synchronous-dispatch store.
+- **Exactly once.** `SaveableStateRegistry.consumeRestored` yields the value once; recomposition
+  cannot double-apply. Cold start dispatches nothing.
+- **Lazy save.** The projection is serialized only when the platform actually saves; there is no
+  per-dispatch cost and no steady-state subscription.
+- **Best-effort decode.** An undecodable snapshot (schema change) is dropped → cold start, no crash.
+  Use `Json { ignoreUnknownKeys = true }` for additive changes, a `version` field for breaking ones.
+- **Main thread.** Restore reads/dispatches on main — the store must accept main-thread access
+  (the concurrent/bundle store does).
+- Desktop / JS / wasm have no OS saved-instance state: the anchor is a no-op there.
+
+**Keys:** the default key is positional (call-site composite hash). Pass an explicit stable `key`
+whenever scopes can collide — multiple anchors, anchors inside lists/nav graphs, or per-entity
+scopes. Scope the key to the data's identity (e.g. `key = "account-ui-$accountId"`) so one
+account's snapshot can never restore into another.
+
+## What NOT to persist
+
+- **Modes/overlays** — restore a detail screen in *view* mode even if the process died in *edit*
+  mode; the snapshot DTO simply omits the field. Persisted modes make interrupted interactions
+  sticky.
+- **Drafts** — keep in-progress text out of the store: plain `rememberSaveable` rides the same
+  registry with zero store coupling (Rule C).
+- **Anything derivable** — recompute, don't snapshot.
+
+## Notification timing (Rule E)
+
+With a concurrent store, writes are synchronous but subscriber callbacks follow the
+`NotificationContext`. Wrap the platform main-thread post with
+`redux-kotlin-concurrent/src/commonMain/kotlin/org/reduxkotlin/concurrent/NotificationContext.kt → coalescingNotificationContext`
+(`isOnTargetThread` + `post`): main-thread dispatches (including the restore dispatch) notify
+inline with no extra frame of latency, while off-main effect dispatches still marshal to main.
+The Compose bindings themselves read `getState()` synchronously on every read, so they never
+*render* stale state either way — see [store-consistency-model.md](./store-consistency-model.md).
+
+## TaskFlow integration (lessons)
+
+The taskflow sample wires all of this — saver + anchor in
+`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/persistence/UiSnapshot.kt → accountUiSaver, RestoreUiState`.
+Its hard-won lessons, in checklist form:
+
+1. One reused `StateSaver<ModelState, UiSnapshot>` for nav stack + filter; restore routed onto the
+   slots via a single `RestoreUiState` action.
+2. Account-scoped anchor key (`"account-ui-$accountId"`) — positional keys collided across accounts.
+3. `CardDetail` restores in **View** mode; the DTO has no edit-mode field.
+4. New-card draft via plain `rememberSaveable` in the screen, not the store.
+5. First paint gated on app bootstrap (account directory loaded from db) so returning users never
+   see a Login flash; on Android, also gated on window-insets dispatch to avoid a status-bar jump
+   on process-death restore.
+6. `coalescingNotificationContext` as the main `NotificationContext` so off-main sync/effects
+   dispatches never leave bindings a frame behind.
+
+## Verify loop
+
+Library round-trip tests live in `redux-kotlin-compose-saveable` (`commonTest` codec/registry tests
++ `jvmTest` end-to-end restore): `./gradlew :redux-kotlin-compose-saveable:jvmTest`. Preload
+overlay tests: `./gradlew :redux-kotlin-routing:jvmTest` and `./gradlew :redux-kotlin-bundle:jvmTest`.
+Then `./gradlew detektAll`; `./gradlew apiCheck` if a library surface changed.
+
+## See also
+
+- [store-consistency-model.md](./store-consistency-model.md) — why preload-at-construction and
+  synchronous binding reads make restore flash-free.
+- [store-setup.md](./store-setup.md) — the store factories these parameters hang off.
+- [compose-binding.md](./compose-binding.md) — Rule C; what belongs in the store vs the composable.
+- [README](./README.md)

--- a/docs/agent/references/store-consistency-model.md
+++ b/docs/agent/references/store-consistency-model.md
@@ -1,3 +1,23 @@
+---
+tier: T1
+concern: store-consistency-model
+derives_from:
+  - redux-kotlin-concurrent/src/commonMain/kotlin/org/reduxkotlin/concurrent/ConcurrentStore.kt → CallerSerializedStore
+  - redux-kotlin-concurrent/src/commonMain/kotlin/org/reduxkotlin/concurrent/NotificationContext.kt → coalescingNotificationContext
+  - redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/CreateModelStore.kt → createModelStore
+  - redux-kotlin-multimodel/src/commonMain/kotlin/org/reduxkotlin/multimodel/ModelState.kt → withAll
+  - redux-kotlin-compose/src/commonMain/kotlin/org/reduxkotlin/compose/FieldState.kt → selectorState, fieldState
+api_files:
+  - redux-kotlin-concurrent/api/redux-kotlin-concurrent.klib.api
+  - redux-kotlin-bundle/api/redux-kotlin-bundle.klib.api
+  - redux-kotlin-routing/api/redux-kotlin-routing.klib.api
+  - redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api
+  - redux-kotlin-compose/api/redux-kotlin-compose.klib.api
+rules: [E]
+assembles_into: [AGENTS.md, claude-skill]
+last_verified: { commit: 75388a1, date: 2026-06-10 }
+---
+
 # Store consistency model (concurrent store + Compose)
 
 The concurrent store (`createConcurrentStore` / `createConcurrentModelStore`, the bundle default)

--- a/docs/agent/references/store-setup.md
+++ b/docs/agent/references/store-setup.md
@@ -37,6 +37,13 @@ A single `createConcurrentModelStore(...) { declare slots }` call with one slot 
 not need any of the topology below for a one-screen app. The module that supplies it is the bundle —
 see [modularization.md](./modularization.md).
 
+Both `createModelStore` and `createConcurrentModelStore` take an optional `preloadedState:
+ModelState?` that overlays restored/persisted models onto the declared defaults at construction
+(key set must be a subset of the declared slots), so the first read already reflects rehydrated
+state — use it instead of a post-paint dispatch. Full treatment →
+[state-persistence.md](./state-persistence.md) and
+[store-consistency-model.md](./store-consistency-model.md).
+
 ## One store vs. two
 
 Taskflow runs **N+1 stores**: one root store plus one store per logged-in account.
@@ -85,6 +92,11 @@ a platform shim (see [platform-shims.md](./platform-shims.md)) that marshals sub
 the UI main thread. This is what lets effects dispatch from a background scope with **no explicit main
 hop**: the write runs serialized, and the store notifies subscribers through the context, which posts
 them to main. Tests override it with an inline context to dispatch synchronously on the caller thread.
+For a lag-free variant, build the context with
+`redux-kotlin-concurrent/src/commonMain/kotlin/org/reduxkotlin/concurrent/NotificationContext.kt → coalescingNotificationContext`
+— it runs the callback inline when the dispatch is already on the target (main) thread and posts
+otherwise, so a main-thread dispatch never waits a loop iteration (see
+[store-consistency-model.md](./store-consistency-model.md)).
 
 ## Per-account lifecycle — the registry
 

--- a/redux-kotlin-routing/README.md
+++ b/redux-kotlin-routing/README.md
@@ -45,7 +45,23 @@ val store = createModelStore {
   belong in middleware). The same applies to the `onWrite` observer.
 - **All-or-nothing.** A handler that throws aborts the whole dispatch;
   no partial commit.
+- **Rehydration at construction.** The optional `preloadedState:
+  ModelState?` parameter overlays restored/persisted models onto the
+  declared defaults (its key set must be a subset of the declared
+  slots), so the first `getState()` already reflects restored state —
+  no post-paint dispatch.
 
 Built on `redux-kotlin` + `redux-kotlin-multimodel`. Wrap with
-`createThreadSafeStore` for cross-thread access; composes with
-`redux-kotlin-granular` and the Compose bindings unchanged.
+`createThreadSafeStore` for cross-thread access (or use
+`redux-kotlin-bundle`'s `createConcurrentModelStore` for the concurrent
+variant); composes with `redux-kotlin-granular` and the Compose bindings
+unchanged.
+
+## See also
+
+- [`docs/agent/references/store-setup.md`](../docs/agent/references/store-setup.md) —
+  store topology and the routing DSL in a full app.
+- [`docs/agent/references/state-persistence.md`](../docs/agent/references/state-persistence.md) —
+  `preloadedState` rehydration and saveable UI persistence.
+- [`redux-kotlin-routing-codegen/README.md`](../redux-kotlin-routing-codegen/README.md) —
+  the KSP processor for `@Reduce` / `@ReduxInitial` annotation-driven wiring.

--- a/website/docs/Glossary.md
+++ b/website/docs/Glossary.md
@@ -173,6 +173,23 @@ There should only be a single store in a Redux app, as the composition happens o
 
 See the complete [store API reference](/api/store-api#dispatchaction-any-any) for more details.
 
+## Preloaded State
+
+The optional initial state passed to a store factory
+([`createStore(reducer, preloadedState)`](/api/createstore), or the
+`preloadedState` parameter of the routed-store factories `createModelStore` /
+`createConcurrentModelStore`). Use it to seed the store with restored or
+server-provided state at construction, so the first read already reflects it —
+see [Saving state across rotation & process death](/advanced/compose-integration#saving-state-across-rotation--process-death).
+
+## State Snapshot (`StateSaver`)
+
+A small `@Serializable` projection of just the store fields worth persisting
+across rotation and process death. `StateSaver` (from
+`redux-kotlin-compose-saveable`) pairs the snapshot with a `save` projection and
+a `restore` function that turns a decoded snapshot back into an action;
+`rememberSaveableState` anchors it to Compose's `SaveableStateRegistry`.
+
 ## Store creator
 
 ```kotlin

--- a/website/docs/Troubleshooting.md
+++ b/website/docs/Troubleshooting.md
@@ -9,3 +9,61 @@ sidebar_label: Troubleshooting
 This is a place to share common problems and solutions to them.  This 
 will be added to over time.  You may find the [JS Redux troubleshooting
 helpful.](https://redux.js.org/troubleshooting)
+
+## State persistence & restore
+
+### My saved state isn't restored after process death
+
+Things to check, in order:
+
+1. **Is the anchor reached on relaunch?** `rememberSaveableState` only
+   restores when it composes. If the anchor sits behind a conditional that
+   is false on a cold start (e.g. a "loaded" gate), the restored snapshot
+   is never consumed. Place the anchor as high as possible in the
+   composition.
+2. **Did the key collide or change?** The default key is derived from the
+   call-site position; navigation or lists can make positions collide, and
+   refactors can move them. Pass an explicit, stable
+   `key = "..."` — and scope it to the data's identity (e.g.
+   `key = "account-ui-$accountId"` in a multi-account app) so one scope's
+   snapshot can't restore into another.
+3. **Did decoding fail?** Restore is best-effort: a snapshot that can't be
+   decoded (e.g. after a schema change) is dropped silently and the app
+   starts cold. Ship `StateSaver(json = Json { ignoreUnknownKeys = true })`
+   for additive changes, and a `version` field in the snapshot for breaking
+   ones.
+4. **Is the platform a no-op?** Desktop, JS and wasm have no OS
+   saved-instance state — the anchor does nothing there. Test on Android
+   (e.g. *"Don't keep activities"* or `adb shell am kill`) or iOS.
+
+### A restored value appears, then reverts to the initial value
+
+Compose bindings are one-directional (`store → State`). If you restore a
+value into a Composable (e.g. with plain `rememberSaveable`) but the value
+*lives in the store*, the next subscription update overwrites it with the
+store's initial state. State that lives in the store must be restored by
+**dispatching** — that's exactly what
+[`rememberSaveableState`](/advanced/compose-integration#saving-state-across-rotation--process-death)
+does.
+
+### The first frame shows the initial (un-restored) state, then jumps
+
+Restore must happen **before** the first frame reads the store:
+
+- For OS-saved snapshots, `rememberSaveableState` dispatches the restore
+  action synchronously during composition of the anchor — make sure the
+  anchor composes *above* the Composables that read the restored slice.
+- For state you persist yourself, seed it at store construction with
+  `preloadedState` (`createStore`, `createModelStore`,
+  `createConcurrentModelStore`) instead of dispatching after the UI is up —
+  see [Rehydrating at construction](/advanced/compose-integration#rehydrating-at-construction-preloadedstate).
+
+### Bindings lag one frame behind a dispatch
+
+With a concurrent store whose `NotificationContext` always *posts* to the
+main thread, a main-thread dispatch is observed one loop iteration later.
+Wrap the post with `coalescingNotificationContext(isOnTargetThread, post)`
+from `redux-kotlin-concurrent`: main-thread dispatches notify inline,
+off-main dispatches still marshal to main. (The Compose bindings themselves
+read the store synchronously, so they never *render* stale state — the lag
+only affects subscription-driven recomposition timing.)

--- a/website/docs/advanced/Compose.md
+++ b/website/docs/advanced/Compose.md
@@ -239,6 +239,33 @@ codec via `StateSaver(json = Json { ignoreUnknownKeys = true })`; for
 breaking changes, add a `version` field to the snapshot and branch on it
 inside `restore`.
 
+### What to persist — and what not to
+
+Persist the **volatile UI state a user would miss**: the current route or
+tab, an active filter or query, a selected item. Leave out anything that
+is *transient* interaction state:
+
+- **Modes and overlays** — if a detail screen was in an *edit* mode when
+  the process died, restore it in *view* mode. Persisting the mode makes
+  interrupted interactions feel sticky; the snapshot type simply doesn't
+  carry the field.
+- **Text drafts local to one Composable** — keep them out of the store
+  entirely. A plain `rememberSaveable { mutableStateOf("") }` rides the
+  same `SaveableStateRegistry` with zero store involvement.
+- **Anything durable** — data that must survive a normal app restart
+  (not just process death) belongs in real storage (a database, files),
+  restored via [`preloadedState`](#rehydrating-at-construction-preloadedstate)
+  below.
+
+### Restore order & the first frame
+
+The restore action is dispatched **synchronously during composition** of
+the anchor, before any child binding reads the store — so on a
+synchronous-dispatch store the very first frame already shows the
+rehydrated state. There is no intermediate frame rendered from the
+store's initial state. Place the anchor *above* the Composables that
+read the restored slice.
+
 ### Threading & platforms
 
 The snapshot is read and the restore action dispatched on the **main
@@ -254,6 +281,61 @@ wasm have no OS restore concept, so the anchor is a no-op there.
 Compose bundle you already have it.
 :::
 
+## Rehydrating at construction: `preloadedState`
+
+`rememberSaveableState` covers state the *OS* saves for you. For state
+**you** persist — a session loaded from disk, models read from a local
+database — seed the store with it at construction instead of dispatching
+it after the UI is up:
+
+```kotlin
+// Core store: pass the restored state as the initial state.
+val store = createStore(::appReducer, restoredAppState)
+
+// Routed ModelState store (routing / bundle modules): overlay restored
+// models onto the declared defaults with `preloadedState`.
+val store = createConcurrentModelStore(
+    preloadedState = ModelState.of(
+        NavModel(restoredStack),
+        FilterModel(restoredQuery),
+    ),
+) {
+    model(NavModel()) { /* handlers */ }
+    model(FilterModel()) { /* handlers */ }
+    model(BoardModel()) { /* handlers */ }   // not preloaded — keeps its default
+}
+```
+
+`preloadedState` overlays the declared defaults via
+`ModelState.withAll(other)` — its key set must be a **subset** of the
+declared models, and every slot you don't preload keeps its declared
+initial value. Because the store is *born* rehydrated, the first
+`getState()` / first render is already correct: no post-paint dispatch,
+no flash of initial state.
+
+**Choosing between the two:** they compose, and a real app often uses
+both —
+
+| | `rememberSaveableState` | `preloadedState` |
+|---|---|---|
+| Storage | OS saved-instance state | Your own (DB, files, server) |
+| Survives | Rotation + process death | Anything, incl. normal restart |
+| Size | Small snapshots only | Whatever you load |
+| Restore point | First composition of the anchor | Store construction |
+
+:::info Real-world example — TaskFlow
+The [TaskFlow sample](https://github.com/reduxkotlin/redux-kotlin/tree/master/examples/taskflow)
+([ARCHITECTURE.md](https://github.com/reduxkotlin/redux-kotlin/blob/master/examples/taskflow/ARCHITECTURE.md))
+splits persistence exactly this way: boards/cards/accounts are durable in
+SQLDelight (domain state, restored at store construction), while the
+per-account nav stack + board filter ride a single
+`StateSaver<ModelState, UiSnapshot>` anchored with an account-scoped key
+(`key = "account-ui-$accountId"`), restoring in view mode and keeping
+new-card drafts in plain `rememberSaveable`.
+:::
+
+## Lifecycle and threading
+
 ## Lifecycle and threading
 
 Each binding subscribes inside a `DisposableEffect` and unsubscribes in
@@ -262,6 +344,16 @@ automatically — no manual tear-down. The underlying granular
 subscription inherits the store's threading guarantees; pair the bridge
 with [`createThreadSafeStore`](../api/createthreadsafestore) if you
 dispatch from multiple threads.
+
+Bindings are **lag-free by construction**: `fieldState` / `selectorState`
+read `store.state` synchronously on every read — the subscription only
+schedules recomposition — so a binding never shows a stale value even
+when the store delivers notifications asynchronously. With a concurrent
+store that posts notifications to the main thread, wrap the post in
+`coalescingNotificationContext(isOnTargetThread, post)` (from
+`redux-kotlin-concurrent`): a main-thread dispatch then notifies
+subscribers inline with no extra frame of latency, while off-main
+dispatches still marshal to main.
 
 ## See also
 

--- a/website/docs/ai-agents/BuildingWithAI.md
+++ b/website/docs/ai-agents/BuildingWithAI.md
@@ -84,6 +84,8 @@ nav), and `ui` (theme, locals, widgets).
 - Platform shims (expect/actual) — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/platform-shims.md
 - Modularization (which module when) — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/modularization.md
 - DevTools debugging loop — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/devtools.md
+- Store consistency model (sync writes, async notify) — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/store-consistency-model.md
+- State persistence & restore (process death, preloadedState, saveable) — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/state-persistence.md
 
 ## Verify loop
 

--- a/website/docs/api/createStore.md
+++ b/website/docs/api/createStore.md
@@ -23,7 +23,12 @@ The rest of this doc applies to all `createStore` functions.
    [action](../glossary#action) to handle.
 
 2. [`preloadedState`] _(State)_: The initial state. You may optionally specify it to hydrate the 
-   state from the server, or to restore a previously serialized user session. 
+   state from the server, or to restore a previously serialized user session. Seeding restored
+   state here (rather than dispatching it after creation) means the first read already sees the
+   rehydrated state. For restoring state across rotation and process death in Compose apps — and
+   the equivalent `preloadedState` parameter on the routed-store factories (`createModelStore` /
+   `createConcurrentModelStore`) — see
+   [Saving state across rotation & process death](../advanced/compose-integration#saving-state-across-rotation--process-death).
 
 3. [`enhancer`] _(StoreEnhancer)_: The store enhancer. You may optionally specify it to enhance the 
    store with third-party capabilities such as middleware, time travel, persistence, etc. The only 

--- a/website/docs/faq/StoreSetup.md
+++ b/website/docs/faq/StoreSetup.md
@@ -10,6 +10,7 @@ sidebar_label: Store Setup
 
 - [Is it OK to have more than one middleware chain in my store enhancer? What is the difference between next and dispatch in a middleware function?](#is-it-ok-to-have-more-than-one-middleware-chain-in-my-store-enhancer-what-is-the-difference-between-next-and-dispatch-in-a-middleware-function)
 - [How do I subscribe to only a portion of the state? Can I get the dispatched action as part of the subscription?](#how-do-i-subscribe-to-only-a-portion-of-the-state-can-i-get-the-dispatched-action-as-part-of-the-subscription)
+- [How do I persist store state and restore it on the next launch?](#how-do-i-persist-store-state-and-restore-it-on-the-next-launch)
 
 ## Store Setup
 
@@ -73,3 +74,36 @@ the action. Middleware can be used if the action is important and needs to be ha
 **Libraries**
 
 - [Redux Addons Catalog: Store Change Subscriptions](https://github.com/markerikson/redux-ecosystem-links/blob/master/store#store-change-subscriptions)
+
+### How do I persist store state and restore it on the next launch?
+
+Two mechanisms, depending on who owns the storage:
+
+- **State the OS saves for you** (rotation + process death on Android/iOS):
+  use `redux-kotlin-compose-saveable` — describe the slice worth keeping with
+  a `StateSaver` and anchor it with `rememberSaveableState`. The snapshot
+  rides Compose's `SaveableStateRegistry`, and on restore the library
+  dispatches your restore action synchronously during composition, so the
+  first frame already shows the rehydrated state.
+- **State you persist yourself** (a database, files, a server session): load
+  it before creating the store and seed it via `preloadedState` —
+  `createStore(reducer, restoredState)` for the core store, or the
+  `preloadedState` parameter on `createModelStore` /
+  `createConcurrentModelStore` for routed `ModelState` stores, which overlays
+  the restored models onto the declared defaults.
+
+Don't restore by dispatching after the UI is up — the first frame renders the
+initial state and then visibly jumps.
+
+#### Further information
+
+**Documentation**
+
+- [Advanced: Saving state across rotation & process death](../advanced/compose-integration#saving-state-across-rotation--process-death)
+- [API: createStore](../api/createstore)
+- [Troubleshooting: State persistence & restore](../troubleshooting#state-persistence--restore)
+
+**Example**
+
+- [TaskFlow](https://github.com/reduxkotlin/redux-kotlin/tree/master/examples/taskflow) — durable
+  domain state in SQLDelight + volatile UI state via `rememberSaveableState`.

--- a/website/docs/introduction/Ecosystem.md
+++ b/website/docs/introduction/Ecosystem.md
@@ -30,7 +30,14 @@ All share the core's group id `org.reduxkotlin` and version.
 | `redux-kotlin-multimodel-granular` | [Granular subscriptions for `ModelState`](../advanced/granular-subscriptions#multi-model-stores) — `subscribeTo(Model::field)` / `subscribeToModel(...)`. |
 | `redux-kotlin-compose` | [Compose integration](../advanced/compose-integration) — bind store fields to Compose `State<T>` with `fieldState` / `selectorState`. |
 | `redux-kotlin-compose-multimodel` | Compose `fieldState(Model::field)` bindings for `ModelState` stores. |
-| `redux-kotlin-compose-saveable` | `StateSaver` + `rememberSaveableState` store-anchored snapshot persistence for Compose (survives rotation + process death) via Compose `SaveableStateRegistry`. |
+| `redux-kotlin-compose-saveable` | [`StateSaver` + `rememberSaveableState`](../advanced/compose-integration#saving-state-across-rotation--process-death) store-anchored snapshot persistence for Compose (survives rotation + process death) via Compose `SaveableStateRegistry`. |
+| `redux-kotlin-concurrent` | `createConcurrentStore` — lock-free reads with caller-serialized writes; `NotificationContext` controls where subscriber callbacks run (incl. `coalescingNotificationContext` for lag-free main-thread notify). |
+| `redux-kotlin-routing` | Routed `(model, action)` dispatch over `ModelState` — declare each slot with `model(initial) { on<Action> { … } }` instead of a `when(action)` cascade; optional `preloadedState` overlays restored models at construction. |
+| `redux-kotlin-routing-codegen` | KSP processor for the routing DSL — `@Reduce` / `@ReduxInitial` annotations generate the `ReduxModule` wiring. |
+| `redux-kotlin-bundle` | One-dependency assembly of the concurrent `ModelState` stack (`createConcurrentModelStore`, registry helpers) — concurrent + multimodel + granular + routing in one artifact. |
+| `redux-kotlin-bundle-compose` | The bundle plus the Compose bindings and `redux-kotlin-compose-saveable` — the single dependency for Compose Multiplatform apps. |
+| `redux-kotlin-bom` | Maven BOM aligning the versions of every `org.reduxkotlin` module. |
+| `redux-kotlin-devtools-*` | DevTools family (`core`, `bridge`, `remote`, `inapp`, `ui`, `cli`, `standalone`) — action/state inspection and diffing for a running app. |
 
 ## Community
 

--- a/website/docs/introduction/Examples.md
+++ b/website/docs/introduction/Examples.md
@@ -9,6 +9,29 @@ sidebar_label: Examples
 ReduxKotlin includes a few examples currently and plans to port many of the JS Redux examples over.
 You may also find the [JS examples](https://redux.js.org/introduction/examples) helpful
 
+## TaskFlow — the reference architecture
+
+[TaskFlow](https://github.com/reduxkotlin/redux-kotlin/tree/master/examples/taskflow)
+is a Compose Multiplatform Kanban app (Android / iOS / desktop / wasm) built to
+exercise the `redux-kotlin-bundle-compose` stack end-to-end, and the best place
+to see the patterns from these docs in one codebase:
+
+- a root store plus a store-per-account registry (`createConcurrentModelStore` + `StoreRegistry`)
+- `ModelState` multi-model slots wired with the routing DSL (`model(initial) { on<Action> { … } }`)
+- granular Compose bindings (`fieldStateOf` / `selectorState`) tuned for tight render isolation
+- offline-first persistence with a sync engine and per-op inverse revert
+- UI-state persistence across rotation & process death via
+  [`redux-kotlin-compose-saveable`](../advanced/compose-integration#saving-state-across-rotation--process-death)
+
+Its [ARCHITECTURE.md](https://github.com/reduxkotlin/redux-kotlin/blob/master/examples/taskflow/ARCHITECTURE.md)
+documents every design rule the app follows.
+
+```sh
+git clone https://github.com/reduxkotlin/redux-kotlin.git
+./gradlew :examples:taskflow:composeApp:run        # desktop
+./gradlew :examples:taskflow:androidApp:installDebug
+```
+
 ## Counter
 
 Run the [Counter](https://github.com/reduxkotlin/redux-kotlin/tree/master/examples/counter) example:


### PR DESCRIPTION
Documentation pass over the new state-persistence API surface (`redux-kotlin-compose-saveable`, `preloadedState`, `ModelState.withAll`, `coalescingNotificationContext`, lag-free Compose bindings), folding in the lessons from the TaskFlow saveable integration (#333). KDocs were audited too — all current, no changes needed.

## Website (Docusaurus)

- **advanced/Compose.md** — what-to-persist guidance (modes restore neutral, drafts stay in `rememberSaveable`), the restore-order/first-frame contract, a new *Rehydrating at construction: `preloadedState`* section (routing/bundle `preloadedState` + `ModelState.withAll` overlay, subset constraint), a saveable-vs-preloadedState comparison table, a TaskFlow real-world callout, and a lag-free-bindings + `coalescingNotificationContext` note.
- **Troubleshooting.md** — was empty; now has a *State persistence & restore* section: snapshot not restored (anchor placement, key collisions, decode failures, platform no-ops), restored-then-reverts, first-frame flash, one-frame notification lag.
- **introduction/Ecosystem.md** — adds the published modules that were missing from the table: concurrent, routing, routing-codegen, bundle, bundle-compose, bom, devtools-*.
- **introduction/Examples.md** — adds TaskFlow as the reference architecture with run commands.
- **api/createStore.md** — `preloadedState` now explains seed-at-construction and links the persistence guide.
- **faq/StoreSetup.md** — new FAQ: *How do I persist store state and restore it on the next launch?*
- **Glossary.md** — *Preloaded State* and *State Snapshot (`StateSaver`)* entries.

## Agent docs

- **New `docs/agent/references/state-persistence.md`** (T1 guide) — the durable-vs-volatile split, `preloadedState` rehydration, the saveable behavioral contract (synchronous restore, exactly-once, lazy save, best-effort decode), key scoping, what not to persist, TaskFlow lessons checklist, verify loop.
- **store-consistency-model.md** — adds the missing YAML frontmatter (was the only reference without it).
- **store-setup.md** — mentions `preloadedState` on the factories and the `coalescingNotificationContext` variant.
- Index/routing updates: references README, skill decision table, AGENTS.md T1 list, AGENTS-external guide list (assembled into the public BuildingWithAI page).
- **redux-kotlin-routing/README.md** — documents `preloadedState` semantics, points at the bundle's concurrent factory, and adds see-also links to the agent guides + codegen README.

## Verification

- `./scripts/check-agent-refs.sh` — ANCHOR CHECK OK (all `path → Symbol` anchors resolve, incl. the new taskflow `UiSnapshot.kt` anchor post-#333)
- `./scripts/assemble-agent-knowledge.sh --check` — ASSEMBLE CHECK OK
- `cd website && yarn build` — succeeds; no new broken links/anchors (remaining warnings are pre-existing `#todo`s)
- Docs-only change: no Kotlin source touched, no API dumps affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)