### PR TITLE
fix(concurrent): publish mirror before signaling listeners; harden unsubscribe + onError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `redux-kotlin-concurrent`: the state mirror is now published **before**
+  subscriber notifications are signaled (previously after, in the dispatch
+  epilogue). A posted callback racing ahead of the dispatching thread could
+  read the pre-dispatch mirror; for diff-based consumers (granular
+  subscriptions, Compose bindings) that meant a lost wakeup — the binding
+  stayed stale until the next dispatch. A callback now always observes state
+  at least as new as the dispatch that triggered it. The old
+  "mirror published after listeners / no mid-listener tear" wording is
+  retired: off-context readers may observe the new state while listeners run.
+- `redux-kotlin-concurrent`: after `unsubscribe()` returns, no new callback
+  invocation begins — a callback already queued on a posting context is
+  skipped at execution time (deliberate divergence from core Redux snapshot
+  delivery; with an inline context a peer unsubscribed earlier in the same
+  fan-out is skipped).
+- `redux-kotlin-concurrent`: a throwing `onError` handler no longer aborts
+  delivery to remaining subscribers or escapes `dispatch` — it is printed and
+  swallowed.
+
 ### Changed
 
 - **Behavior change:** `dispatch` from inside a reducer now throws

--- a/docs/agent/references/store-consistency-model.md
+++ b/docs/agent/references/store-consistency-model.md
@@ -29,16 +29,24 @@ separates two things:
 - **Subscriber notifications follow the `NotificationContext`.** With a posting context (e.g. a bare
   `Handler.post` on Android), callbacks run on a *later* loop iteration — eventual consistency.
 
-Exact ordering inside one dispatch: reducer commits to the inner store → listeners are notified
-through the context → the read mirror is published → the writer lock releases. Consequences worth
-knowing:
+Exact per-dispatch ordering: reducer commits to the inner store → the read mirror is published →
+listeners are signaled through the context → the writer lock releases. Consequences:
 
-- With an **inline** context, all subscriber callbacks run *while the writer lock is held* (a slow
-  subscriber delays other dispatchers, never readers), and the dispatching thread sees the new state
-  inside callbacks while other threads still read the previous mirror until publish.
-- With a **posting** context, a posted callback can be scheduled *before* the mirror publish and
-  read pre-dispatch state — callbacks must pull current state via `getState()`/`getModel()` and treat
-  a notification as "something may have changed", never as a payload.
+- **A callback always observes state at least as new as its triggering dispatch** (the mirror is
+  published before the signal). Later dispatches may already have landed, so callbacks must pull
+  current state via `getState()`/`getModel()` and treat a notification as "something may have
+  changed", never as a payload.
+- With an **inline** context, all subscriber callbacks run *while the writer lock is held* — a slow
+  subscriber delays other dispatchers, never readers — and other threads already see the new mirror
+  while listeners run (there is no "listeners finished" barrier).
+- **Notification contexts must deliver serially** (one block at a time, in post order, with a
+  happens-before edge between blocks). Multi-threaded executors are unsupported: the granular diff
+  layer (and therefore `selectorState`/`fieldState`) assumes serial delivery.
+- **After `unsubscribe()` returns, no new callback invocation begins**; one already executing on
+  another thread may complete. With an inline context a peer unsubscribed earlier in the same
+  fan-out is skipped (deliberate divergence from core Redux snapshot delivery).
+- **`dispatch` from inside a reducer throws** on every store flavor (core guard) — reducers are
+  pure; follow-ups belong in middleware or subscribers.
 
 ## Don't branch on a binding right after dispatch
 

--- a/examples/taskflow/composeApp/src/jvmMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/Notification.jvm.kt
+++ b/examples/taskflow/composeApp/src/jvmMain/kotlin/org/reduxkotlin/sample/taskflow/infra/platform/Notification.jvm.kt
@@ -8,8 +8,9 @@ import javax.swing.SwingUtilities
  * JVM (desktop) [mainNotificationContext]: runs subscriber callbacks on the Swing
  * Event Dispatch Thread.
  *
- * Runs the block inline when already on the EDT (avoids a needless re-post and preserves
- * publish-after-notify ordering); otherwise marshals it via [SwingUtilities.invokeLater].
+ * Runs the block inline when already on the EDT (avoids a needless re-post and keeps
+ * subscribers synchronous with the dispatch); otherwise marshals it via
+ * [SwingUtilities.invokeLater].
  *
  * @return a [NotificationContext] that runs callbacks on the EDT.
  */

--- a/redux-kotlin-concurrent/build.gradle.kts
+++ b/redux-kotlin-concurrent/build.gradle.kts
@@ -49,6 +49,13 @@ kotlin {
                 implementation(project(":redux-kotlin-threadsafe"))
             }
         }
+        jvmTest {
+            dependencies {
+                // Race tests pin the publish-then-signal contract through the
+                // granular diff layer (the consumer the C1 race actually bit).
+                implementation(project(":redux-kotlin-granular"))
+            }
+        }
     }
 }
 

--- a/redux-kotlin-concurrent/src/commonMain/kotlin/org/reduxkotlin/concurrent/ConcurrentStore.kt
+++ b/redux-kotlin-concurrent/src/commonMain/kotlin/org/reduxkotlin/concurrent/ConcurrentStore.kt
@@ -18,11 +18,24 @@ import org.reduxkotlin.StoreSubscription
  *
  * Reads off the processing context return a value from an atomic state mirror;
  * reads on the processing context (from a listener/middleware on the dispatching
- * thread) return the inner store's in-progress state, matching core Redux. The
- * mirror is published after listeners run, so off-context readers never observe
- * a mid-listener tear; reads are otherwise eventually consistent and strictly
- * weaker than a fully synchronized store (the intentional trade for non-blocking
- * reads). See the design spec for the full consistency model.
+ * thread) return the inner store's in-progress state, matching core Redux.
+ *
+ * Per-dispatch ordering: the reducer commits → the mirror is published →
+ * listeners are signaled through the [NotificationContext] → the writer lock
+ * releases. A callback therefore always observes state at least as new as the
+ * dispatch that triggered it — no lost wakeups for diff-based consumers.
+ * Multiple dispatches may coalesce into what one callback observes, so
+ * callbacks must pull current state via `getState`; a notification is a
+ * signal, never a payload. There is no "listeners finished" barrier:
+ * off-context readers may observe the new state while listeners are still
+ * running. Reads are otherwise eventually consistent and strictly weaker than
+ * a fully synchronized store (the intentional trade for non-blocking reads).
+ *
+ * Subscription contract: after `unsubscribe()` returns, no new callback
+ * invocation begins; a callback already executing on another thread may run to
+ * completion. With an inline context this means a peer unsubscribed by an
+ * earlier listener in the same fan-out is skipped (a deliberate divergence
+ * from core Redux's snapshot delivery).
  */
 public interface ConcurrentStore<State> : Store<State>
 
@@ -50,23 +63,54 @@ public class CallerSerializedStore<State>(
     private val lock = SynchronizedObject()
     private val context = DispatchContext()
     private val mirror = atomic(inner.getState())
-    private val listeners = atomic<List<StoreSubscriber>>(emptyList())
+    private val listeners = atomic<List<Registration>>(emptyList())
+
+    /**
+     * Per-subscription handle: the posted callback checks [active] at execution
+     * time, so after `unsubscribe()` returns no new callback invocation begins
+     * (an already-executing callback may run to completion).
+     */
+    private class Registration(val subscriber: StoreSubscriber) {
+        val active = atomic(true)
+    }
 
     init {
+        // This fan-out hook must remain the FIRST listener registered on the
+        // inner store (tests pin the ordering): inner listeners run only after
+        // the reducer has committed, so the mirror published here is the
+        // post-reducer state, and the atomic write happens-before every post()
+        // below. A posted callback therefore never observes a mirror older than
+        // the dispatch that triggered it — no lost wakeups for diff-based
+        // consumers. sequenced()'s finally re-publish stays as an idempotent
+        // backstop for reducer-throw and middleware-swallowed-action paths.
         inner.subscribe {
+            mirror.value = inner.getState()
             val snapshot = listeners.value
-            snapshot.forEach { subscriber ->
+            snapshot.forEach { registration ->
                 notificationContext.post {
-                    try {
-                        subscriber()
-                    } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
-                        onError(t)
+                    if (registration.active.value) {
+                        notifyGuarded(registration.subscriber)
                     }
                 }
             }
         }
         val pipeline = inner.dispatch
         inner.dispatch = { action -> sequenced(pipeline, action) }
+    }
+
+    private fun notifyGuarded(subscriber: StoreSubscriber) {
+        try {
+            subscriber()
+        } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+            try {
+                onError(t)
+            } catch (@Suppress("TooGenericExceptionCaught") suppressed: Throwable) {
+                println(
+                    "redux-kotlin-concurrent: onError handler threw and was suppressed: " +
+                        "$suppressed (original listener error: $t)",
+                )
+            }
+        }
     }
 
     private fun sequenced(pipeline: Dispatcher, action: Any): Any = synchronized(lock) {
@@ -88,11 +132,11 @@ public class CallerSerializedStore<State>(
     }
 
     override val subscribe: (StoreSubscriber) -> StoreSubscription = { subscriber ->
-        listeners.update { it + subscriber }
-        val subscribed = atomic(true)
+        val registration = Registration(subscriber)
+        listeners.update { it + registration }
         val unsub: StoreSubscription = {
-            if (subscribed.compareAndSet(expect = true, update = false)) {
-                listeners.update { it - subscriber }
+            if (registration.active.compareAndSet(expect = true, update = false)) {
+                listeners.update { it - registration }
             }
         }
         unsub

--- a/redux-kotlin-concurrent/src/commonMain/kotlin/org/reduxkotlin/concurrent/CreateConcurrentStore.kt
+++ b/redux-kotlin-concurrent/src/commonMain/kotlin/org/reduxkotlin/concurrent/CreateConcurrentStore.kt
@@ -20,10 +20,15 @@ import org.reduxkotlin.typedReducer
  * @param State the application state type.
  * @param reducer the root reducer.
  * @param preloadedState the initial state. Must be deeply immutable.
- * @param notificationContext where listener callbacks and [onError] run; default
- *  runs them synchronously on the dispatching thread. UI consumers should pass a
- *  main-thread context.
- * @param onError isolates listener throwables (default logs and continues).
+ * @param notificationContext where listener callbacks and [onError] run; the
+ *  default [NotificationContext.Inline] runs every subscriber while the writer
+ *  lock is held — a slow subscriber delays concurrent dispatchers (and
+ *  `replaceReducer`), never readers. UI consumers should pass a main-thread
+ *  context (e.g. [coalescingNotificationContext]); supply a posting/coalescing
+ *  context if subscribers can be slow.
+ * @param onError isolates listener throwables (default logs and continues). Must
+ *  not throw; a throw from the handler itself is printed and swallowed — dispatch
+ *  and delivery to remaining subscribers always proceed.
  * @param enhancer optional store enhancer (e.g. `applyMiddleware(...)`).
  */
 public fun <State> createConcurrentStore(
@@ -62,6 +67,9 @@ public inline fun <State, reified Action : Any> createTypedConcurrentStore(
  * Caveat (same as core Redux): middleware that captured the dispatch *function by
  * value* at construction, or captured a foreign store object, is not intercepted.
  * Prefer the [enhancer] argument of [createConcurrentStore].
+ *
+ * [notificationContext] and [onError] carry the same contracts as on
+ * [createConcurrentStore].
  */
 public fun <State> Store<State>.asConcurrent(
     notificationContext: NotificationContext = NotificationContext.Inline,

--- a/redux-kotlin-concurrent/src/commonMain/kotlin/org/reduxkotlin/concurrent/NotificationContext.kt
+++ b/redux-kotlin-concurrent/src/commonMain/kotlin/org/reduxkotlin/concurrent/NotificationContext.kt
@@ -4,19 +4,26 @@ package org.reduxkotlin.concurrent
  * Decides on which thread/dispatcher a [ConcurrentStore]'s listener callbacks
  * (and the store's `onError` handler) are invoked.
  *
- * The default [Inline] runs the callback synchronously on the dispatching
- * thread, which preserves the store's publish-after-notify read ordering. UI
- * consumers should supply a context that marshals to the main thread (e.g. a
- * wrapper around the platform main dispatcher), so subscribers that touch
- * UI state never run off-main.
+ * The store publishes its read mirror **before** signaling listeners, so a
+ * callback — inline or posted — always observes state at least as new as the
+ * dispatch that triggered it. Callbacks must pull current state via
+ * `getState`; a notification is a signal that something may have changed,
+ * never a payload (later dispatches may already have landed).
  *
- * Note: a non-[Inline] (asynchronous) context relaxes the no-mid-listener-tear
- * guarantee to eventual consistency — the mirror is published when the
- * dispatch's write section completes, while listeners run whenever the target
- * dispatcher schedules them. That is usually after the publish, but a posted
- * callback can also win the race and still observe the previous mirror, so
- * callbacks must pull current state via `getState` and treat a notification as
- * "something may have changed", never as a payload.
+ * Implementations MUST execute posted blocks for a given store one at a time,
+ * in post order, with a happens-before edge between consecutive blocks (any
+ * single-threaded executor, main-thread post, or inline execution qualifies).
+ * Handing blocks to a multi-threaded executor is unsupported: diff-based
+ * consumers (redux-kotlin-granular's per-entry last value, and therefore
+ * `selectorState`/`fieldState`) assume serial notification and will lose or
+ * duplicate diffs otherwise.
+ *
+ * The default [Inline] runs every callback synchronously on the dispatching
+ * thread while the writer lock is held — a slow subscriber delays concurrent
+ * dispatchers (and `replaceReducer`), never readers. UI consumers should
+ * supply a context that marshals to the main thread (e.g.
+ * [coalescingNotificationContext] around the platform main dispatcher), so
+ * subscribers that touch UI state never run off-main.
  */
 public fun interface NotificationContext {
     /**
@@ -27,7 +34,12 @@ public fun interface NotificationContext {
 
     /** Built-in contexts. */
     public companion object {
-        /** Runs the block synchronously on the calling (dispatching) thread. */
+        /**
+         * Runs the block synchronously on the calling (dispatching) thread,
+         * while the writer lock is still held — slow subscribers delay other
+         * dispatchers, never readers. Supply a posting or coalescing context
+         * if subscribers can be slow.
+         */
         public val Inline: NotificationContext = NotificationContext { block -> block() }
     }
 }
@@ -42,6 +54,9 @@ public fun interface NotificationContext {
  * on the target thread keeps the subscriber synchronous with the dispatch (matching a plain
  * synchronous store), while off-thread dispatches still marshal via [post] (preserving the
  * off-main-effects rule).
+ *
+ * "Coalescing" refers to this inline-vs-marshal routing only — bursts are NOT collapsed: every
+ * dispatch still delivers exactly one callback per subscriber.
  *
  * @param isOnTargetThread returns true when the calling thread is the target (e.g. the main thread).
  * @param post marshals [block] to the target thread (e.g. `handler::post`); used only when
@@ -59,6 +74,9 @@ public fun coalescingNotificationContext(
  * Default `onError` handler for [createConcurrentStore]: prints the throwable and
  * continues, so one failing listener never aborts delivery to the others or
  * corrupts the store. Override to forward to your own logging.
+ *
+ * A handler must not throw; if it does, the throwable is printed and swallowed —
+ * dispatch and delivery to the remaining subscribers always proceed.
  */
 public val LogAndContinue: (Throwable) -> Unit = { throwable ->
     println("redux-kotlin-concurrent: listener threw and was isolated: $throwable")

--- a/redux-kotlin-concurrent/src/commonTest/kotlin/org/reduxkotlin/concurrent/CoalescingContextDeliveryTest.kt
+++ b/redux-kotlin-concurrent/src/commonTest/kotlin/org/reduxkotlin/concurrent/CoalescingContextDeliveryTest.kt
@@ -1,0 +1,94 @@
+package org.reduxkotlin.concurrent
+
+import org.reduxkotlin.Reducer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins [coalescingNotificationContext]'s delivery arithmetic against a real
+ * store (closes test gap T5): "coalescing" = inline-vs-marshal routing only —
+ * bursts are never collapsed; every dispatch delivers one callback per
+ * subscriber. Any future burst-coalescing becomes a deliberate, test-visible
+ * change.
+ */
+class CoalescingContextDeliveryTest {
+
+    private data class S(val count: Int = 0)
+    private object Inc
+
+    private val reducer: Reducer<S> = { s, a -> if (a is Inc) s.copy(count = s.count + 1) else s }
+
+    @Test
+    fun offTargetBurstQueuesOneSignalPerSubscriberPerDispatch() {
+        val queued = mutableListOf<() -> Unit>()
+        val context = coalescingNotificationContext(
+            isOnTargetThread = { false },
+            post = { block -> queued += block },
+        )
+        val store = CallerSerializedStore(
+            inner = org.reduxkotlin.createStore(reducer, S()),
+            notificationContext = context,
+            onError = LogAndContinue,
+        )
+        val hits = IntArray(3)
+        repeat(3) { i -> store.subscribe { hits[i]++ } }
+
+        repeat(5) { store.dispatch(Inc) }
+
+        assertEquals(15, queued.size, "3 subscribers x 5 dispatches, no burst collapsing")
+        assertEquals(listOf(0, 0, 0), hits.toList(), "nothing delivered before the queue runs")
+
+        queued.forEach { it() }
+        assertEquals(listOf(5, 5, 5), hits.toList(), "each subscriber exactly once per dispatch")
+    }
+
+    @Test
+    fun onTargetCallbacksRunInlineAndQueueStaysEmpty() {
+        val queued = mutableListOf<() -> Unit>()
+        val context = coalescingNotificationContext(
+            isOnTargetThread = { true },
+            post = { block -> queued += block },
+        )
+        val store = CallerSerializedStore(
+            inner = org.reduxkotlin.createStore(reducer, S()),
+            notificationContext = context,
+            onError = LogAndContinue,
+        )
+        var hits = 0
+        var seen = -1
+        store.subscribe {
+            hits++
+            seen = store.state.count
+        }
+
+        store.dispatch(Inc)
+
+        assertEquals(1, hits, "on-target callback runs inline with the dispatch")
+        assertEquals(1, seen)
+        assertEquals(0, queued.size, "nothing marshals when already on the target thread")
+    }
+
+    @Test
+    fun drainedOffTargetCallbackPullsLatestState() {
+        val queued = mutableListOf<() -> Unit>()
+        var onTarget = false
+        val context = coalescingNotificationContext(
+            isOnTargetThread = { onTarget },
+            post = { block -> queued += block },
+        )
+        val store = CallerSerializedStore(
+            inner = org.reduxkotlin.createStore(reducer, S()),
+            notificationContext = context,
+            onError = LogAndContinue,
+        )
+        val seen = mutableListOf<Int>()
+        store.subscribe { seen += store.state.count }
+
+        store.dispatch(Inc) // off-target: queued
+        onTarget = true
+        store.dispatch(Inc) // on-target: inline, reads 2
+        queued.forEach { it() } // late drain of the first signal: also reads 2
+
+        assertEquals(listOf(2, 2), seen, "callbacks pull current state — a signal is not a payload")
+    }
+}

--- a/redux-kotlin-concurrent/src/commonTest/kotlin/org/reduxkotlin/concurrent/OnErrorIsolationTest.kt
+++ b/redux-kotlin-concurrent/src/commonTest/kotlin/org/reduxkotlin/concurrent/OnErrorIsolationTest.kt
@@ -1,0 +1,54 @@
+package org.reduxkotlin.concurrent
+
+import org.reduxkotlin.Reducer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins onError self-shielding (hardening plan C6): a throwing `onError`
+ * handler must not abort delivery to remaining subscribers nor escape
+ * `dispatch` — the module's own promise ("never aborts delivery").
+ */
+class OnErrorIsolationTest {
+
+    private data class S(val count: Int = 0)
+    private object Inc
+
+    private val reducer: Reducer<S> = { s, a -> if (a is Inc) s.copy(count = s.count + 1) else s }
+
+    @Test
+    fun throwingOnErrorHandlerIsSwallowedAndDeliveryProceeds() {
+        val store = CallerSerializedStore(
+            inner = org.reduxkotlin.createStore(reducer, S()),
+            notificationContext = NotificationContext.Inline,
+            onError = { throw IllegalArgumentException("handler is itself broken") },
+        )
+        var goodHits = 0
+        store.subscribe { throw IllegalStateException("boom") }
+        store.subscribe { goodHits++ }
+
+        store.dispatch(Inc) // must return normally despite listener AND handler throwing
+
+        assertEquals(1, goodHits, "delivery to remaining subscribers must proceed")
+        assertEquals(1, store.state.count, "state and mirror stay consistent")
+    }
+
+    @Test
+    fun throwingOnErrorHandlerSurvivesQueuedDrainToo() {
+        val queue = QueueingNotificationContext()
+        val store = CallerSerializedStore(
+            inner = org.reduxkotlin.createStore(reducer, S()),
+            notificationContext = queue,
+            onError = { throw IllegalArgumentException("handler is itself broken") },
+        )
+        var goodHits = 0
+        store.subscribe { throw IllegalStateException("boom") }
+        store.subscribe { goodHits++ }
+
+        store.dispatch(Inc)
+        queue.drain() // must complete despite the double fault
+
+        assertEquals(1, goodHits)
+        assertEquals(1, store.state.count)
+    }
+}

--- a/redux-kotlin-concurrent/src/commonTest/kotlin/org/reduxkotlin/concurrent/QueuedNotificationStoreTest.kt
+++ b/redux-kotlin-concurrent/src/commonTest/kotlin/org/reduxkotlin/concurrent/QueuedNotificationStoreTest.kt
@@ -1,0 +1,105 @@
+package org.reduxkotlin.concurrent
+
+import org.reduxkotlin.Reducer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Store-level behavior under a real (queued) posting context — closes test gap
+ * T2: every prior store test used [NotificationContext.Inline].
+ */
+class QueuedNotificationStoreTest {
+
+    private data class S(val count: Int = 0)
+    private object Inc
+
+    private val reducer: Reducer<S> = { s, a -> if (a is Inc) s.copy(count = s.count + 1) else s }
+
+    private fun storeWithQueue(): Pair<CallerSerializedStore<S>, QueueingNotificationContext> {
+        val queue = QueueingNotificationContext()
+        val store = CallerSerializedStore(
+            inner = org.reduxkotlin.createStore(reducer, S()),
+            notificationContext = queue,
+            onError = LogAndContinue,
+        )
+        return store to queue
+    }
+
+    @Test
+    fun stateIsCurrentImmediatelyWhileCallbacksWaitForDrain() {
+        val (store, queue) = storeWithQueue()
+        val hits = mutableMapOf("a" to 0, "b" to 0, "c" to 0)
+        val seenAtCallback = mutableListOf<Int>()
+        listOf("a", "b", "c").forEach { key ->
+            store.subscribe {
+                hits[key] = hits.getValue(key) + 1
+                seenAtCallback += store.state.count
+            }
+        }
+
+        store.dispatch(Inc)
+
+        // Writes are synchronous; notification rides the (queued) context.
+        assertEquals(1, store.state.count, "state must be current before drain")
+        assertEquals(0, seenAtCallback.size, "no callback may run before drain")
+        assertEquals(3, queue.pending, "one queued block per subscriber per dispatch")
+
+        queue.drain()
+        assertEquals(listOf(1, 1, 1), hits.values.toList(), "each subscriber exactly once")
+        assertEquals(listOf(1, 1, 1), seenAtCallback, "each callback reads the published state")
+    }
+
+    @Test
+    fun burstDeliversEverySignalAndCallbacksPullLatestState() {
+        val (store, queue) = storeWithQueue()
+        var hits = 0
+        val seen = mutableListOf<Int>()
+        store.subscribe {
+            hits++
+            seen += store.state.count
+        }
+
+        store.dispatch(Inc)
+        store.dispatch(Inc)
+        assertEquals(2, queue.pending, "no burst collapsing: one signal per dispatch")
+
+        queue.drain()
+        assertEquals(2, hits)
+        // Signal-not-payload: both callbacks read the final state.
+        assertEquals(listOf(2, 2), seen)
+    }
+
+    @Test
+    fun nestedDispatchFromDrainedCallbackEnqueuesNextRound() {
+        val (store, queue) = storeWithQueue()
+        var redispatched = false
+        var hits = 0
+        store.subscribe {
+            hits++
+            if (!redispatched) {
+                redispatched = true
+                store.dispatch(Inc)
+            }
+        }
+
+        store.dispatch(Inc)
+        queue.drain() // drains the first signal AND the nested dispatch's signal
+
+        assertEquals(2, store.state.count)
+        assertEquals(2, hits)
+    }
+
+    @Test
+    fun replaceReducerPublishesMirrorBeforeDrainAndSignalsOnce() {
+        val (store, queue) = storeWithQueue()
+        var hits = 0
+        store.subscribe { hits++ }
+
+        store.replaceReducer { st, a -> if (a is Inc) st.copy(count = st.count + 10) else st.copy(count = 42) }
+
+        assertEquals(42, store.state.count, "mirror published before the queued signals run")
+        assertEquals(0, hits)
+        queue.drain()
+        assertEquals(1, hits, "REPLACE delivers one signal per subscriber")
+    }
+}

--- a/redux-kotlin-concurrent/src/commonTest/kotlin/org/reduxkotlin/concurrent/QueueingNotificationContext.kt
+++ b/redux-kotlin-concurrent/src/commonTest/kotlin/org/reduxkotlin/concurrent/QueueingNotificationContext.kt
@@ -1,0 +1,29 @@
+package org.reduxkotlin.concurrent
+
+/**
+ * Test fixture: a [NotificationContext] that queues every posted block and runs
+ * them only when [drain] is called. Makes async-notify behavior deterministic
+ * and single-threaded on every KMP target (including JS/wasm).
+ */
+internal class QueueingNotificationContext : NotificationContext {
+    private val queue = mutableListOf<() -> Unit>()
+
+    /** Number of blocks currently queued and not yet drained. */
+    val pending: Int get() = queue.size
+
+    override fun post(block: () -> Unit) {
+        queue += block
+    }
+
+    /**
+     * Runs queued blocks in post order until the queue is empty, including
+     * blocks enqueued by the blocks themselves (e.g. nested dispatches).
+     */
+    fun drain() {
+        while (queue.isNotEmpty()) {
+            val batch = queue.toList()
+            queue.clear()
+            batch.forEach { it() }
+        }
+    }
+}

--- a/redux-kotlin-concurrent/src/commonTest/kotlin/org/reduxkotlin/concurrent/UnsubscribeSemanticsTest.kt
+++ b/redux-kotlin-concurrent/src/commonTest/kotlin/org/reduxkotlin/concurrent/UnsubscribeSemanticsTest.kt
@@ -1,0 +1,89 @@
+package org.reduxkotlin.concurrent
+
+import org.reduxkotlin.Reducer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the unsubscribe contract (hardening plan C5): after `unsubscribe()`
+ * returns, no NEW callback invocation begins — including callbacks already
+ * queued on a posting context. Deliberate divergence from core Redux's
+ * snapshot delivery; closes test gap T4.
+ */
+class UnsubscribeSemanticsTest {
+
+    private data class S(val count: Int = 0)
+    private object Inc
+
+    private val reducer: Reducer<S> = { s, a -> if (a is Inc) s.copy(count = s.count + 1) else s }
+
+    private fun storeWithQueue(): Pair<CallerSerializedStore<S>, QueueingNotificationContext> {
+        val queue = QueueingNotificationContext()
+        val store = CallerSerializedStore(
+            inner = org.reduxkotlin.createStore(reducer, S()),
+            notificationContext = queue,
+            onError = LogAndContinue,
+        )
+        return store to queue
+    }
+
+    @Test
+    fun queuedCallbackIsSkippedWhenUnsubscribedBeforeDrain() {
+        val (store, queue) = storeWithQueue()
+        var hits = 0
+        val unsub = store.subscribe { hits++ }
+
+        store.dispatch(Inc) // signal queued
+        unsub() // unsubscribed before the queue drains
+        queue.drain()
+
+        assertEquals(0, hits, "a queued callback must not run after unsubscribe() returned")
+    }
+
+    @Test
+    fun inlinePeerUnsubscribedByEarlierListenerInSameFanOutIsSkipped() {
+        val store = CallerSerializedStore(
+            inner = org.reduxkotlin.createStore(reducer, S()),
+            notificationContext = NotificationContext.Inline,
+            onError = LogAndContinue,
+        )
+        var bHits = 0
+        lateinit var unsubB: () -> Any
+        store.subscribe { unsubB() } // A unsubscribes its peer B mid-round
+        unsubB = store.subscribe { bHits++ }
+
+        store.dispatch(Inc)
+
+        // Deliberate divergence from core Redux snapshot delivery: B was
+        // unsubscribed by A in the same fan-out and is skipped (guaranteed on
+        // the same thread — the active flag is checked at execution time).
+        assertEquals(0, bHits)
+    }
+
+    @Test
+    fun doubleUnsubscribeIsIdempotent() {
+        val (store, queue) = storeWithQueue()
+        var hits = 0
+        val unsub = store.subscribe { hits++ }
+        unsub()
+        unsub()
+        store.dispatch(Inc)
+        queue.drain()
+        assertEquals(0, hits)
+    }
+
+    @Test
+    fun sameLambdaSubscribedTwiceLosesExactlyOneDeliveryPerUnsubscribe() {
+        val (store, queue) = storeWithQueue()
+        var hits = 0
+        val listener: () -> Unit = { hits++ }
+        store.subscribe(listener)
+        val unsubSecond = store.subscribe(listener)
+
+        unsubSecond()
+        store.dispatch(Inc)
+        queue.drain()
+
+        assertEquals(1, hits, "unsubscribing one registration must not affect the other")
+    }
+}

--- a/redux-kotlin-concurrent/src/jvmTest/kotlin/org/reduxkotlin/concurrent/concurrency/LockFreeReadGuaranteesTest.kt
+++ b/redux-kotlin-concurrent/src/jvmTest/kotlin/org/reduxkotlin/concurrent/concurrency/LockFreeReadGuaranteesTest.kt
@@ -1,0 +1,115 @@
+package org.reduxkotlin.concurrent.concurrency
+
+import org.reduxkotlin.concurrent.CallerSerializedStore
+import org.reduxkotlin.concurrent.LogAndContinue
+import org.reduxkotlin.concurrent.NotificationContext
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins the lock-free read guarantee (test gap T1) and the publish point (C1):
+ * while a dispatch holds the writer lock — parked in a reducer or in an Inline
+ * subscriber — `getState()` and `subscribe()` on another thread return
+ * promptly, and what `getState()` returns is determined by the publish point
+ * (before listener fan-out, after the reducer commits).
+ *
+ * Latch choreography only; generous awaits; assertions on completion, never
+ * on latency.
+ */
+class LockFreeReadGuaranteesTest {
+
+    private data class S(val count: Int = 0)
+    private object Inc
+
+    private val awaitSeconds = 30L
+
+    @Test
+    fun readsDoNotBlockAndSeeTheNewStateWhileAnInlineSubscriberHoldsTheLock() {
+        val subscriberParked = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val store = CallerSerializedStore(
+            inner = org.reduxkotlin.createStore(
+                { s: S, a -> if (a is Inc) s.copy(count = s.count + 1) else s },
+                S(),
+            ),
+            notificationContext = NotificationContext.Inline,
+            onError = LogAndContinue,
+        )
+        store.subscribe {
+            subscriberParked.countDown()
+            check(release.await(awaitSeconds, TimeUnit.SECONDS)) { "release latch timed out" }
+        }
+
+        val dispatcher = thread(isDaemon = true) { store.dispatch(Inc) }
+        assertTrue(subscriberParked.await(awaitSeconds, TimeUnit.SECONDS), "subscriber never parked")
+
+        // Writer lock is held by the parked Inline fan-out. Reads and
+        // subscriptions must complete without it.
+        val readerDone = CountDownLatch(1)
+        var observed = -1
+        var subscribed = false
+        val reader = thread(isDaemon = true) {
+            observed = store.state.count
+            store.subscribe { }
+            subscribed = true
+            readerDone.countDown()
+        }
+        assertTrue(
+            readerDone.await(awaitSeconds, TimeUnit.SECONDS),
+            "getState/subscribe blocked while the writer lock was held",
+        )
+        // Publish point: the mirror was published BEFORE the fan-out, so the
+        // reader already sees the new state while the subscriber is parked.
+        assertEquals(1, observed, "reader must see the published (new) state mid-fan-out")
+        assertTrue(subscribed)
+
+        release.countDown()
+        dispatcher.join(TimeUnit.SECONDS.toMillis(awaitSeconds))
+        reader.join(TimeUnit.SECONDS.toMillis(awaitSeconds))
+        assertEquals(1, store.state.count)
+    }
+
+    @Test
+    fun readsDoNotBlockAndSeeThePreviousStateWhileTheReducerIsRunning() {
+        val reducerParked = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val store = CallerSerializedStore(
+            inner = org.reduxkotlin.createStore(
+                { s: S, a ->
+                    if (a is Inc) {
+                        reducerParked.countDown()
+                        check(release.await(awaitSeconds, TimeUnit.SECONDS)) { "release latch timed out" }
+                        s.copy(count = s.count + 1)
+                    } else {
+                        s
+                    }
+                },
+                S(),
+            ),
+            notificationContext = NotificationContext.Inline,
+            onError = LogAndContinue,
+        )
+
+        val dispatcher = thread(isDaemon = true) { store.dispatch(Inc) }
+        assertTrue(reducerParked.await(awaitSeconds, TimeUnit.SECONDS), "reducer never parked")
+
+        val readerDone = CountDownLatch(1)
+        var observed = -1
+        val reader = thread(isDaemon = true) {
+            observed = store.state.count
+            readerDone.countDown()
+        }
+        assertTrue(readerDone.await(awaitSeconds, TimeUnit.SECONDS), "getState blocked mid-reduce")
+        // Mid-reduce there is nothing committed yet: the previous mirror is correct.
+        assertEquals(0, observed, "mid-reduce reads return the previous published state")
+
+        release.countDown()
+        dispatcher.join(TimeUnit.SECONDS.toMillis(awaitSeconds))
+        reader.join(TimeUnit.SECONDS.toMillis(awaitSeconds))
+        assertEquals(1, store.state.count)
+    }
+}

--- a/redux-kotlin-concurrent/src/jvmTest/kotlin/org/reduxkotlin/concurrent/concurrency/MirrorPublishOrderingTest.kt
+++ b/redux-kotlin-concurrent/src/jvmTest/kotlin/org/reduxkotlin/concurrent/concurrency/MirrorPublishOrderingTest.kt
@@ -1,0 +1,143 @@
+package org.reduxkotlin.concurrent.concurrency
+
+import org.reduxkotlin.concurrent.CallerSerializedStore
+import org.reduxkotlin.concurrent.LogAndContinue
+import org.reduxkotlin.concurrent.NotificationContext
+import org.reduxkotlin.granular.subscribeTo
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins the publish-then-signal contract (hardening plan C1): a posted subscriber
+ * callback must observe state at least as new as the dispatch that triggered it.
+ *
+ * The pre-fix code published the mirror in `sequenced()`'s finally, AFTER the
+ * fan-out posts — so a posted callback racing ahead of the dispatching thread
+ * read the stale mirror, the granular diff saw no change, and no further
+ * callback ever arrived for that dispatch (lost wakeup; the binding stayed
+ * stale until the next dispatch).
+ *
+ * The race is frozen deterministically: a second listener registered directly
+ * on the INNER store parks the dispatching thread after the wrapper's fan-out
+ * hook has posted (the hook subscribes first, in `init`) but before the
+ * pre-fix finally-publish could run. The posted callback then provably executes
+ * against whatever mirror is published at fan-out time.
+ */
+class MirrorPublishOrderingTest {
+
+    private data class S(val count: Int = 0)
+    private object Inc
+
+    private val awaitSeconds = 30L
+
+    @Test
+    fun postedCallbackObservesStateAtLeastAsNewAsItsTriggeringDispatch() {
+        val executor = Executors.newSingleThreadExecutor(DaemonThreadFactory())
+        try {
+            val postedDone = CountDownLatch(1)
+            // Posting context backed by a single-thread executor: callbacks run
+            // off the dispatching thread, like a main-thread Handler would.
+            val postingContext = NotificationContext { block ->
+                executor.execute {
+                    block()
+                    postedDone.countDown()
+                }
+            }
+            val store = CallerSerializedStore(
+                inner = org.reduxkotlin.createStore(
+                    { s: S, a -> if (a is Inc) s.copy(count = s.count + 1) else s },
+                    S(),
+                ),
+                notificationContext = postingContext,
+                onError = LogAndContinue,
+            )
+
+            // Diff-based consumer (the layer the race actually bit): fires only
+            // when the value it reads at callback time differs from its last.
+            val observed = mutableListOf<Int>()
+            store.subscribeTo({ it.count }, triggerOnSubscribe = false) { _, new ->
+                observed += new
+            }
+
+            // Parks the dispatching thread inside the inner notification loop,
+            // AFTER the wrapper's fan-out hook (registered first in init) has
+            // posted, and BEFORE sequenced()'s finally can run.
+            val release = CountDownLatch(1)
+            store.store.subscribe {
+                check(release.await(awaitSeconds, TimeUnit.SECONDS)) { "release latch timed out" }
+            }
+
+            val dispatcher = thread(isDaemon = true) { store.dispatch(Inc) }
+
+            // The posted granular callback runs to completion while the
+            // dispatching thread is still parked pre-(finally-)publish.
+            assertTrue(postedDone.await(awaitSeconds, TimeUnit.SECONDS), "posted callback never ran")
+            release.countDown()
+            dispatcher.join(TimeUnit.SECONDS.toMillis(awaitSeconds))
+
+            // Drain the executor so any (correct or buggy) trailing work lands.
+            val drained = CountDownLatch(1)
+            executor.execute { drained.countDown() }
+            assertTrue(drained.await(awaitSeconds, TimeUnit.SECONDS), "executor never drained")
+
+            assertEquals(
+                listOf(1),
+                observed,
+                "posted callback must observe the state of its triggering dispatch exactly once " +
+                    "(empty = lost wakeup: callback read the pre-publish mirror)",
+            )
+            assertEquals(1, store.state.count)
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun stormNeverLosesTheFinalValue() {
+        val executor = Executors.newSingleThreadExecutor(DaemonThreadFactory())
+        try {
+            val postingContext = NotificationContext { block -> executor.execute(block) }
+            val store = CallerSerializedStore(
+                inner = org.reduxkotlin.createStore(
+                    { s: S, a -> if (a is Inc) s.copy(count = s.count + 1) else s },
+                    S(),
+                ),
+                notificationContext = postingContext,
+                onError = LogAndContinue,
+            )
+
+            val lastObserved = java.util.concurrent.atomic.AtomicInteger(-1)
+            store.subscribeTo({ it.count }, triggerOnSubscribe = false) { _, new ->
+                lastObserved.set(new)
+            }
+
+            val dispatchesPerThread = 1000
+            val threads = (1..2).map {
+                thread(isDaemon = true) {
+                    repeat(dispatchesPerThread) { store.dispatch(Inc) }
+                }
+            }
+            threads.forEach { it.join(TimeUnit.SECONDS.toMillis(awaitSeconds)) }
+
+            // Quiesce the notification executor, then the diff layer must have
+            // observed the final value (no lost trailing wakeup).
+            val drained = CountDownLatch(1)
+            executor.execute { drained.countDown() }
+            assertTrue(drained.await(awaitSeconds, TimeUnit.SECONDS), "executor never drained")
+
+            assertEquals(2 * dispatchesPerThread, store.state.count)
+            assertEquals(
+                2 * dispatchesPerThread,
+                lastObserved.get(),
+                "diff layer missed the final dispatch (lost trailing wakeup)",
+            )
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+}


### PR DESCRIPTION
**Stage 2 of the concurrent-store hardening plan (#336)** — concerns C1 (HIGH), C5, C6, atomically, plus test gaps T1/T2/T4/T5.

## The lost-wakeup race (C1)

The mirror was published in `sequenced()`'s `finally` — *after* the fan-out posts. A posted callback racing ahead of the dispatching thread read the pre-dispatch mirror; for diff-based consumers (granular subscriptions → Compose bindings) the diff compared old-vs-old, no further signal arrived for that dispatch, and the binding stayed stale until the next one.

**Fix: publish-then-signal.** The mirror publish is now the first step of the inner-store fan-out hook (the hook runs after the reducer commits; the atomic write happens-before every `post()`). A callback now always observes state at least as new as its triggering dispatch. The `finally` re-publish stays as an idempotent backstop (reducer-throw, middleware-swallowed actions). `MirrorPublishOrderingTest` freezes the race deterministically (parked inner listener) — **fails on master, passes here**; a posting-storm companion pins the trailing wakeup.

## Unsubscribe (C5) + onError (C6)

Private `Registration` wrapper with an `active` flag checked at callback **execution** time: after `unsubscribe()` returns, no new callback invocation begins — including callbacks already queued on a posting context. (Deliberate, documented divergence from core Redux snapshot delivery: with Inline, a peer unsubscribed earlier in the same fan-out is skipped.) The same fan-out lambda self-shields `onError`: a throwing handler is printed and swallowed; delivery and dispatch always proceed. All 6 C5/C6 tests verified RED against pre-fix code.

## Contract changes (documented in the same commit)

The old "mirror published after listeners / no mid-listener tear" KDoc claim is **retired** (it was already false for posting contexts — that *was* the bug; audited: no test pinned it). New invariant, written into ConcurrentStore/NotificationContext/CreateConcurrentStore KDocs + `store-consistency-model.md` + CHANGELOG:

> reducer commits → mirror publishes → listeners signaled → lock releases; a callback always observes state ≥ its triggering dispatch; callbacks pull state (signal, not payload); no "listeners finished" barrier; contexts MUST deliver serially; Inline holds the writer lock across callbacks (delays dispatchers, never readers); coalescing = inline-vs-marshal, never burst collapsing; unsubscribe-wins.

## New tests

| Test | Closes |
|---|---|
| `MirrorPublishOrderingTest` (jvmTest, latch-choreographed, no sleeps) | C1 / T3 |
| `LockFreeReadGuaranteesTest` (jvmTest) | T1 + publish-point pin |
| `QueuedNotificationStoreTest` (commonTest, via new `QueueingNotificationContext` fixture) | T2 |
| `UnsubscribeSemanticsTest` (commonTest, 4 cases) | C5 / T4 |
| `CoalescingContextDeliveryTest` (commonTest) | T5 |
| `OnErrorIsolationTest` (commonTest) | C6 |

Build edge: `redux-kotlin-concurrent` jvmTest now depends on `:redux-kotlin-granular` (test-scope only, acyclic — the race is pinned through the layer it actually bit).

## Verification

Full `./gradlew build` green (all module suites incl. existing concurrent stress tests, granular, compose, taskflow). `apiDump` no-op — `Registration` is private; zero public-signature changes.

Note: overlaps textually with the doc-only #335 in `NotificationContext` KDoc / `store-consistency-model.md` — this PR carries the post-fix wording (the #335 "posted callback can win the race" note is obsolete once this merges). Merging this first and dropping that hunk from #335, or rebasing whichever lands second, both work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)