### PR TITLE
test: tripwire pins for granular-over-concurrent serial delivery and Inline lock-held fan-out

### DIFF
--- a/redux-kotlin-concurrent/src/jvmTest/kotlin/org/reduxkotlin/concurrent/concurrency/WriterSerializationOrderingTest.kt
+++ b/redux-kotlin-concurrent/src/jvmTest/kotlin/org/reduxkotlin/concurrent/concurrency/WriterSerializationOrderingTest.kt
@@ -40,10 +40,12 @@ class WriterSerializationOrderingTest {
                 { s: S, a ->
                     when (a) {
                         is MarkA -> s.copy(count = s.count + 1)
+
                         is MarkB -> {
                             events += "B-reduce"
                             s.copy(count = s.count + 1)
                         }
+
                         else -> s
                     }
                 },

--- a/redux-kotlin-concurrent/src/jvmTest/kotlin/org/reduxkotlin/concurrent/concurrency/WriterSerializationOrderingTest.kt
+++ b/redux-kotlin-concurrent/src/jvmTest/kotlin/org/reduxkotlin/concurrent/concurrency/WriterSerializationOrderingTest.kt
@@ -1,0 +1,91 @@
+package org.reduxkotlin.concurrent.concurrency
+
+import org.reduxkotlin.concurrent.CallerSerializedStore
+import org.reduxkotlin.concurrent.LogAndContinue
+import org.reduxkotlin.concurrent.NotificationContext
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.LockSupport
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tripwire (hardening plan C7): with the Inline context, subscriber callbacks
+ * run while the writer lock is held — dispatcher A's parked subscriber must
+ * complete strictly before dispatcher B's reducer runs. Any future
+ * fan-out-off-the-lock change flips this ordering consciously (and must then
+ * revisit granular's serial-delivery assumption — see
+ * GranularOnConcurrentStoreStressTest in redux-kotlin-granular).
+ *
+ * Latch-choreographed event log; no timing assertions.
+ */
+class WriterSerializationOrderingTest {
+
+    private data class S(val count: Int = 0)
+    private object MarkA
+    private object MarkB
+
+    private val awaitSeconds = 30L
+
+    @Test
+    fun parkedInlineSubscriberCompletesBeforeTheNextDispatchersReducerRuns() {
+        val events = java.util.Collections.synchronizedList(mutableListOf<String>())
+        val subscriberParked = CountDownLatch(1)
+        val release = CountDownLatch(1)
+
+        val store = CallerSerializedStore(
+            inner = org.reduxkotlin.createStore(
+                { s: S, a ->
+                    when (a) {
+                        is MarkA -> s.copy(count = s.count + 1)
+                        is MarkB -> {
+                            events += "B-reduce"
+                            s.copy(count = s.count + 1)
+                        }
+                        else -> s
+                    }
+                },
+                S(),
+            ),
+            notificationContext = NotificationContext.Inline,
+            onError = LogAndContinue,
+        )
+
+        var parkedOnce = false
+        store.subscribe {
+            if (!parkedOnce) {
+                parkedOnce = true
+                events += "A-sub-start"
+                subscriberParked.countDown()
+                check(release.await(awaitSeconds, TimeUnit.SECONDS)) { "release latch timed out" }
+                events += "A-sub-end"
+            }
+        }
+
+        val dispatcherA = thread(isDaemon = true) { store.dispatch(MarkA) }
+        assertTrue(subscriberParked.await(awaitSeconds, TimeUnit.SECONDS), "A's subscriber never parked")
+
+        val dispatcherB = thread(isDaemon = true) { store.dispatch(MarkB) }
+        // Confirm B is genuinely blocked on the writer lock before releasing A
+        // (bounded thread-state poll — a liveness wait, not a timing assertion).
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(awaitSeconds)
+        while (dispatcherB.state != Thread.State.BLOCKED && dispatcherB.state != Thread.State.WAITING) {
+            check(System.nanoTime() < deadline) { "dispatcher B never blocked on the writer lock" }
+            check(dispatcherB.isAlive || events.contains("B-reduce")) { "dispatcher B died unexpectedly" }
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1))
+        }
+
+        release.countDown()
+        dispatcherA.join(TimeUnit.SECONDS.toMillis(awaitSeconds))
+        dispatcherB.join(TimeUnit.SECONDS.toMillis(awaitSeconds))
+
+        assertEquals(
+            listOf("A-sub-start", "A-sub-end", "B-reduce"),
+            events.toList(),
+            "Inline fan-out must hold the writer lock: A's subscriber completes before B's reducer",
+        )
+        assertEquals(2, store.state.count)
+    }
+}

--- a/redux-kotlin-granular/build.gradle.kts
+++ b/redux-kotlin-granular/build.gradle.kts
@@ -51,6 +51,9 @@ kotlin {
                 // Concurrency stress tests use the thread-safe store as
                 // the canonical multi-threaded host.
                 implementation(project(":redux-kotlin-threadsafe"))
+                // Tripwire: granular diffing over the concurrent store relies on
+                // the fan-out staying under the writer lock (serial delivery).
+                implementation(project(":redux-kotlin-concurrent"))
             }
         }
         named("jvmBenchmark") {

--- a/redux-kotlin-granular/src/jvmTest/kotlin/org/reduxkotlin/granular/concurrency/GranularOnConcurrentStoreStressTest.kt
+++ b/redux-kotlin-granular/src/jvmTest/kotlin/org/reduxkotlin/granular/concurrency/GranularOnConcurrentStoreStressTest.kt
@@ -1,0 +1,105 @@
+package org.reduxkotlin.granular.concurrency
+
+import org.reduxkotlin.Reducer
+import org.reduxkotlin.concurrent.createConcurrentStore
+import org.reduxkotlin.granular.subscribeTo
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReferenceArray
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tripwire (hardening plan C4): granular diffing over the REAL concurrent
+ * store. `Entry.last` is a read-compare-write that is only sound under serial
+ * notification delivery; with the default Inline context that serialism comes
+ * for free from the fan-out running under the writer lock. If anyone ever
+ * moves the fan-out off the lock (or otherwise breaks serial delivery), this
+ * test fails loudly with lost/duplicated diffs.
+ *
+ * (Scenario 5a/5b in ConcurrencyStressTest run against createThreadSafeStore;
+ * granular-over-ConcurrentStore previously had zero coverage.)
+ */
+class GranularOnConcurrentStoreStressTest {
+
+    private class DaemonThreadFactory : java.util.concurrent.ThreadFactory {
+        override fun newThread(r: Runnable): Thread = Thread(r).apply { isDaemon = true }
+    }
+
+    private data class GridState(val cells: List<Int>)
+    private data class IncCell(val index: Int)
+
+    private val cellCount = 100
+    private val threads = 4
+    private val dispatchesPerThread = 2_500
+    private val awaitSeconds = 30L
+
+    private val reducer: Reducer<GridState> = { state, action ->
+        if (action is IncCell) {
+            state.copy(cells = state.cells.toMutableList().also { it[action.index] = it[action.index] + 1 })
+        } else {
+            state
+        }
+    }
+
+    @Test
+    fun hundredGranularSubscriptionsSurviveAFourThreadDispatchStorm() {
+        val store = createConcurrentStore(reducer, GridState(List(cellCount) { 0 }))
+        val selectorErrors = AtomicInteger(0)
+        val lastObserved = AtomicReferenceArray<Int>(cellCount)
+        val monotonicViolations = AtomicInteger(0)
+
+        repeat(cellCount) { index ->
+            lastObserved.set(index, 0)
+            store.subscribeTo({ it.cells[index] }, triggerOnSubscribe = false) { old, new ->
+                // Serial delivery makes each entry's stream of diffs strictly
+                // monotonic for this counter; any lost or duplicated diff
+                // breaks the chain.
+                if (old != lastObserved.get(index) || new != old + 1) monotonicViolations.incrementAndGet()
+                lastObserved.set(index, new)
+            }
+        }
+
+        val barrier = CyclicBarrier(threads)
+        val done = CountDownLatch(threads)
+        val pool = Executors.newFixedThreadPool(threads, DaemonThreadFactory())
+        try {
+            repeat(threads) { t ->
+                pool.execute {
+                    try {
+                        barrier.await(awaitSeconds, TimeUnit.SECONDS)
+                        var seed = t + 1
+                        repeat(dispatchesPerThread) {
+                            seed = seed * 1_103_515_245 + 12_345
+                            store.dispatch(IncCell((seed ushr 16).mod(cellCount)))
+                        }
+                    } catch (@Suppress("TooGenericExceptionCaught") t2: Throwable) {
+                        selectorErrors.incrementAndGet()
+                        println("storm worker failed: $t2")
+                    } finally {
+                        done.countDown()
+                    }
+                }
+            }
+            assertTrue(done.await(awaitSeconds * 2, TimeUnit.SECONDS), "storm never finished")
+        } finally {
+            pool.shutdownNow()
+        }
+
+        val finalState = store.state
+        assertEquals(threads * dispatchesPerThread, finalState.cells.sum(), "no lost reducer updates")
+        assertEquals(0, selectorErrors.get(), "no worker/selector failures")
+        assertEquals(0, monotonicViolations.get(), "no lost or duplicated diffs under contention")
+        repeat(cellCount) { index ->
+            assertEquals(
+                finalState.cells[index],
+                lastObserved.get(index),
+                "entry $index missed its final notification (lost trailing wakeup)",
+            )
+        }
+    }
+}


### PR DESCRIPTION
**Stage 5 (final) of the concurrent-store hardening plan (#336)** — executable evidence for the two document-only decisions, C4 and C7.

C4 and C7 were resolved as *documented constraints* (serial-delivery requirement on `NotificationContext`; Inline runs callbacks under the writer lock — delays dispatchers, never readers). These tripwires make both decisions enforceable instead of prose-only:

- **`GranularOnConcurrentStoreStressTest`** (granular jvmTest): 100 `subscribeTo` entries over a **real** `createConcurrentStore` (default Inline) under a 4-thread × 2,500-dispatch storm. Per-entry diff streams must stay strictly monotonic (any lost or duplicated diff breaks the chain), every entry must observe its final value, and no reducer update may be lost. Granular-over-ConcurrentStore previously had zero coverage — the existing stress scenarios run against `createThreadSafeStore`. If anyone ever moves the fan-out off the writer lock or hands notifications to a multi-threaded executor, this fails loudly. Adds the test-scope build edge `granular jvmCommonTest → :redux-kotlin-concurrent` (acyclic; precedented by the existing `:redux-kotlin-threadsafe` test dep).
- **`WriterSerializationOrderingTest`** (concurrent jvmTest): latch-choreographed event log proving dispatcher A's parked Inline subscriber completes strictly before dispatcher B's reducer runs. B is confirmed genuinely blocked on the writer lock via a bounded thread-state poll (liveness wait, not a timing assertion). A future fan-out-off-the-lock change flips this ordering consciously — and must then revisit granular's serial-delivery assumption.

Both tests pin behavior that holds on current master **and** after #339 (the publish point moves, the lock-held fan-out does not), so this PR is order-independent of the other stages.

Test-only change: full `./gradlew build` green, no API delta, no CHANGELOG entry needed.

With this, all five stages of #336 are delivered: #338 (C3) → #339 (C1+C5+C6) → #340 (C2a) → #341 (C2b) → this (C4/C7 tripwires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)