### PR TITLE
fix(taskflow): make bot moves bidirectional so the board can't drain into Done

### DIFF
--- a/examples/taskflow/ARCHITECTURE.md
+++ b/examples/taskflow/ARCHITECTURE.md
@@ -664,9 +664,14 @@ scope.launch {
 }
 ```
 
-It picks a non-terminal column with cards and advances one card to the next column,
-dispatching **`BotMovedCard`** (not `Undoable`, so it never enters user undo history, and
-it triggers no sync — it represents server truth). The bot is started/stopped by
+It picks a card from any populated column and moves it one column forward or backward
+(direction uniform among the valid neighbours, clamped at the ends), dispatching
+**`BotMovedCard`** (not `Undoable`, so it never enters user undo history, and
+it triggers no sync — it represents server truth). The backward moves matter: a
+forward-only bot makes the terminal column an absorbing state, so within minutes every
+card piles up in "Done" and the earlier columns render their empty state — which reads
+as data loss (it surfaced as a "no cards after process-death restore" bug report). The
+bot is started/stopped by
 `AccountRegistry.startBot/stopBot`, driven by `app/App.kt`'s `BoardLifecycleEffect` (start on
 board open, stop on dispose). Defaults: every 4 s, toggleable via Settings.
 

--- a/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/collaborators/BotCollaborator.kt
+++ b/examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/feature/collaborators/BotCollaborator.kt
@@ -19,8 +19,10 @@ import kotlin.random.Random
  *
  * The loop ticks every `settings().botIntervalMs`; each tick is skipped when the bot is disabled
  * (`!settings().botEnabled`) or no board is loaded. Otherwise it picks — deterministically given
- * [rngSeed] plus the current board — a card sitting in a non-terminal column and dispatches a
- * [BotMovedCard] advancing it one column forward. Because [BotMovedCard] is not `Undoable` and is
+ * [rngSeed] plus the current board — a card from a populated column and dispatches a
+ * [BotMovedCard] moving it one column forward or backward (see [pickMove]; the backward moves keep
+ * the walk non-absorbing so the board never drains into the terminal column). Because
+ * [BotMovedCard] is not `Undoable` and is
  * folded by the integrity-preserving `boardReducer` (remove from all columns, insert once), an
  * interleaved bot/user move can never orphan or duplicate a card, and the move is treated as
  * server-truth (no optimistic revert, not in the user's undo history).
@@ -58,20 +60,28 @@ private fun nextBotMove(store: Store<ModelState>, config: FakeServiceConfig, rng
 }
 
 /**
- * Picks a deterministic forward move: chooses a card from a non-terminal column (one that has a
- * column after it) and advances it to the next column. Returns `null` when no card is movable
- * (every populated column is already the last one, or the board is empty).
+ * Picks a deterministic move to an ADJACENT column: chooses a card from any populated column and
+ * moves it one column forward or backward (direction uniform among the valid neighbours; clamped
+ * at the first/last column). Returns `null` when no card is movable (the board is empty or has a
+ * single column).
+ *
+ * Backward moves are what keep the walk non-absorbing. A forward-only bot turns the terminal
+ * column into an absorbing state: within minutes every card piles up in "Done" and the earlier
+ * columns render their empty state — which reads as data loss (it surfaced as a "no cards after
+ * process-death restore" bug report).
  */
 private fun pickMove(board: Board, rng: Random): BotMovedCard? {
     val lastIndex = board.columns.lastIndex
-    // Columns that hold at least one card AND have a column after them (so a forward move exists).
-    val movableColumns = board.columns.withIndex()
-        .filter { (index, column) -> index < lastIndex && column.cardIds.isNotEmpty() }
-    if (movableColumns.isEmpty()) return null
+    val populated = board.columns.withIndex().filter { (_, column) -> column.cardIds.isNotEmpty() }
+    if (lastIndex < 1 || populated.isEmpty()) return null
 
-    val (columnIndex, column) = movableColumns[rng.nextInt(movableColumns.size)]
+    val (columnIndex, column) = populated[rng.nextInt(populated.size)]
     val cardId = column.cardIds[rng.nextInt(column.cardIds.size)]
-    val target = board.columns[columnIndex + 1]
-    // Insert at the head of the next column (a deterministic, valid index for any column size).
-    return BotMovedCard(cardId = cardId, to = target.id, toIndex = 0)
+    val targetIndex = when (columnIndex) {
+        0 -> 1
+        lastIndex -> lastIndex - 1
+        else -> if (rng.nextBoolean()) columnIndex + 1 else columnIndex - 1
+    }
+    // Insert at the head of the target column (a deterministic, valid index for any column size).
+    return BotMovedCard(cardId = cardId, to = board.columns[targetIndex].id, toIndex = 0)
 }

--- a/examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/feature/collaborators/BotCollaboratorTest.kt
+++ b/examples/taskflow/composeApp/src/commonTest/kotlin/org/reduxkotlin/sample/taskflow/feature/collaborators/BotCollaboratorTest.kt
@@ -138,6 +138,34 @@ class BotCollaboratorTest {
         assertEquals(afterFirst, total, "no further dispatches after cancel: ${store.dispatched}")
     }
 
+    /**
+     * The terminal column must not be an absorbing state: when every card has piled up in Done,
+     * the bot must move one BACK out (otherwise the board permanently drains into Done and the
+     * earlier columns render "No cards" — perceived data loss, see the death-restore bug).
+     */
+    @Test
+    fun terminalPileUpIsNotAbsorbing_botMovesACardBackOut() = runTest {
+        val c1 = card("c1")
+        val c2 = card("c2")
+        val allDone = Board(
+            boardId = BoardId("b1"),
+            columns = persistentListOf(
+                Column(todo, "To Do", persistentListOf()),
+                Column(doing, "Doing", persistentListOf()),
+                Column(done, "Done", persistentListOf(c1.id, c2.id)),
+            ),
+            cards = persistentMapOf(c1.id to c1, c2.id to c2),
+        )
+        val store = storeFor(allDone)
+        startBot(backgroundScope, store, { config(enabled = true) }, rngSeed = 1L)
+
+        advanceTimeBy(intervalMs.toLong())
+        runCurrent()
+
+        val move = store.dispatched.filterIsInstance<BotMovedCard>().single()
+        assertEquals(doing, move.to, "the only legal move from an all-in-Done board is back to Doing")
+    }
+
     @Test
     fun noBoardLoadedSkipsDispatch() = runTest {
         val store = RecordingStore(ModelState.of(BoardModel(null)))

--- a/examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/app/ProcessDeathRestoreTest.kt
+++ b/examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/app/ProcessDeathRestoreTest.kt
@@ -1,0 +1,141 @@
+package org.reduxkotlin.sample.taskflow.app
+
+import app.cash.sqldelight.async.coroutines.synchronous
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.reduxkotlin.concurrent.NotificationContext
+import org.reduxkotlin.devtools.DevToolsHub
+import org.reduxkotlin.sample.taskflow.app.persistence.accountUiSaver
+import org.reduxkotlin.sample.taskflow.core.AccountId
+import org.reduxkotlin.sample.taskflow.core.BoardId
+import org.reduxkotlin.sample.taskflow.core.ColumnId
+import org.reduxkotlin.sample.taskflow.core.NavModel
+import org.reduxkotlin.sample.taskflow.core.Route
+import org.reduxkotlin.sample.taskflow.db.TaskFlowDb
+import org.reduxkotlin.sample.taskflow.feature.board.BoardModel
+import org.reduxkotlin.sample.taskflow.feature.board.LoadBoardRequested
+import org.reduxkotlin.sample.taskflow.infra.SeedData
+import org.reduxkotlin.sample.taskflow.infra.data.local.LocalStore
+import org.reduxkotlin.sample.taskflow.infra.data.local.SqlDelightLocalStore
+import org.reduxkotlin.sample.taskflow.infra.db.taskFlowDb
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Store-level regression proof for the app-death restore flow: the [accountUiSaver] snapshot
+ * (saved while the user was on the add-card screen) restores into a FRESH account store
+ * (simulating process death), the BoardLifecycleEffect-equivalent [LoadBoardRequested] runs, and
+ * the board model comes back populated with the persisted cards.
+ *
+ * Harness note: the effects scope must be a FOREGROUND test scope —
+ * `TestScope.backgroundScope` tasks are skipped by [advanceUntilIdle] (it only drains until no
+ * foreground tasks remain), so effects launched there would never run under virtual time.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProcessDeathRestoreTest {
+
+    private val annId = AccountId("ann")
+    private val annBoardId = BoardId("ann-board")
+    private val todo = ColumnId("ann-todo")
+
+    private fun newLocal(): LocalStore {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        TaskFlowDb.Schema.synchronous().create(driver)
+        return SqlDelightLocalStore(taskFlowDb(driver))
+    }
+
+    @Test
+    fun control_freshStore_loadBoardRequested_populatesBoard() = runTest {
+        val local = newLocal()
+        local.ensureSeeded()
+        val rootStore = createAppStore(NotificationContext.Inline)
+        val scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler))
+        val session = createAccountStore(
+            detail = SeedData.accountDetail(annId),
+            rootStore = rootStore,
+            localStore = local,
+            notificationContext = NotificationContext.Inline,
+            scope = scope,
+        )
+        session.store.dispatch(
+            org.reduxkotlin.sample.taskflow.app.nav.Navigate(Route.Board(annBoardId)),
+        )
+        session.store.dispatch(LoadBoardRequested(annBoardId))
+        advanceUntilIdle()
+        assertNotNull(session.store.state.get<BoardModel>().board, "control: fresh store must load the board")
+        scope.cancel()
+    }
+
+    @Test
+    fun restoreIntoAddCardStack_thenLifecycleLoad_populatesBoard() = runTest {
+        val local = newLocal()
+        local.ensureSeeded()
+        val rootStore = createAppStore(NotificationContext.Inline)
+
+        // --- session 1: user is on the add-card screen; platform saves the UI snapshot ---
+        val scope1 = CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler))
+        val session1 = createAccountStore(
+            detail = SeedData.accountDetail(annId),
+            rootStore = rootStore,
+            localStore = local,
+            notificationContext = NotificationContext.Inline,
+            scope = scope1,
+        )
+        session1.store.dispatch(
+            org.reduxkotlin.sample.taskflow.app.nav.Navigate(Route.Board(annBoardId)),
+        )
+        session1.store.dispatch(
+            org.reduxkotlin.sample.taskflow.app.nav.Navigate(Route.ComposeCard(todo)),
+        )
+        advanceUntilIdle()
+        val encoded = accountUiSaver.json.encodeToString(
+            accountUiSaver.serializer,
+            accountUiSaver.save(session1.store.state),
+        )
+
+        // --- process death: session 1 fully torn down (like a killed process), same durable DB ---
+        session1.bridgeOutput?.stop()
+        session1.devtoolsId?.let { DevToolsHub.removeSession(it) }
+        scope1.cancel()
+        advanceUntilIdle()
+
+        val scope2 = CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler))
+        val session2 = createAccountStore(
+            detail = SeedData.accountDetail(annId),
+            rootStore = rootStore,
+            localStore = local,
+            notificationContext = NotificationContext.Inline,
+            scope = scope2,
+        )
+        val store = session2.store
+
+        // rememberSaveableState's applyRestore: decode + dispatch the restore action.
+        val snapshot = accountUiSaver.json.decodeFromString(accountUiSaver.serializer, encoded)
+        store.dispatch(accountUiSaver.restore(snapshot))
+
+        val nav = store.state.get<NavModel>()
+        assertEquals(
+            persistentListOf(Route.BoardList, Route.Board(annBoardId), Route.ComposeCard(todo)),
+            nav.stack,
+            "nav stack must restore [BoardList, Board, ComposeCard]",
+        )
+
+        // BoardLifecycleEffect equivalent: activeBoardId is non-null -> load the board.
+        store.dispatch(LoadBoardRequested(annBoardId))
+        advanceUntilIdle()
+
+        val board = store.state.get<BoardModel>().board
+        assertNotNull(board, "board must be loaded after restore + LoadBoardRequested")
+        assertTrue(board.cards.isNotEmpty(), "restored board must contain the persisted cards")
+        scope2.cancel()
+    }
+}

--- a/examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/app/ProcessDeathRestoreUiTest.kt
+++ b/examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/app/ProcessDeathRestoreUiTest.kt
@@ -1,0 +1,199 @@
+package org.reduxkotlin.sample.taskflow.app
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
+import androidx.compose.runtime.saveable.SaveableStateRegistry
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.runComposeUiTest
+import app.cash.sqldelight.async.coroutines.synchronous
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import coil3.compose.setSingletonImageLoaderFactory
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.reduxkotlin.Store
+import org.reduxkotlin.compose.multimodel.fieldStateOf
+import org.reduxkotlin.compose.rememberStableStore
+import org.reduxkotlin.compose.saveable.rememberSaveableState
+import org.reduxkotlin.concurrent.NotificationContext
+import org.reduxkotlin.multimodel.ModelState
+import org.reduxkotlin.sample.taskflow.app.persistence.RouteDto
+import org.reduxkotlin.sample.taskflow.app.persistence.UiSnapshot
+import org.reduxkotlin.sample.taskflow.app.persistence.accountUiSaver
+import org.reduxkotlin.sample.taskflow.core.AccountId
+import org.reduxkotlin.sample.taskflow.core.BoardId
+import org.reduxkotlin.sample.taskflow.core.ColumnId
+import org.reduxkotlin.sample.taskflow.core.NavModel
+import org.reduxkotlin.sample.taskflow.core.Route
+import org.reduxkotlin.sample.taskflow.db.TaskFlowDb
+import org.reduxkotlin.sample.taskflow.feature.account.ProfileScreen
+import org.reduxkotlin.sample.taskflow.feature.board.BoardClosed
+import org.reduxkotlin.sample.taskflow.feature.board.BoardScreen
+import org.reduxkotlin.sample.taskflow.feature.board.CardDetailScreen
+import org.reduxkotlin.sample.taskflow.feature.board.LoadBoardRequested
+import org.reduxkotlin.sample.taskflow.feature.boardlist.BoardListScreen
+import org.reduxkotlin.sample.taskflow.feature.settings.SettingsScreen
+import org.reduxkotlin.sample.taskflow.infra.SeedData
+import org.reduxkotlin.sample.taskflow.infra.data.local.LocalStore
+import org.reduxkotlin.sample.taskflow.infra.data.local.SqlDelightLocalStore
+import org.reduxkotlin.sample.taskflow.infra.db.taskFlowDb
+import org.reduxkotlin.sample.taskflow.ui.image.fakeNoNetworkImageLoader
+import org.reduxkotlin.sample.taskflow.ui.theme.TaskFlowTheme
+import kotlin.test.assertEquals
+
+/**
+ * Compose-level regression proof for the app-death restore flow: the platform restores the saveable snapshot
+ * (nav stack `[BoardList, Board, ComposeCard]`), the ActiveAccount-shaped harness applies it via
+ * [rememberSaveableState], the board-lifecycle effect dispatches [LoadBoardRequested], and the
+ * board layer (beneath the add-card overlay) must eventually render the persisted cards.
+ *
+ * The harness mirrors `ActiveAccount` + `BoardLifecycleEffect` + `RouteScreen` from App.kt
+ * (those are private), minus AdaptiveNav chrome and the predictive-back animation.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ProcessDeathRestoreUiTest {
+
+    private val annId = AccountId("ann")
+    private val annBoardId = BoardId("ann-board")
+
+    private fun newLocal(): LocalStore {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        TaskFlowDb.Schema.synchronous().create(driver)
+        return SqlDelightLocalStore(taskFlowDb(driver))
+    }
+
+    /** The persisted snapshot a previous session saved while the user was on the add-card screen. */
+    private fun savedSnapshotJson(): String = accountUiSaver.json.encodeToString(
+        accountUiSaver.serializer,
+        UiSnapshot(
+            stack = listOf(RouteDto.BoardList, RouteDto.Board("ann-board"), RouteDto.ComposeCard("ann-todo")),
+            filterQuery = "",
+            filterAssignee = null,
+            filterLabelIds = emptyList(),
+        ),
+    )
+
+    @Test
+    fun restoredAddCardStack_boardLayerShowsCards() = runComposeUiTest {
+        val local = newLocal()
+        runBlocking { local.ensureSeeded() }
+        val rootStore = createAppStore(NotificationContext.Inline)
+        val registry = AccountRegistry(rootStore, local, NotificationContext.Inline)
+
+        // A SaveableStateRegistry primed with the previous session's snapshot — what the Android
+        // host provides after process death.
+        val restoredRegistry = SaveableStateRegistry(
+            restoredValues = mapOf("account-ui-ann" to listOf(savedSnapshotJson())),
+            canBeSaved = { true },
+        )
+
+        setContent {
+            setSingletonImageLoaderFactory { ctx -> fakeNoNetworkImageLoader(ctx) }
+            TaskFlowTheme {
+                CompositionLocalProvider(LocalSaveableStateRegistry provides restoredRegistry) {
+                    ActiveAccountReplica(registry = registry, activeId = annId)
+                }
+            }
+        }
+
+        // The full stack restored: the nav stack is the saved one...
+        waitForIdle()
+        val store = registry.store(annId)!!
+        assertEquals(
+            persistentListOf(
+                Route.BoardList,
+                Route.Board(annBoardId),
+                Route.ComposeCard(ColumnId("ann-todo")),
+            ),
+            store.state.get<NavModel>().stack,
+            "nav stack must restore [BoardList, Board, ComposeCard]",
+        )
+
+        // ...and the board layer (beneath the add-card overlay) shows the persisted cards.
+        waitUntil(timeoutMillis = 5_000) {
+            onAllNodesWithText("Design the API surface").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    /** Mirror of App.kt's private `ActiveAccount` (minus switcher/back-handler chrome). */
+    @Composable
+    private fun ActiveAccountReplica(registry: AccountRegistry, activeId: AccountId) {
+        val handle = remember(activeId) { registry.getOrCreate(activeId, SeedData.accountDetail(activeId)) }
+        val accountStore = handle.store
+
+        accountStore.rememberSaveableState(accountUiSaver, key = "account-ui-${activeId.v}")
+
+        val nav by rememberStableStore(accountStore).value.fieldStateOf(NavModel::class) { it }
+
+        BoardLifecycleEffectReplica(
+            accountStore = accountStore,
+            registry = registry,
+            activeId = activeId,
+            activeBoardId = nav.activeBoardId,
+        )
+
+        RoutingReplica(accountStore = accountStore, nav = nav)
+    }
+
+    /** Mirror of App.kt's private `BoardLifecycleEffect` (bot kept on for fidelity). */
+    @Composable
+    private fun BoardLifecycleEffectReplica(
+        accountStore: Store<ModelState>,
+        registry: AccountRegistry,
+        activeId: AccountId,
+        activeBoardId: BoardId?,
+    ) {
+        DisposableEffect(activeId, activeBoardId) {
+            if (activeBoardId != null) {
+                accountStore.dispatch(LoadBoardRequested(activeBoardId))
+                registry.startBot(activeId, rngSeed = 0L)
+            }
+            onDispose {
+                if (activeBoardId != null) {
+                    accountStore.dispatch(BoardClosed)
+                    registry.stopBot(activeId)
+                }
+            }
+        }
+    }
+
+    /** Mirror of App.kt's private routing: render every stack layer bottom-to-top. */
+    @Composable
+    private fun RoutingReplica(accountStore: Store<ModelState>, nav: NavModel) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            nav.stack.forEach { route ->
+                key(route) {
+                    when (route) {
+                        is Route.BoardList -> Surface(modifier = Modifier.fillMaxSize()) {
+                            BoardListScreen(accountStore)
+                        }
+
+                        is Route.Board -> Surface(modifier = Modifier.fillMaxSize()) {
+                            BoardScreen(accountStore)
+                        }
+
+                        Route.Profile -> Surface(modifier = Modifier.fillMaxSize()) {
+                            ProfileScreen(accountStore, accountStore)
+                        }
+
+                        Route.Settings -> Surface(modifier = Modifier.fillMaxSize()) {
+                            SettingsScreen(accountStore)
+                        }
+
+                        is Route.CardDetail, is Route.ComposeCard -> CardDetailScreen(accountStore)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Investigates the reported **"no cards after app-death state restoration"** bug in the TaskFlow sample and fixes it at the root.

**The bug was not in restoration.** The saveable snapshot, nav stack, board load (`LoadBoardRequested` → `LoadBoardSucceeded`), and Compose bindings all restore correctly — proven by two new regression tests and by on-device logcat. The cards "vanished" because the **bot collaborator only ever advanced cards forward**, making the terminal *Done* column an absorbing state: at the default 4s interval, every card piles up in Done within ~30s of a board being open. After a process-death restore the user lands back on the board, the compact pager shows the first column ("To Do") empty — which reads as data loss. The data was always intact (bot moves are in-memory only; the durable store stayed correct).

## Changes

- `BotCollaborator.pickMove`: picks a card from any populated column and moves it one column **forward or backward** (uniform among valid neighbours, clamped at the ends) — the walk is non-absorbing, so the board stays visibly populated.
- New bot test: `terminalPileUpIsNotAbsorbing_botMovesACardBackOut` (red before the fix).
- Two regression tests pinning the restore flow:
  - `ProcessDeathRestoreTest` — store level: saver round-trip into a fresh store + lifecycle load repopulates the board.
  - `ProcessDeathRestoreUiTest` — Compose level: `SaveableStateRegistry`-driven restore in a real composition renders the persisted cards beneath the restored add-card overlay.
- `ARCHITECTURE.md` §12 updated to document the bidirectional walk and why it matters.

## Verification

- Full `:examples:taskflow:composeApp:jvmTest` suite green; `detektAll` clean.
- On-device (emulator): old build reproduces the report exactly (restore → back → "No cards", all 6 cards in Done); fixed build with the bot running shows cards distributed across columns after the same death-restore cycle. Also installed and launched on a physical Pixel 10 Pro.

## Test-harness note (baked into the new tests)

`TestScope.backgroundScope` + `advanceUntilIdle()` silently never runs launched effects — `advanceUntilIdle` only drains until no *foreground* tasks remain. Effect scopes in `runTest` need a foreground `StandardTestDispatcher` scope; this faked a store-level restoration failure during the investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)