### PR TITLE
fix(granular): re-diff every entry after subscription install (race-safe registration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   new order every change before the install is caught by the re-sample and
   every change after it by the subscription; the worst-case overlap is one
   redundant same-value recomposition.
+- `redux-kotlin-granular`: `subscribeTo` / `subscribeFields` registration is
+  now race-safe — after the underlying `store.subscribe` is installed, every
+  selector is re-evaluated and a change that landed during registration fires
+  the real `(old, new)` diff at activation (previously it was silently
+  missed; only `triggerOnSubscribe` entries got a `(current, current)`
+  callback). A moved value subsumes the `triggerOnSubscribe` callback — no
+  double-fire; worst case on a posting store is one redundant same-value
+  callback.
 
 ### Changed
 

--- a/redux-kotlin-granular/src/commonMain/kotlin/org/reduxkotlin/granular/SubscribeFields.kt
+++ b/redux-kotlin-granular/src/commonMain/kotlin/org/reduxkotlin/granular/SubscribeFields.kt
@@ -16,6 +16,14 @@ import kotlin.concurrent.Volatile
  * and removes the typical "render once + subscribe to changes" two-step
  * in UI binding code.
  *
+ * Registration is race-safe: after the underlying `store.subscribe` is
+ * installed, every selector is re-evaluated and a change that landed
+ * during registration fires the real `(old, new)` diff at that point
+ * (subsuming the `triggerOnSubscribe` callback — no double-fire). On a
+ * store that posts notifications, a callback for the same change may
+ * already be queued; the worst case is one redundant same-value
+ * callback.
+ *
  * Returns a [StoreSubscription] (`() -> Unit`) that tears down the
  * subscription when invoked.
  */
@@ -111,8 +119,11 @@ internal class FieldSubscriptionRegistry<State>(
             val state = store.state
             // `entries` is sealed (no further mutation). The only mutable
             // field per entry is `entry.last`, which is @Volatile and
-            // written serially because the store contract guarantees
-            // subscribers are invoked serially within a dispatch.
+            // written serially because notification delivery is required to
+            // be serial: plain stores notify inline under dispatch, and the
+            // concurrent store's NotificationContext contract requires
+            // one-at-a-time, post-ordered delivery (a multi-threaded
+            // executor context is unsupported and would race this field).
             for (i in entries.indices) {
                 @Suppress("UNCHECKED_CAST")
                 val entry = entries[i] as Entry<State, Any?>
@@ -135,25 +146,47 @@ internal class FieldSubscriptionRegistry<State>(
             }
         }
 
-        // Fire triggerOnSubscribe=true entries AFTER the underlying
-        // subscriber is installed, so a racing dispatch can't be silently
-        // dropped (the worst case is the listener fires twice — once from
-        // the dispatch with a real diff, once from the trigger with
-        // (current, current) — which is harmless).
+        // Post-install re-diff, for EVERY entry: a change landing during
+        // registration — after on() sampled `entry.last`, before the
+        // store.subscribe above was installed — has no notification of its
+        // own, so re-evaluate each selector now and fire the real diff if the
+        // value moved. This also subsumes the triggerOnSubscribe firing: a
+        // moved value fires (prev, next) once (no double-fire); an unchanged
+        // value fires the documented (current, current) trigger. On a posting
+        // context a callback for the same change may already be queued — the
+        // worst case is one redundant same-value callback, which is harmless.
+        reDiffAfterInstall()
+
+        return { storeSub() }
+    }
+
+    private fun reDiffAfterInstall() {
+        val state = store.state
         for (i in entries.indices) {
             @Suppress("UNCHECKED_CAST")
             val entry = entries[i] as Entry<State, Any?>
-            if (entry.triggerOnSubscribe) {
-                val current = entry.last
-                try {
-                    entry.listener(current, current)
-                } catch (@Suppress("TooGenericExceptionCaught") cause: Throwable) {
-                    onSelectorError?.invoke(cause)
-                }
+            val next: Any? = try {
+                entry.selector(state)
+            } catch (@Suppress("TooGenericExceptionCaught") cause: Throwable) {
+                onSelectorError?.invoke(cause)
+                continue
+            }
+            val prev = entry.last
+            if (next !== prev && next != prev) {
+                entry.last = next
+                notifyGuarded(entry, prev, next)
+            } else if (entry.triggerOnSubscribe) {
+                notifyGuarded(entry, prev, prev)
             }
         }
+    }
 
-        return { storeSub() }
+    private fun notifyGuarded(entry: Entry<State, Any?>, prev: Any?, next: Any?) {
+        try {
+            entry.listener(prev, next)
+        } catch (@Suppress("TooGenericExceptionCaught") cause: Throwable) {
+            onSelectorError?.invoke(cause)
+        }
     }
 
     private companion object {

--- a/redux-kotlin-granular/src/commonTest/kotlin/org/reduxkotlin/granular/ActivationReDiffTest.kt
+++ b/redux-kotlin-granular/src/commonTest/kotlin/org/reduxkotlin/granular/ActivationReDiffTest.kt
@@ -1,0 +1,94 @@
+package org.reduxkotlin.granular
+
+import org.reduxkotlin.Dispatcher
+import org.reduxkotlin.GetState
+import org.reduxkotlin.Reducer
+import org.reduxkotlin.Store
+import org.reduxkotlin.StoreSubscriber
+import org.reduxkotlin.StoreSubscription
+import org.reduxkotlin.createStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the activate-time re-diff (hardening plan C2(b)): a state change landing
+ * during registration — after `on()` sampled `entry.last`, before (or while)
+ * `activate()` installs the underlying `store.subscribe` — must fire the
+ * listener at activation instead of being silently missed.
+ */
+class ActivationReDiffTest {
+
+    private data class S(val count: Int = 0, val label: String = "init")
+    private object Inc
+
+    private val reducer: Reducer<S> = { s, a -> if (a is Inc) s.copy(count = s.count + 1) else s }
+
+    /** Delegates to a real store but dispatches [Inc] inside `subscribe`, BEFORE registering. */
+    private class MutateOnSubscribeStore(private val inner: Store<S>) : Store<S> {
+        override val store: Store<S> = this
+        override val getState: GetState<S> = inner.getState
+        override var dispatch: Dispatcher = { a -> inner.dispatch(a) }
+        override val subscribe: (StoreSubscriber) -> StoreSubscription = { l ->
+            inner.dispatch(Inc) // lands exactly in the registration window
+            inner.subscribe(l)
+        }
+        override val replaceReducer: (Reducer<S>) -> Unit = inner.replaceReducer
+    }
+
+    @Test
+    fun changeLandingDuringRegistrationFiresAtActivate() {
+        val store = MutateOnSubscribeStore(createStore(reducer, S()))
+        val fired = mutableListOf<Pair<Int, Int>>()
+
+        store.subscribeTo({ it.count }, triggerOnSubscribe = false) { old, new ->
+            fired += old to new
+        }
+
+        // The change landed inside subscribe() with no notification for it;
+        // only an activate-time re-diff can observe it.
+        assertEquals(listOf(0 to 1), fired, "registration-window change must fire at activate")
+
+        // The diff state is consistent afterwards: the next real change fires once.
+        store.dispatch(Inc)
+        assertEquals(listOf(0 to 1, 1 to 2), fired)
+    }
+
+    @Test
+    fun triggerOnSubscribeFiresTheRealDiffWhenTheWindowChangedTheValue() {
+        val store = MutateOnSubscribeStore(createStore(reducer, S()))
+        val fired = mutableListOf<Pair<Int, Int>>()
+
+        store.subscribeTo({ it.count }, triggerOnSubscribe = true) { old, new ->
+            fired += old to new
+        }
+
+        // Exactly one activation callback: the real (0, 1) diff subsumes the
+        // (current, current) trigger — no double-fire.
+        assertEquals(listOf(0 to 1), fired)
+    }
+
+    @Test
+    fun triggerOnSubscribeStillFiresCurrentCurrentWhenNothingChanged() {
+        val store = createStore(reducer, S())
+        val fired = mutableListOf<Pair<Int, Int>>()
+
+        store.subscribeTo({ it.count }, triggerOnSubscribe = true) { old, new ->
+            fired += old to new
+        }
+
+        assertEquals(listOf(0 to 0), fired, "unchanged value keeps the (current, current) trigger")
+    }
+
+    @Test
+    fun untouchedEntriesDoNotFireAtActivate() {
+        val store = MutateOnSubscribeStore(createStore(reducer, S()))
+        val labelFired = mutableListOf<Pair<String, String>>()
+
+        store.subscribeTo({ it.label }, triggerOnSubscribe = false) { old, new ->
+            labelFired += old to new
+        }
+
+        // The window change touched `count`, not `label` — no spurious callback.
+        assertEquals(emptyList(), labelFired)
+    }
+}


### PR DESCRIPTION
**Stage 4 of the concurrent-store hardening plan (#336)** — concern C2(b), the granular-layer twin of #340.

## The window

`subscribeTo`/`subscribeFields` sampled each entry's baseline (`entry.last`) at `on()` registration, then installed the underlying `store.subscribe` in `activate()`. A change landing in between had no notification of its own and was silently missed — the diff layer's baseline already held the new value, so the listener never fired for it. #340 fixed this for Compose bindings; this fixes it where it belongs, for **every** granular consumer.

## The fix

`activate()` now re-evaluates every selector after the install and fires the real `(old, new)` diff for any value that moved. The moved-value case **subsumes** the `triggerOnSubscribe` callback (one callback, real diff, no double-fire); the unchanged case keeps the documented `(current, current)` trigger. Worst case on a posting store is one redundant same-value callback (notification for the same change already queued) — harmless for diff consumers.

Also: the serial-delivery comment in the dispatch hot path now correctly cites the `NotificationContext` serial-delivery requirement (it previously claimed a generic "store contract"), and the registration-window contract is documented on `subscribeTo` (C4 doc rider).

## TDD

- `changeLandingDuringRegistrationFiresAtActivate` — delegate store dispatches inside `subscribe()` before registering — **failed pre-fix**
- `triggerOnSubscribeFiresTheRealDiffWhenTheWindowChangedTheValue` — **failed pre-fix**
- `triggerOnSubscribeStillFiresCurrentCurrentWhenNothingChanged` + `untouchedEntriesDoNotFireAtActivate` — regression pins, green throughout

All pre-existing granular tests (incl. the `triggerOnSubscribe` suite and both concurrency stress scenarios), compose, and multimodel-granular suites stay green. Full `./gradlew build` green; no public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)