### PR TITLE
fix: restore dispatch-during-reduce guard in createStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Behavior change:** `dispatch` from inside a reducer now throws
+  `IllegalStateException` ("You may not dispatch while state is being reduced"),
+  restoring the core Redux contract. Previously the nested dispatch was silently
+  accepted and its state change overwritten. `getState`/`subscribe`/`unsubscribe`
+  already enforced the same guard. Dispatch follow-up actions from middleware or a
+  subscriber instead.
 - CI/toolchain bumped to JDK 21; library bytecode stays at JVM 17 to preserve downstream
   compatibility with JDK 17 consumers. Test matrix runs both JDKs.
 - Sample apps modernised: `compileSdk`/`targetSdk` 33 → 35, `JavaVersion` 1.8 → 21,

--- a/redux-kotlin-concurrent/src/commonTest/kotlin/org/reduxkotlin/concurrent/CallerSerializedStoreTest.kt
+++ b/redux-kotlin-concurrent/src/commonTest/kotlin/org/reduxkotlin/concurrent/CallerSerializedStoreTest.kt
@@ -3,6 +3,7 @@ package org.reduxkotlin.concurrent
 import org.reduxkotlin.Reducer
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class CallerSerializedStoreTest {
@@ -10,6 +11,7 @@ class CallerSerializedStoreTest {
     private data class S(val count: Int = 0)
     private object Inc
     private object Noop
+    private object TriggerNested
     private val reducer: Reducer<S> = { s, a -> if (a is Inc) s.copy(count = s.count + 1) else s }
 
     private fun store(onError: (Throwable) -> Unit = LogAndContinue) = CallerSerializedStore(
@@ -106,5 +108,35 @@ class CallerSerializedStoreTest {
         assertEquals(42, observedDuringReplace, "on-context getState during REPLACE must route to inner")
         s.dispatch(Inc)
         assertEquals(52, s.state.count)
+    }
+
+    @Test
+    fun dispatch_from_reducer_throws_through_wrapper_and_mirror_stays_consistent() {
+        lateinit var wrapped: ConcurrentStore<S>
+        val selfDispatchingReducer: Reducer<S> = { st, a ->
+            when (a) {
+                is Inc -> st.copy(count = st.count + 1)
+
+                is TriggerNested -> {
+                    wrapped.dispatch(Inc)
+                    st
+                }
+
+                else -> st
+            }
+        }
+        wrapped = CallerSerializedStore(
+            inner = org.reduxkotlin.createStore(selfDispatchingReducer, S()),
+            notificationContext = NotificationContext.Inline,
+            onError = LogAndContinue,
+        )
+
+        assertFailsWith<IllegalStateException> { wrapped.dispatch(TriggerNested) }
+
+        // The aborted dispatch left a consistent mirror: off-context reads see the
+        // unchanged state, and the store remains usable.
+        assertEquals(0, wrapped.state.count, "mirror must stay consistent after reducer-dispatch ISE")
+        wrapped.dispatch(Inc)
+        assertEquals(1, wrapped.state.count)
     }
 }

--- a/redux-kotlin/src/commonMain/kotlin/org/reduxkotlin/CreateStore.kt
+++ b/redux-kotlin/src/commonMain/kotlin/org/reduxkotlin/CreateStore.kt
@@ -163,6 +163,10 @@ public fun <State> createStore(
      * middleware will eventually dispatch plain object actions using this
      * method.
      *
+     * Dispatching while the reducer is executing (i.e. from inside a reducer)
+     * throws [IllegalStateException] — reducers must be pure; trigger follow-up
+     * actions from middleware or a subscriber instead.
+     *
      * @param {Any} [action] A plain object representing “what changed”. It is
      * a good idea to keep actions serializable so you can record and replay
      * user sessions, or use the time travelling `redux-devtools`.
@@ -179,16 +183,16 @@ public fun <State> createStore(
             """.trimMargin()
         }
 
-        /*
         check(!isDispatching) {
             """You may not dispatch while state is being reduced.
             |2 conditions can cause this error:
             |    1) Dispatching from a reducer
             |    2) Dispatching from multiple threads
-            |If #2 switch to createThreadSafeStore().
-            |https://reduxkotlin.org/introduction/threading""".trimMargin()
+            |If #2 switch to a thread-safe store (createConcurrentStore or
+            |createThreadSafeStore).
+            |https://reduxkotlin.org/introduction/threading
+            """.trimMargin()
         }
-         */
 
         try {
             isDispatching = true

--- a/redux-kotlin/src/commonTest/kotlin/org/reduxkotlin/DispatchDuringReduceTest.kt
+++ b/redux-kotlin/src/commonTest/kotlin/org/reduxkotlin/DispatchDuringReduceTest.kt
@@ -1,0 +1,82 @@
+package org.reduxkotlin
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class DispatchDuringReduceTest {
+
+    private data class CounterState(val count: Int = 0)
+    private object Inc
+    private object TriggerNestedDispatch
+    private object TriggerReplaceReducer
+
+    private fun storeWithSelfReference(): Store<CounterState> {
+        lateinit var store: Store<CounterState>
+        val reducer: Reducer<CounterState> = { state, action ->
+            when (action) {
+                is Inc -> state.copy(count = state.count + 1)
+
+                is TriggerNestedDispatch -> {
+                    store.dispatch(Inc)
+                    state
+                }
+
+                is TriggerReplaceReducer -> {
+                    store.replaceReducer { s, _ -> s }
+                    state
+                }
+
+                else -> state
+            }
+        }
+        store = createStore(reducer, CounterState())
+        return store
+    }
+
+    @Test
+    fun dispatchFromReducerThrowsAndLeavesStateUnchanged() {
+        val store = storeWithSelfReference()
+
+        val e = assertFailsWith<IllegalStateException> {
+            store.dispatch(TriggerNestedDispatch)
+        }
+
+        assertTrue(
+            e.message.orEmpty().contains("may not dispatch while state is being reduced"),
+            "unexpected message: ${e.message}",
+        )
+        assertEquals(0, store.state.count, "state must be unchanged after the aborted dispatch")
+
+        // The store stays usable after the failed dispatch.
+        store.dispatch(Inc)
+        assertEquals(1, store.state.count)
+    }
+
+    @Test
+    fun replaceReducerFromReducerThrows() {
+        val store = storeWithSelfReference()
+
+        assertFailsWith<IllegalStateException> {
+            store.dispatch(TriggerReplaceReducer)
+        }
+        assertEquals(0, store.state.count)
+    }
+
+    @Test
+    fun dispatchFromListenerStillSucceeds() {
+        val store = storeWithSelfReference()
+        var redispatched = false
+
+        store.subscribe {
+            if (!redispatched) {
+                redispatched = true
+                store.dispatch(Inc)
+            }
+        }
+
+        store.dispatch(Inc)
+        assertEquals(2, store.state.count, "listener-time dispatch is allowed (reduction finished)")
+    }
+}


### PR DESCRIPTION
**Stage 1 of the concurrent-store hardening plan (#336)** — concern C3.

`dispatch` from inside a reducer was silently accepted (the guard was commented out), and the nested dispatch's state change was overwritten by the outer reducer's return — silent state corruption. `getState`, `subscribe`, and `unsubscribe` already enforce the identical `check(!isDispatching)` guard, so this restores internal consistency and the core Redux contract (Redux JS throws unconditionally here).

## Behavior change

Dispatching from a reducer (or calling `replaceReducer` from one, whose internal REPLACE dispatch hits the same guard) now throws `IllegalStateException` ("You may not dispatch while state is being reduced"). The guard message now points at `createConcurrentStore` alongside `createThreadSafeStore` for the multi-threaded case. Dispatch-from-a-**listener** remains legal — reduction has finished by then — and is pinned by a new boundary test. CHANGELOG headlines the change.

Through `CallerSerializedStore`, the ISE propagates out of the wrapped pipeline before the inner state is assigned, so the mirror stays consistent and the store stays usable — pinned by a wrapper companion test.

## TDD

Tests written first and watched fail (no ISE thrown on current master):
- `dispatchFromReducerThrowsAndLeavesStateUnchanged`
- `replaceReducerFromReducerThrows`
- `dispatch_from_reducer_throws_through_wrapper_and_mirror_stays_consistent` (concurrent)
- `dispatchFromListenerStillSucceeds` (boundary pin, passed pre-fix as expected)

## Verification

- Full `./gradlew build` green with the guard enabled — every module suite incl. taskflow passes (no in-repo code dispatches from a reducer; examples grep confirms)
- `detektAll` green, `apiCheck` green — no `.api` delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)