### PR TITLE
fix(compose): install binding subscription before the subscribe-time re-sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `redux-kotlin-concurrent`: a throwing `onError` handler no longer aborts
   delivery to remaining subscribers or escapes `dispatch` — it is printed and
   swallowed.
+- `redux-kotlin-compose`: `selectorState` / `fieldState` now install their store
+  subscription **before** running the subscribe-time re-sample (previously
+  after). A state change landing between the re-sample and the subscription
+  install — e.g. a fast off-main dispatch during effect commit — could
+  otherwise go unobserved forever (no notification, no re-sample). With the
+  new order every change before the install is caught by the re-sample and
+  every change after it by the subscription; the worst-case overlap is one
+  redundant same-value recomposition.
 
 ### Changed
 

--- a/redux-kotlin-compose/build.gradle.kts
+++ b/redux-kotlin-compose/build.gradle.kts
@@ -36,6 +36,9 @@ kotlin {
                 implementation(compose.uiTest)
                 implementation(compose.desktop.currentOs)
                 implementation(libs.kotlinx.coroutines.test)
+                // Binding tests against the real concurrent store (test-scope only;
+                // the published POM is unaffected).
+                implementation(project(":redux-kotlin-concurrent"))
             }
         }
     }

--- a/redux-kotlin-compose/src/commonMain/kotlin/org/reduxkotlin/compose/FieldState.kt
+++ b/redux-kotlin-compose/src/commonMain/kotlin/org/reduxkotlin/compose/FieldState.kt
@@ -30,10 +30,13 @@ import kotlin.reflect.KProperty1
  * state change — reads the freshest store state, never a stale cached
  * snapshot lagging a frame behind the notification.
  *
- * A B3 re-sample runs inside the [DisposableEffect]: it compares the value at first composition
- * against the value at the effect's commit and bumps the tick **only if it changed**. This catches a
- * change that landed between first composition and subscribe (e.g. a fast async load), for which no
- * real notification is delivered — without it the binding would stay stuck on the first-frame value.
+ * A B3 re-sample runs inside the [DisposableEffect], AFTER the subscription is installed: it
+ * compares the value at first composition against the current value and bumps the tick **only if
+ * it changed**. The subscribe-then-resample order is load-bearing — every change before the
+ * install is caught by the re-sample, every change after it by the subscription, so no window
+ * remains (the worst-case overlap is one redundant same-value bump). This catches a change that
+ * landed between first composition and the install (e.g. a fast async load), for which no real
+ * notification is delivered — without it the binding would stay stuck on the first-frame value.
  * Because the bump is conditional, an unchanged value adds no mount-time recomposition (so render
  * isolation is preserved: a binding only recomposes when its selected value actually moves).
  *
@@ -55,16 +58,21 @@ public fun <S, F> Store<S>.selectorState(selector: (S) -> F): State<F> {
     // landed before the subscription was installed.
     val initial = remember(store, rememberedSelector) { rememberedSelector(store.state) }
     DisposableEffect(store, rememberedSelector) {
-        // B3 re-sample: if the selected value changed between first composition and this effect's
-        // commit (e.g. a fast async load), bump the tick so the getter re-reads. Conditional, so an
-        // unchanged value adds no mount-time recomposition (preserves render isolation).
-        if (rememberedSelector(store.state) != initial) tick.intValue++
+        // Install the subscription FIRST, then re-sample — the order is load-bearing: a change
+        // landing before the install is caught by the re-sample below; a change landing after it
+        // is caught by the subscription. With the reverse order, a change landing between the
+        // re-sample and the install (e.g. inside subscribe() itself, or a fast off-main dispatch)
+        // was never observed. Worst-case overlap is one redundant same-value tick bump.
         val sub = store.subscribeTo(
             selector = rememberedSelector,
             triggerOnSubscribe = false,
         ) { _, _ ->
             tick.intValue++
         }
+        // B3 re-sample: if the selected value changed between first composition and this point
+        // (e.g. a fast async load), bump the tick so the getter re-reads. Conditional, so an
+        // unchanged value adds no mount-time recomposition (preserves render isolation).
+        if (rememberedSelector(store.state) != initial) tick.intValue++
         onDispose { sub() }
     }
     return remember(store, rememberedSelector) {
@@ -90,8 +98,8 @@ public fun <S, F> Store<S>.selectorState(selector: (S) -> F): State<F> {
  * `store.state` on every [State.value] access; the subscription only
  * schedules recomposition, so the value is correct even when the store
  * delivers notifications asynchronously (e.g. a concurrent store posting
- * to the main thread). Like [selectorState] it runs a conditional B3 re-sample in the effect to
- * catch a change that landed between first composition and the effect commit.
+ * to the main thread). Like [selectorState] it installs the subscription and then runs a
+ * conditional B3 re-sample, so a change landing any time before the install is caught.
  *
  * Hidden from Swift via [HiddenFromObjC] (KProperty1 is Kotlin-only).
  */
@@ -105,15 +113,16 @@ public fun <S, F> Store<S>.fieldState(property: KProperty1<S, F>): State<F> {
     // landed before the subscription was installed.
     val initial = remember(store, property) { property.get(store.state) }
     DisposableEffect(store, property) {
-        // B3 re-sample (see selectorState): bump only if the value changed between first composition
-        // and commit, so an unchanged value adds no mount-time recomposition.
-        if (property.get(store.state) != initial) tick.intValue++
+        // Subscribe first, then re-sample (see selectorState — the order is load-bearing).
         val sub = store.subscribeTo(
             property = property,
             triggerOnSubscribe = false,
         ) { _, _ ->
             tick.intValue++
         }
+        // B3 re-sample: bump only if the value changed between first composition and this point,
+        // so an unchanged value adds no mount-time recomposition.
+        if (property.get(store.state) != initial) tick.intValue++
         onDispose { sub() }
     }
     return remember(store, property) {

--- a/redux-kotlin-compose/src/jvmTest/kotlin/org/reduxkotlin/compose/ConcurrentStoreBindingTest.kt
+++ b/redux-kotlin-compose/src/jvmTest/kotlin/org/reduxkotlin/compose/ConcurrentStoreBindingTest.kt
@@ -1,0 +1,113 @@
+package org.reduxkotlin.compose
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.runComposeUiTest
+import org.junit.Test
+import org.reduxkotlin.concurrent.ConcurrentStore
+import org.reduxkotlin.concurrent.NotificationContext
+import org.reduxkotlin.concurrent.createConcurrentStore
+
+private data class BState(val count: Int = 0, val label: String = "init")
+private data class Add(val amount: Int = 1)
+
+private fun bReducer(state: BState, action: Any): BState = when (action) {
+    is Add -> state.copy(count = state.count + action.amount)
+    else -> state
+}
+
+// Local re-declaration of the queueing context (test fixtures don't cross modules):
+// posts are captured and run only on drain(), making async notification deterministic.
+private class QueueingContext : NotificationContext {
+    private val queue = mutableListOf<() -> Unit>()
+    override fun post(block: () -> Unit) {
+        queue += block
+    }
+    fun drain() {
+        while (queue.isNotEmpty()) {
+            val batch = queue.toList()
+            queue.clear()
+            batch.forEach { it() }
+        }
+    }
+}
+
+private fun queuedConcurrentStore(): Pair<ConcurrentStore<BState>, QueueingContext> {
+    val queue = QueueingContext()
+    return createConcurrentStore(::bReducer, BState(), notificationContext = queue) to queue
+}
+
+/**
+ * Binding behavior against the real `ConcurrentStore` (closes test gap T6 —
+ * the async-notify guarantees were previously proven only against a
+ * hand-rolled fake store).
+ */
+@OptIn(ExperimentalTestApi::class)
+class ConcurrentStoreBindingTest {
+
+    @Test
+    fun bindingUpdatesAfterNotificationDrain() = runComposeUiTest {
+        val (store, queue) = queuedConcurrentStore()
+        setContent {
+            val count by store.fieldState(BState::count)
+            Text("count=$count")
+        }
+        waitForIdle()
+        onAllNodesWithText("count=0").assertCountEquals(1)
+
+        store.dispatch(Add())
+        queue.drain()
+        waitForIdle()
+        onAllNodesWithText("count=1").assertCountEquals(1)
+    }
+
+    @Test
+    fun bindingReadsFreshStateWhenRecomposedBeforeDrain() = runComposeUiTest {
+        val (store, queue) = queuedConcurrentStore()
+        val external = mutableStateOf(0)
+        setContent {
+            val tick = external.value
+            val count by store.fieldState(BState::count)
+            Text("count=$count t=$tick")
+        }
+        waitForIdle()
+        onAllNodesWithText("count=0 t=0").assertCountEquals(1)
+
+        store.dispatch(Add()) // mirror published synchronously; notification queued
+        external.value = 1 // recompose via unrelated state, notification NOT drained
+        waitForIdle()
+        // Live getter against the real store: reads the published mirror, not a cache.
+        onAllNodesWithText("count=1 t=1").assertCountEquals(1)
+        queue.drain()
+        waitForIdle()
+        onAllNodesWithText("count=1 t=1").assertCountEquals(1)
+    }
+
+    @Test
+    fun bindingCatchesChangeThatLandedBeforeItSubscribedOnTheRealStore() = runComposeUiTest {
+        val (store, queue) = queuedConcurrentStore()
+        setContent {
+            // Commits before the binding's DisposableEffect (composition order):
+            // the dispatch's notification is queued and never drained, so only the
+            // post-install re-sample can catch the change.
+            DisposableEffect(Unit) {
+                store.dispatch(Add(amount = 7))
+                onDispose {}
+            }
+            val count by store.fieldState(BState::count)
+            Text("count=$count")
+        }
+        waitForIdle()
+        onAllNodesWithText("count=7").assertCountEquals(1)
+        check(store.state.count == 7)
+        // `queue` deliberately not drained — the re-sample alone must suffice.
+        queue.drain() // cleanliness; must not change the rendered value
+        waitForIdle()
+        onAllNodesWithText("count=7").assertCountEquals(1)
+    }
+}

--- a/redux-kotlin-compose/src/jvmTest/kotlin/org/reduxkotlin/compose/FieldStateTest.kt
+++ b/redux-kotlin-compose/src/jvmTest/kotlin/org/reduxkotlin/compose/FieldStateTest.kt
@@ -61,10 +61,8 @@ private class DeferredNotifyStore<S>(initial: S) : org.reduxkotlin.Store<S> {
 // Lands a silent state change exactly inside the binding's effect-time window: `subscribe()`
 // first mutates state WITHOUT notifying, then registers the listener. Whatever the binding does
 // before its subscription is installed cannot see this change; only work done AFTER install can.
-private class MutateOnSubscribeStore(
-    initial: String,
-    private val valueAtSubscribe: String,
-) : org.reduxkotlin.Store<String> {
+private class MutateOnSubscribeStore(initial: String, private val valueAtSubscribe: String) :
+    org.reduxkotlin.Store<String> {
     private var current: String = initial
     private val listeners = mutableListOf<org.reduxkotlin.StoreSubscriber>()
 

--- a/redux-kotlin-compose/src/jvmTest/kotlin/org/reduxkotlin/compose/FieldStateTest.kt
+++ b/redux-kotlin-compose/src/jvmTest/kotlin/org/reduxkotlin/compose/FieldStateTest.kt
@@ -58,8 +58,51 @@ private class DeferredNotifyStore<S>(initial: S) : org.reduxkotlin.Store<S> {
     override val replaceReducer: (org.reduxkotlin.Reducer<S>) -> Unit = { }
 }
 
+// Lands a silent state change exactly inside the binding's effect-time window: `subscribe()`
+// first mutates state WITHOUT notifying, then registers the listener. Whatever the binding does
+// before its subscription is installed cannot see this change; only work done AFTER install can.
+private class MutateOnSubscribeStore(
+    initial: String,
+    private val valueAtSubscribe: String,
+) : org.reduxkotlin.Store<String> {
+    private var current: String = initial
+    private val listeners = mutableListOf<org.reduxkotlin.StoreSubscriber>()
+
+    override val store: org.reduxkotlin.Store<String> = this
+    override val getState: org.reduxkotlin.GetState<String> = { current }
+    override var dispatch: org.reduxkotlin.Dispatcher = { action ->
+        @Suppress("UNCHECKED_CAST")
+        run { current = action as String }
+        action
+    }
+    override val subscribe: (org.reduxkotlin.StoreSubscriber) -> org.reduxkotlin.StoreSubscription = { l ->
+        current = valueAtSubscribe // silent change DURING registration; no notification follows
+        listeners.add(l)
+        val unsubscribe: org.reduxkotlin.StoreSubscription = {
+            listeners.remove(l)
+            Unit
+        }
+        unsubscribe
+    }
+    override val replaceReducer: (org.reduxkotlin.Reducer<String>) -> Unit = { }
+}
+
 @OptIn(ExperimentalTestApi::class)
 class FieldStateTest {
+
+    @Test
+    fun bindingCatchesChangeThatLandedDuringSubscriptionInstall() = runComposeUiTest {
+        val store = MutateOnSubscribeStore(initial = "a", valueAtSubscribe = "b")
+        setContent {
+            val value by store.selectorState { it }
+            Text("v=$value")
+        }
+        waitForIdle()
+        // The change landed inside subscribe() itself, with no notification ever delivered.
+        // Only a re-sample that runs AFTER the subscription is installed can catch it; the
+        // pre-install re-sample order left the binding stale on "a" forever.
+        onAllNodesWithText("v=b").assertCountEquals(1)
+    }
 
     @Test
     fun fieldState_renders_initial_value_on_first_frame() = runComposeUiTest {


### PR DESCRIPTION
**Stage 3 of the concurrent-store hardening plan (#336)** — concern C2(a) + test gap T6.

## The window

`selectorState` / `fieldState` ran the B3 re-sample *before* installing the store subscription. A change landing between the re-sample and the install — inside `subscribe()` itself, or a fast off-main dispatch during effect commit — was never observed: no notification (granular's last-value was sampled with the change already applied), no re-sample, binding stale until an unrelated recomposition.

## The fix

Swap to **subscribe-then-resample** in both bindings: every change before the install is caught by the re-sample (compared against the first-composition value), every change after it by the subscription. No window remains; worst-case overlap is one redundant same-value tick bump. KDoc now documents the order as load-bearing.

## TDD

`bindingCatchesChangeThatLandedDuringSubscriptionInstall` — an evil store whose `subscribe()` mutates state silently before delegating registration, landing exactly in the old gap — **fails on master, passes here**. All 10 pre-existing `FieldStateTest` cases (including both `DeferredNotifyStore` fakes and the existing pre-effect-window test) stay green.

## T6: bindings proven against the real store

New `ConcurrentStoreBindingTest`: the async-notify binding guarantees were previously proven only against a hand-rolled fake. Now pinned against a real `createConcurrentStore` with a queueing `NotificationContext` (locally re-declared — test fixtures don't cross modules): update-after-drain, fresh read on unrelated recomposition *before* the notification drains, and the pre-subscribe change caught by the re-sample alone. Adds a test-scope build edge `compose jvmTest → :redux-kotlin-concurrent` (published POM unaffected; precedented by granular's test deps).

## Verification

Full `./gradlew build` green; no public API change (`apiDump` no-op); detekt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)