### PR TITLE
docs(concurrent): correct threading/consistency claims after multi-agent review

### DIFF
--- a/docs/agent/api-map.md
+++ b/docs/agent/api-map.md
@@ -17,7 +17,7 @@ Read the committed `.api` dump for a module's public surface; regenerate with `.
 |---|---|---|
 | `:redux-kotlin` | `redux-kotlin/api/redux-kotlin.klib.api` | Core contract: `Store`/`TypedStore`, `Reducer`, `Middleware`, `createStore`, `applyMiddleware`, `combineReducers`, `compose`. |
 | `:redux-kotlin-threadsafe` | `redux-kotlin-threadsafe/api/redux-kotlin-threadsafe.klib.api` | `createThreadSafeStore` (atomicfu-locked store wrapper). |
-| `:redux-kotlin-concurrent` | `redux-kotlin-concurrent/api/redux-kotlin-concurrent.klib.api` | `createConcurrentStore` (lock-free reads + reentrant-lock-serialized writes; CallerSerialized strategy) + `NotificationContext` notify control (`coalescingNotificationContext` collapses bursts to one trailing notify). |
+| `:redux-kotlin-concurrent` | `redux-kotlin-concurrent/api/redux-kotlin-concurrent.klib.api` | `createConcurrentStore` (lock-free reads + reentrant-lock-serialized writes; CallerSerialized strategy) + `NotificationContext` notify control (`coalescingNotificationContext` runs the callback inline when already on the target thread, else posts — one callback per subscriber per dispatch, no burst collapsing). |
 | `:redux-kotlin-granular` | `redux-kotlin-granular/api/redux-kotlin-granular.klib.api` | `subscribeTo` / `subscribeFields` field-level subscriptions. |
 | `:redux-kotlin-registry` | `redux-kotlin-registry/api/redux-kotlin-registry.klib.api` | `StoreRegistry<K,S>` / `TypedStoreRegistry` keyed multi-store container. |
 | `:redux-kotlin-multimodel` | `redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api` | `ModelState` typesafe heterogeneous model bag (incl. `withAll` bulk merge). |

--- a/docs/agent/references/state-persistence.md
+++ b/docs/agent/references/state-persistence.md
@@ -107,10 +107,12 @@ account's snapshot can never restore into another.
 With a concurrent store, writes are synchronous but subscriber callbacks follow the
 `NotificationContext`. Wrap the platform main-thread post with
 `redux-kotlin-concurrent/src/commonMain/kotlin/org/reduxkotlin/concurrent/NotificationContext.kt → coalescingNotificationContext`
-(`isOnTargetThread` + `post`): main-thread dispatches (including the restore dispatch) notify
-inline with no extra frame of latency, while off-main effect dispatches still marshal to main.
-The Compose bindings themselves read `getState()` synchronously on every read, so they never
-*render* stale state either way — see [store-consistency-model.md](./store-consistency-model.md).
+(`isOnTargetThread` + `post`): **main-thread** dispatches (including the restore dispatch) notify
+inline with no extra frame of latency; off-main effect dispatches still marshal to main, arriving
+on a later loop iteration (that lag is inherent to posting, not removed by coalescing). The Compose
+bindings read `getState()` synchronously on every read, so any recomposition renders current state;
+the notification only schedules recomposition — see
+[store-consistency-model.md](./store-consistency-model.md) for the exact publish/notify ordering.
 
 ## TaskFlow integration (lessons)
 
@@ -126,8 +128,8 @@ Its hard-won lessons, in checklist form:
 5. First paint gated on app bootstrap (account directory loaded from db) so returning users never
    see a Login flash; on Android, also gated on window-insets dispatch to avoid a status-bar jump
    on process-death restore.
-6. `coalescingNotificationContext` as the main `NotificationContext` so off-main sync/effects
-   dispatches never leave bindings a frame behind.
+6. `coalescingNotificationContext` as the main `NotificationContext` so main-thread dispatches
+   notify inline (no lag frame); off-main sync/effects dispatches marshal to main as before.
 
 ## Verify loop
 

--- a/docs/agent/references/store-consistency-model.md
+++ b/docs/agent/references/store-consistency-model.md
@@ -29,6 +29,17 @@ separates two things:
 - **Subscriber notifications follow the `NotificationContext`.** With a posting context (e.g. a bare
   `Handler.post` on Android), callbacks run on a *later* loop iteration — eventual consistency.
 
+Exact ordering inside one dispatch: reducer commits to the inner store → listeners are notified
+through the context → the read mirror is published → the writer lock releases. Consequences worth
+knowing:
+
+- With an **inline** context, all subscriber callbacks run *while the writer lock is held* (a slow
+  subscriber delays other dispatchers, never readers), and the dispatching thread sees the new state
+  inside callbacks while other threads still read the previous mirror until publish.
+- With a **posting** context, a posted callback can be scheduled *before* the mirror publish and
+  read pre-dispatch state — callbacks must pull current state via `getState()`/`getModel()` and treat
+  a notification as "something may have changed", never as a payload.
+
 ## Don't branch on a binding right after dispatch
 
 `selectorState` / `fieldState` are driven by the subscription. As of the lag-free rewrite they read

--- a/docs/agent/references/store-setup.md
+++ b/docs/agent/references/store-setup.md
@@ -90,12 +90,12 @@ Both factories default their notification context to
 `examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/Notification.kt → mainNotificationContext`,
 a platform shim (see [platform-shims.md](./platform-shims.md)) that marshals subscriber callbacks to
 the UI main thread. This is what lets effects dispatch from a background scope with **no explicit main
-hop**: the write runs serialized, and the store notifies subscribers through the context, which posts
-them to main. Tests override it with an inline context to dispatch synchronously on the caller thread.
-For a lag-free variant, build the context with
+hop**: the write runs serialized, and the store notifies subscribers through the context, which
+delivers them on main. Tests override it with an inline context to dispatch synchronously on the
+caller thread. The platform actuals build `mainNotificationContext` on
 `redux-kotlin-concurrent/src/commonMain/kotlin/org/reduxkotlin/concurrent/NotificationContext.kt → coalescingNotificationContext`
-— it runs the callback inline when the dispatch is already on the target (main) thread and posts
-otherwise, so a main-thread dispatch never waits a loop iteration (see
+— callbacks run inline when the dispatch is already on main and are posted otherwise, so a
+main-thread dispatch never waits a loop iteration while off-main dispatches still marshal (see
 [store-consistency-model.md](./store-consistency-model.md)).
 
 ## Per-account lifecycle — the registry

--- a/redux-kotlin-concurrent/src/commonMain/kotlin/org/reduxkotlin/concurrent/NotificationContext.kt
+++ b/redux-kotlin-concurrent/src/commonMain/kotlin/org/reduxkotlin/concurrent/NotificationContext.kt
@@ -11,8 +11,12 @@ package org.reduxkotlin.concurrent
  * UI state never run off-main.
  *
  * Note: a non-[Inline] (asynchronous) context relaxes the no-mid-listener-tear
- * guarantee to eventual consistency — the mirror is published when the reducer
- * completes, while listeners arrive later on the target dispatcher.
+ * guarantee to eventual consistency — the mirror is published when the
+ * dispatch's write section completes, while listeners run whenever the target
+ * dispatcher schedules them. That is usually after the publish, but a posted
+ * callback can also win the race and still observe the previous mirror, so
+ * callbacks must pull current state via `getState` and treat a notification as
+ * "something may have changed", never as a payload.
  */
 public fun interface NotificationContext {
     /**

--- a/website/docs/Troubleshooting.md
+++ b/website/docs/Troubleshooting.md
@@ -64,6 +64,8 @@ With a concurrent store whose `NotificationContext` always *posts* to the
 main thread, a main-thread dispatch is observed one loop iteration later.
 Wrap the post with `coalescingNotificationContext(isOnTargetThread, post)`
 from `redux-kotlin-concurrent`: main-thread dispatches notify inline,
-off-main dispatches still marshal to main. (The Compose bindings themselves
-read the store synchronously, so they never *render* stale state — the lag
-only affects subscription-driven recomposition timing.)
+off-main dispatches still marshal to main (at most one loop hop — that part
+is inherent to posting). The Compose bindings read the store synchronously
+on every read, so any recomposition that does run renders current state;
+the lag affects *when* the dispatch-triggered recomposition is scheduled,
+not what a recomposition reads.

--- a/website/docs/advanced/Compose.md
+++ b/website/docs/advanced/Compose.md
@@ -336,24 +336,26 @@ new-card drafts in plain `rememberSaveable`.
 
 ## Lifecycle and threading
 
-## Lifecycle and threading
-
 Each binding subscribes inside a `DisposableEffect` and unsubscribes in
 `onDispose`, so subscriptions follow the Composable's lifecycle
 automatically — no manual tear-down. The underlying granular
-subscription inherits the store's threading guarantees; pair the bridge
-with [`createThreadSafeStore`](../api/createthreadsafestore) if you
-dispatch from multiple threads.
+subscription inherits the store's threading guarantees; if you dispatch
+from multiple threads, use a concurrent store (the bundle's
+`createConcurrentModelStore`, or `createConcurrentStore` from
+`redux-kotlin-concurrent`) or wrap the store with
+[`createThreadSafeStore`](../api/createthreadsafestore).
 
-Bindings are **lag-free by construction**: `fieldState` / `selectorState`
-read `store.state` synchronously on every read — the subscription only
-schedules recomposition — so a binding never shows a stale value even
-when the store delivers notifications asynchronously. With a concurrent
-store that posts notifications to the main thread, wrap the post in
-`coalescingNotificationContext(isOnTargetThread, post)` (from
-`redux-kotlin-concurrent`): a main-thread dispatch then notifies
-subscribers inline with no extra frame of latency, while off-main
-dispatches still marshal to main.
+`fieldState` / `selectorState` read `store.state` synchronously on every
+read — the subscription only *schedules recomposition*, it never caches a
+value. So whenever a binding is read (any recomposition, however
+triggered), it returns the store's current state, not a stale snapshot.
+The recomposition that a dispatch itself triggers rides the store's
+notification: inline contexts deliver it synchronously; a posting context
+delivers it on a later main-loop iteration. With a concurrent store, wrap
+the main-thread post in `coalescingNotificationContext(isOnTargetThread,
+post)` (from `redux-kotlin-concurrent`): a **main-thread** dispatch then
+notifies subscribers inline with no extra frame of latency, while
+off-main dispatches still marshal to main (at most one loop hop).
 
 ## See also
 

--- a/website/docs/api/createStore.md
+++ b/website/docs/api/createStore.md
@@ -11,8 +11,10 @@ There should only be a single store in your app.
 
 If using `createStore` directly, it will not be threadsafe.
 
-It is ***STRONGLY*** recommended that [`createThreadSafeStore()`](./createthreadsafestore) is used unless there is
- good reason to do otherwise.
+On multi-threaded platforms it is ***STRONGLY*** recommended to use a thread-safe variant:
+a concurrent store (`createConcurrentStore` from `redux-kotlin-concurrent` — lock-free reads,
+serialized writes; see [Threading](../introduction/threading)) or the fully-synchronized
+[`createThreadSafeStore()`](./createthreadsafestore).
 
 The rest of this doc applies to all `createStore` functions.
 

--- a/website/docs/api/createThreadSafeStore.md
+++ b/website/docs/api/createThreadSafeStore.md
@@ -8,7 +8,11 @@ sidebar_label: createThreadSafeStore
 
 Creates a Redux [store](./store-api) that is may be accessed from any thread.
 
-***This is the recommended way to create a store.***
+***This is the simplest thread-safe way to create a store*** — every store
+function is synchronized on one lock. If you want reads that never block
+(lock-free `getState`/`subscribe` with serialized writes), use
+`createConcurrentStore` from `redux-kotlin-concurrent` instead — see
+[Threading](../introduction/threading).
 
 There is some performance overhead in using `createThreadSafeStore()` due to
 synchronization, however it is small and mostly likely not impact UI.

--- a/website/docs/introduction/Threading.md
+++ b/website/docs/introduction/Threading.md
@@ -6,7 +6,10 @@ sidebar_label: Threading
 
 # Redux on Multi-threaded Platforms
 
-TLDR; use [createThreadSafeStore()](../api/createthreadsafestore), unless your app is Javascript only.
+TLDR; use a **concurrent store** (`createConcurrentStore` from
+`redux-kotlin-concurrent`, or the bundle's `createConcurrentModelStore`) or the
+fully-synchronized [createThreadSafeStore()](../api/createthreadsafestore),
+unless your app is Javascript only.
 
 Redux in multi-threaded environments brings additional concerns that are not present in redux
 for Javascript.  Javascript is single threaded, so Redux.js did not have to address the issue.
@@ -16,19 +19,43 @@ In a multi-threaded system invalid states and race conditions can happen.
 For example if `getState` was called at the same time as a dispatch, the state could represent a past
 state.  Or 2 actions dispatched concurrently could cause an invalid state.
 
-**So you there are 3 options:**
+**So there are 4 options:**
 
-1) Synchronize access to the store  - [createThreadSafeStore()](../api/createthreadsafestore)
-2) Only access the store from the same thread - [createSameThreadEnforcedStore()](../api/createsamethreadenforcedstore)
-3) Live in the wild west and access store anytime, any thread
+1) Lock-free reads + serialized writes - `createConcurrentStore` (`redux-kotlin-concurrent`)
+2) Synchronize all access to the store  - [createThreadSafeStore()](../api/createthreadsafestore)
+3) Only access the store from the same thread - [createSameThreadEnforcedStore()](../api/createsamethreadenforcedstore)
+4) Live in the wild west and access store anytime, any thread
     and live with consequences - NOT_RECOMMENDED - [createStore()](../api/createstore)
 
-ReduxKotlin allows all these, but most cases will fall into #1.
+ReduxKotlin allows all of these; most apps will use #1 or #2.
+
+## Concurrent store
+
+`redux-kotlin-concurrent` (and the `redux-kotlin-bundle`, which builds on it)
+provides the `CallerSerialized` strategy: `getState` and `subscribe` are
+**lock-free** — they never block, even during an in-flight dispatch — while
+writes (`dispatch`) are serialized through a reentrant writer lock. Reads off
+the dispatching thread return an atomic state mirror published at the end of
+each dispatch; reads on the dispatching thread see the in-progress state,
+matching core Redux. A `NotificationContext` controls which thread subscriber
+callbacks run on (UI apps marshal them to the main thread — see
+[Compose integration](../advanced/compose-integration#lifecycle-and-threading)).
+
+```kotlin
+val store = createConcurrentStore(reducer, initialState)
+```
+
+This trades strict read synchronization for non-blocking reads: off-thread
+reads are eventually consistent (they may briefly observe the previous state
+while a dispatch is completing). If you want every read fully synchronized
+instead, use `createThreadSafeStore`.
 
 ## ThreadSafe
 
 Starting with ReduxKotlin 0.5.0 there is a threadsafe store which uses synchronization (AtomicFu library)
-to allow safe access to all the functions on the store.  This is the recommended usage for 90% of use cases.
+to allow safe access to all the functions on the store.  It is the simplest fully-synchronized option:
+every read and write takes the same lock, so reads block during an in-flight dispatch (which the
+concurrent store above avoids).
 
 ```kotlin
     val store = createThreadSafeStore(reducer, state)


### PR DESCRIPTION
A 46-agent adversarial review of the concurrent store stack (implementation threading semantics, doc accuracy, Compose-binding interaction, test evidence) verified the docs against the code. This PR fixes every confirmed doc inaccuracy. Code-behavior findings (races, guard gaps, test gaps) are reported separately — no behavior changes here.

## Confirmed inaccuracies fixed

- **`api-map.md`** — claimed `coalescingNotificationContext` "collapses bursts to one trailing notify". The implementation is `if (isOnTargetThread()) block() else post(block)`: one callback per subscriber per dispatch, **no burst collapsing**. Reworded.
- **`NotificationContext` KDoc** — implied posted listeners always arrive *after* the mirror publish. A posted callback can win the race and observe the previous mirror; callbacks must pull via `getState` and treat a notification as a signal, not a payload. KDoc now says so (doc-only, no API change).
- **`store-consistency-model.md`** — now documents the exact per-dispatch ordering (reducer commit → notify → mirror publish → lock release), that inline contexts run all subscriber callbacks while the writer lock is held, and the posted-callback-before-publish window.
- **`state-persistence.md` / `Troubleshooting.md`** — had the coalescing benefit backwards ("off-main dispatches never leave bindings a frame behind"). Correct: coalescing removes the lag frame for **main-thread** dispatches; off-main dispatches still post (≤1 loop hop, inherent to posting). Also replaced "bindings never render stale state" with the precise distinction: reads are synchronous (any recomposition renders current state), notification only *schedules* recomposition.
- **`store-setup.md`** — presented `coalescingNotificationContext` as an optional "lag-free variant" when taskflow's `mainNotificationContext` actuals are already built on it.
- **`advanced/Compose.md`** — removed a duplicated "Lifecycle and threading" heading (introduced in #334), replaced the "lag-free by construction / never shows a stale value" overclaim, and pointed multi-thread users at the concurrent store rather than only `createThreadSafeStore`.
- **`introduction/Threading.md`, `api/createStore.md`, `api/createThreadSafeStore.md`** — these pages predate `redux-kotlin-concurrent` ("3 options", "recommended way"). Added the concurrent store as the headline option with an honest trade-off statement (lock-free reads, serialized writes, eventually-consistent off-thread reads vs fully-synchronized).

## Verification

- `./scripts/check-agent-refs.sh` — ANCHOR CHECK OK
- `./scripts/assemble-agent-knowledge.sh --check` — ASSEMBLE CHECK OK
- `cd website && yarn build` — succeeds, no new broken links/anchors
- detekt via pre-commit hook — green (only KDoc touched in Kotlin source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)