### PR TITLE
docs: post-merge consistency review fixes (targets, iOS claim, changelog, skill index)

### DIFF
--- a/.claude/skills/redux-kotlin/SKILL.md
+++ b/.claude/skills/redux-kotlin/SKILL.md
@@ -33,6 +33,7 @@ companion modules on one `Store<S>` contract. Recommended app organization is **
 | **Modularization** | [`modularization.md`](../../../docs/agent/references/modularization.md) |
 | **Debugging** a running app (actions/state/diffs) | [`devtools.md`](../../../docs/agent/references/devtools.md) |
 | **Persisting/restoring state** (process death, `preloadedState`, saveable) | [`state-persistence.md`](../../../docs/agent/references/state-persistence.md) |
+| **Store consistency model** (sync writes, async notify, timing) | [`store-consistency-model.md`](../../../docs/agent/references/store-consistency-model.md) |
 
 ## Pointers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New module `redux-kotlin-compose-saveable`: `StateSaver` + `rememberSaveableState` —
+  store-anchored snapshot persistence via Compose `SaveableStateRegistry` +
+  kotlinx.serialization. Survives rotation and process death on Android; restore is applied
+  synchronously during composition (no stale first frame).
+- `redux-kotlin-concurrent`: `coalescingNotificationContext(isOnTargetThread, post)` — runs
+  subscriber callbacks inline when the dispatch is already on the target (main) thread, posts
+  otherwise; removes the one-frame notification lag for main-thread dispatches.
+- `redux-kotlin-routing` / `redux-kotlin-bundle`: optional `preloadedState: ModelState?` on
+  `createModelStore` / `createConcurrentModelStore` — overlays restored models onto the declared
+  defaults at construction, so the first read/render already reflects rehydrated state.
+- `redux-kotlin-multimodel`: `ModelState.withAll(other: ModelState)` overlay overload backing
+  `preloadedState`.
 ### Fixed
 
 - `redux-kotlin-concurrent`: the state mirror is now published **before**
@@ -53,6 +67,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   accepted and its state change overwritten. `getState`/`subscribe`/`unsubscribe`
   already enforced the same guard. Dispatch follow-up actions from middleware or a
   subscriber instead.
+- `redux-kotlin-compose`: `selectorState` / `fieldState` now read store state synchronously on
+  every read and use the subscription only to schedule recomposition — bindings stay fresh even
+  with asynchronous notification contexts, and re-sample conditionally at subscribe so a change
+  landing before the subscription is not lost.
 - CI/toolchain bumped to JDK 21; library bytecode stays at JVM 17 to preserve downstream
   compatibility with JDK 17 consumers. Test matrix runs both JDKs.
 - Sample apps modernised: `compileSdk`/`targetSdk` 33 → 35, `JavaVersion` 1.8 → 21,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,8 @@ are good patterns to copy.
 ## KMP targets & where they run
 
 `convention.library-mpp-loved` targets: `jvm`, `android`, `js` (browser+node),
-`wasmJs` (browser+node), `iosArm64`, `iosSimulatorArm64`, `iosX64`, `macosX64`,
-`macosArm64`, `linuxX64`, `mingwX64`. The core uses `convention.library-mpp-all`,
+`wasmJs` (browser+node), `iosArm64`, `iosSimulatorArm64`, `macosArm64`,
+`linuxX64`, `mingwX64`. The core uses `convention.library-mpp-all`,
 which additionally has `linuxArm64`.
 
 - `jvm`/`js`/`android` compile on **every** host (host-independent; the Android

--- a/docs/agent/references/state-persistence.md
+++ b/docs/agent/references/state-persistence.md
@@ -86,7 +86,9 @@ Behavioral contract (all KDoc'd in the sources above):
   Use `Json { ignoreUnknownKeys = true }` for additive changes, a `version` field for breaking ones.
 - **Main thread.** Restore reads/dispatches on main — the store must accept main-thread access
   (the concurrent/bundle store does).
-- Desktop / JS / wasm have no OS saved-instance state: the anchor is a no-op there.
+- Only Android's Compose runtime wires `SaveableStateRegistry` to OS saved-instance state today;
+  on iOS, desktop, JS and wasm the anchor is a no-op for process death — durable state goes
+  through your own storage + `preloadedState` there.
 
 **Keys:** the default key is positional (call-site composite hash). Pass an explicit stable `key`
 whenever scopes can collide — multiple anchors, anchors inside lists/nav graphs, or per-entity

--- a/website/docs/advanced/Compose.md
+++ b/website/docs/advanced/Compose.md
@@ -271,9 +271,13 @@ read the restored slice.
 The snapshot is read and the restore action dispatched on the **main
 thread**, so the persisted store must accept main-thread reads and dispatch
 — the Compose-facing store (the concurrent/threadsafe bundle store, or a
-main-confined store). On Android the snapshot rides `savedInstanceState`
-(rotation + process death); iOS uses state restoration; desktop, JS and
-wasm have no OS restore concept, so the anchor is a no-op there.
+main-confined store). The anchor rides whatever `SaveableStateRegistry`
+the platform's Compose runtime provides. On Android that registry is wired
+to `savedInstanceState`, so snapshots survive rotation **and** process
+death. On iOS, desktop, JS and wasm the Compose runtime does not currently
+wire the registry to an OS restore mechanism, so the anchor is a no-op for
+process death there — persist anything durable yourself and seed it via
+[`preloadedState`](#rehydrating-at-construction-preloadedstate) instead.
 
 :::tip Bundled
 `redux-kotlin-compose-saveable` ships inside

--- a/website/docs/advanced/GranularSubscriptions.md
+++ b/website/docs/advanced/GranularSubscriptions.md
@@ -30,8 +30,8 @@ implementation("org.reduxkotlin:redux-kotlin-granular:<version>")
 ```
 
 The module targets every platform the core library supports: JVM,
-Android, JS, wasmJs, iosArm64, iosX64, iosSimulatorArm64, macosArm64,
-macosX64, linuxX64, mingwX64.
+Android, JS, wasmJs, iosArm64, iosSimulatorArm64, macosArm64,
+linuxX64, mingwX64.
 
 ## Single-field subscription
 

--- a/website/docs/advanced/StoreRegistry.md
+++ b/website/docs/advanced/StoreRegistry.md
@@ -27,8 +27,8 @@ implementation("org.reduxkotlin:redux-kotlin-registry:<version>")
 ```
 
 The module targets every platform the core library supports: JVM,
-Android, JS, wasmJs, iosArm64, iosX64, iosSimulatorArm64, macosArm64,
-macosX64, linuxX64, mingwX64. Its only dependencies are `redux-kotlin`
+Android, JS, wasmJs, iosArm64, iosSimulatorArm64, macosArm64,
+linuxX64, mingwX64. Its only dependencies are `redux-kotlin`
 and `kotlinx.atomicfu` — no coroutines requirement.
 
 ## Tier 1: `StoreRegistry<K, S>`

--- a/website/docs/introduction/GettingStarted.md
+++ b/website/docs/introduction/GettingStarted.md
@@ -26,8 +26,8 @@ __Requirements__
 
 - Kotlin 1.9 or newer (artefacts are built with Kotlin 2.3)
 - Android `minSdk 21` or higher; library bytecode is JVM 17
-- Supported KMP targets: `jvm`, `js` (browser/node), `android`, `iosArm64`, `iosX64`,
-  `iosSimulatorArm64`, `macosArm64`, `macosX64`, `linuxArm64`, `linuxX64`, `mingwX64`
+- Supported KMP targets: `jvm`, `js` (browser/node), `wasmJs`, `android`, `iosArm64`,
+  `iosSimulatorArm64`, `macosArm64`, `linuxArm64` (core), `linuxX64`, `mingwX64`
 
 __For a multiplatform project:__
 


### PR DESCRIPTION
4-lens review of master after #333/#334 (cross-platform correctness, docs consistency, test quality, AI-integration consistency). Mechanical gates all green on master: full `./gradlew build` (tests + detekt + apiCheck), website build, anchor + assemble checks.

## Fixes

- **Nonexistent KMP targets in docs**: CLAUDE.md, GettingStarted, StoreRegistry, GranularSubscriptions listed `iosX64`/`macosX64`, which the build conventions don't declare (only `iosSimulatorArm64`/`macosArm64`). Lists corrected; `wasmJs` added to GettingStarted.
- **Wrong iOS persistence claim**: docs said "iOS uses state restoration" for `rememberSaveableState`. The anchor delegates entirely to the platform's `SaveableStateRegistry`, and only Android's Compose runtime wires that to OS saved-instance state — iOS is a no-op for process death, same as desktop/JS/wasm. Corrected in Compose.md + state-persistence.md, pointing durable state at `preloadedState`.
- **Skill routing table**: added the missing `store-consistency-model.md` row (10th guide; index/AGENTS lists already had it).
- **CHANGELOG**: Unreleased section had no entries for the persistence feature set — added `redux-kotlin-compose-saveable`, `coalescingNotificationContext`, `preloadedState`/`withAll`, and the lag-free compose binding rewrite.

## Verified clean

Concurrency primitives (atomicfu/SynchronizedObject/DispatchContext actuals per platform), granular `@Volatile` visibility on native, taskflow's per-platform `isOnTargetThread` checks, and test source-set placement (no JVM constructs in commonTest, no @Ignore'd tests) all audited — correct.

New test gaps found (saveable explicit-key collision, taskflow `RestoreUiState` routing, `save()`-throws path) are folded into the hardening-plan implementation (#336) rather than this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)