### PR TITLE
docs: state-restoration lessons — Rule I (state-keyed effects), restore contract, harness traps

### DIFF
--- a/.claude/skills/redux-kotlin/SKILL.md
+++ b/.claude/skills/redux-kotlin/SKILL.md
@@ -18,6 +18,7 @@ companion modules on one `Store<S>` contract. Recommended app organization is **
 - **Rule F — Delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
 - **Rule G — Mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
 - **Rule H — Single inset point.** Window insets are applied once at the shell root.
+- **Rule I — State-keyed lifecycle effects.** Screen-data loads key on **state** (the nav-derived slice, e.g. `BoardLifecycleEffect` on `nav.activeBoardId`), never on navigation events — state-only entry points (process-death restore, deep links, DevTools time-travel, account-switch hydration) set state without replaying events, so an event-keyed load silently never runs. Fallback: match the hydrating action in middleware.
 <!-- assemble:rules:end -->
 
 ## Decision routing
@@ -32,7 +33,7 @@ companion modules on one `Store<S>` contract. Recommended app organization is **
 | The 5 **platform shims** | [`platform-shims.md`](../../../docs/agent/references/platform-shims.md) |
 | **Modularization** | [`modularization.md`](../../../docs/agent/references/modularization.md) |
 | **Debugging** a running app (actions/state/diffs) | [`devtools.md`](../../../docs/agent/references/devtools.md) |
-| **Persisting/restoring state** (process death, `preloadedState`, saveable) | [`state-persistence.md`](../../../docs/agent/references/state-persistence.md) |
+| **Persisting/restoring state** (process death, `preloadedState`, saveable, restored-screen-has-no-data) | [`state-persistence.md`](../../../docs/agent/references/state-persistence.md) |
 | **Store consistency model** (sync writes, async notify, timing) | [`store-consistency-model.md`](../../../docs/agent/references/store-consistency-model.md) |
 
 ## Pointers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ does not auto-correct. Full gate detail → `CLAUDE.md`.
 - **Rule F — Delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
 - **Rule G — Mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
 - **Rule H — Single inset point.** Window insets are applied once at the shell root.
+- **Rule I — State-keyed lifecycle effects.** Screen-data loads key on **state** (the nav-derived slice, e.g. `BoardLifecycleEffect` on `nav.activeBoardId`), never on navigation events — state-only entry points (process-death restore, deep links, DevTools time-travel, account-switch hydration) set state without replaying events, so an event-keyed load silently never runs. Fallback: match the hydrating action in middleware.
 <!-- assemble:rules:end -->
 
 Full text → `examples/taskflow/ARCHITECTURE.md`.

--- a/docs/agent/AGENTS-external.md
+++ b/docs/agent/AGENTS-external.md
@@ -49,6 +49,7 @@ Faithful one-liners from the canonical sample app (`examples/taskflow`):
 - **Rule F — Delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
 - **Rule G — Mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
 - **Rule H — Single inset point.** Window insets are applied once at the shell root.
+- **Rule I — State-keyed lifecycle effects.** Screen-data loads key on **state** (the nav-derived slice, e.g. `BoardLifecycleEffect` on `nav.activeBoardId`), never on navigation events — state-only entry points (process-death restore, deep links, DevTools time-travel, account-switch hydration) set state without replaying events, so an event-keyed load silently never runs. Fallback: match the hydrating action in middleware.
 <!-- assemble:rules:end -->
 
 Full architecture + rules:

--- a/docs/agent/_fragments/rules.md
+++ b/docs/agent/_fragments/rules.md
@@ -4,3 +4,4 @@
 - **Rule F — Delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
 - **Rule G — Mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
 - **Rule H — Single inset point.** Window insets are applied once at the shell root.
+- **Rule I — State-keyed lifecycle effects.** Screen-data loads key on **state** (the nav-derived slice, e.g. `BoardLifecycleEffect` on `nav.activeBoardId`), never on navigation events — state-only entry points (process-death restore, deep links, DevTools time-travel, account-switch hydration) set state without replaying events, so an event-keyed load silently never runs. Fallback: match the hydrating action in middleware.

--- a/docs/agent/references/effects-sync.md
+++ b/docs/agent/references/effects-sync.md
@@ -12,9 +12,9 @@ derives_from:
   - examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/infra/data/OfflineSyncE2ETest.kt → OfflineSyncE2ETest
 api_files:
   - redux-kotlin-bundle/api/redux-kotlin-bundle.klib.api
-rules: [E, F, G]
+rules: [E, F, G, I]
 assembles_into: [AGENTS.md, claude-skill]
-last_verified: { commit: 3c1cd67, date: 2026-06-04 }
+last_verified: { commit: ab2fb5b, date: 2026-06-11 }
 ---
 
 # Effects + sync (Rule E)
@@ -33,6 +33,13 @@ effects`, see [store-setup.md](./store-setup.md)) — "Rule E" is this disciplin
 All repository work runs on the per-account background `CoroutineScope` (off-main, `Dispatchers.Default`).
 Dispatches that follow marshal back to main through the store's `NotificationContext`, so the effect
 code does **no explicit main hop**.
+
+**Lifecycle loads key on STATE, not navigation events.** A load triggered alongside a `Navigate`
+dispatch never fires on state-only entry points — process-death restore, deep links, DevTools
+time-travel, account-switch hydration — because those set state without replaying events. Key the
+effect on the state slice instead (taskflow's board load keys on the nav-derived `activeBoardId`),
+or match the hydrating action itself in middleware. See
+[state-persistence.md](./state-persistence.md) ("Restore replays no events").
 
 ## The optimistic dance
 

--- a/docs/agent/references/state-persistence.md
+++ b/docs/agent/references/state-persistence.md
@@ -4,6 +4,8 @@ concern: state-persistence
 derives_from:
   - redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/StateSaver.kt → StateSaver
   - redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/RememberSaveableState.kt → rememberSaveableState
+  - redux-kotlin-compose-saveable/src/jvmTest/kotlin/org/reduxkotlin/compose/saveable/RestoreRetriggersEffectsTest.kt → RestoreRetriggersEffectsTest
+  - examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt → BoardLifecycleEffect
   - redux-kotlin-routing/src/commonMain/kotlin/org/reduxkotlin/routing/CreateModelStore.kt → createModelStore
   - redux-kotlin-bundle/src/commonMain/kotlin/org/reduxkotlin/bundle/StoreFactory.kt → createConcurrentModelStore
   - redux-kotlin-multimodel/src/commonMain/kotlin/org/reduxkotlin/multimodel/ModelState.kt → withAll
@@ -14,9 +16,9 @@ api_files:
   - redux-kotlin-bundle/api/redux-kotlin-bundle.klib.api
   - redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api
   - redux-kotlin-concurrent/api/redux-kotlin-concurrent.klib.api
-rules: [C, E]
+rules: [C, E, I]
 assembles_into: [AGENTS.md, claude-skill]
-last_verified: { commit: 75388a1, date: 2026-06-10 }
+last_verified: { commit: ab2fb5b, date: 2026-06-11 }
 ---
 
 # State persistence & restore (process death, rotation, relaunch)
@@ -95,6 +97,33 @@ whenever scopes can collide — multiple anchors, anchors inside lists/nav graph
 scopes. Scope the key to the data's identity (e.g. `key = "account-ui-$accountId"`) so one
 account's snapshot can never restore into another.
 
+## Restore replays no events — key load effects on state
+
+A restore dispatches exactly **one** action (the saver's restore action). None of the events that
+originally produced the saved state are replayed — no clicks, no `Navigate`-style actions. Anything
+the app loads *in response to an event* never loads on the restore path: the nav stack comes back,
+the screen renders, and its data is empty. This is the deep-link bug class (a web page that fetches
+in a click handler breaks on refresh); redux adds more entry points with the same shape — DevTools
+time-travel, replay, and hydrating on an account switch all set state without re-running events.
+
+Two patterns survive all of them:
+
+- **Derive the effect from state** (preferred): key the load on the state the restore produces —
+  e.g. a `DisposableEffect(activeId)` watching the restored route slice, as taskflow's board
+  lifecycle does
+  (`examples/taskflow/composeApp/src/commonMain/kotlin/org/reduxkotlin/sample/taskflow/app/App.kt → BoardLifecycleEffect`).
+  Restore is applied synchronously during composition, so the effect's first key evaluation already
+  sees the restored value and the load fires exactly as after a real navigation. Pinned by
+  `redux-kotlin-compose-saveable/src/jvmTest/kotlin/org/reduxkotlin/compose/saveable/RestoreRetriggersEffectsTest.kt → RestoreRetriggersEffectsTest`.
+- **Match the restore action in middleware** (fallback): the restore action is a normal dispatch
+  through the full middleware chain, so an effects middleware can react to it and kick loads
+  explicitly.
+
+Downstream of either pattern, tolerate **dangling references**: a snapshot can outlive the data it
+points at (deleted entity, removed board). Treat "referenced entity not found" as an empty state or
+a navigate-away, never a crash. And before blaming restoration for "missing" data, check the
+DevTools action log — a background actor (sync, taskflow's bot) may have legitimately moved it.
+
 ## What NOT to persist
 
 - **Modes/overlays** — restore a detail screen in *view* mode even if the process died in *edit*
@@ -132,6 +161,11 @@ Its hard-won lessons, in checklist form:
    on process-death restore.
 6. `coalescingNotificationContext` as the main `NotificationContext` so main-thread dispatches
    notify inline (no lag frame); off-main sync/effects dispatches marshal to main as before.
+7. Board data survives restore ONLY because the board-load effect keys on **state**
+   (`DisposableEffect(activeId, activeBoardId)` over the restored nav slice), not on `Navigate`
+   events — see "Restore replays no events" above. A "no cards after restore" report against this
+   flow turned out to be the demo bot relocating cards, found via the DevTools action log — verify
+   store contents before suspecting restoration.
 
 ## Verify loop
 

--- a/docs/agent/references/testing.md
+++ b/docs/agent/references/testing.md
@@ -10,7 +10,7 @@ derives_from:
   - examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/app/AccountRegistryTest.kt → AccountRegistryTest
 assembles_into: [AGENTS.md, claude-skill]
 rules: [C]
-last_verified: { commit: 3c1cd67, date: 2026-06-04 }
+last_verified: { commit: ab2fb5b, date: 2026-06-11 }
 ---
 
 # Testing & the verify loop
@@ -75,6 +75,18 @@ every host.
 
 - Putting a SQLDelight or coroutine-virtual-time test in `commonTest` — it will fail to run on
   native/JS. Keep it in `jvmTest`.
+- Launching effect coroutines on `TestScope.backgroundScope` and driving the test with
+  `advanceUntilIdle()` — `advanceUntilIdle` only drains until no FOREGROUND tasks remain, so
+  background-only work is silently skipped: the effect never runs and the test "proves" a bug that
+  doesn't exist. Give effects a foreground scope —
+  `CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler))` — or drive with
+  `runCurrent()`, which runs current-time tasks regardless of the foreground/background flag.
+- Testing process-death restore by dispatching the restore action by hand only — that skips the
+  registry/decode path. Prime a real registry instead:
+  `SaveableStateRegistry(restoredValues = saved) { true }` provided via `LocalSaveableStateRegistry`
+  inside `runComposeUiTest` exercises the exact mechanism the anchor uses (see
+  `redux-kotlin-compose-saveable/src/jvmTest/kotlin/org/reduxkotlin/compose/saveable/RestoreRetriggersEffectsTest.kt → RestoreRetriggersEffectsTest`
+  and [state-persistence.md](./state-persistence.md)).
 - Asserting on a board snapshot after a rejected op instead of asserting the single reverted op — masks
   whether the per-op inverse is correct.
 - Writing recomposition-count state into a snapshot-backed `mutableStateOf` — it perturbs the very
@@ -85,4 +97,5 @@ every host.
 - [feature-slice.md](./feature-slice.md) — the reducer/selector tests each slice ships.
 - [effects-sync.md](./effects-sync.md) — the virtual-time sync E2E.
 - [compose-binding.md](./compose-binding.md) — the render-isolation proof.
+- [state-persistence.md](./state-persistence.md) — restore-path testing (registry-primed restore).
 - [README](./README.md)

--- a/examples/taskflow/ARCHITECTURE.md
+++ b/examples/taskflow/ARCHITECTURE.md
@@ -910,6 +910,12 @@ The codebase follows a small set of named conventions (referenced throughout the
   `LocalClock` CompositionLocals (`ui/Locals.kt`; `IdGenerator` itself in
   `infra/util/IdGenerator.kt`) at the dispatch site, never from a reducer.
 - **Rule H — Single inset point.** Window insets are applied once at the shell root.
+- **Rule I — State-keyed lifecycle effects.** A load that brings a screen its data keys on
+  **state** (the nav-derived slice), never on a navigation event. State-only entry points —
+  process-death restore, deep links, DevTools time-travel, account-switch hydration — set
+  state without replaying events, so an event-keyed load silently never runs there.
+  `BoardLifecycleEffect` (`app/App.kt`) keys on `nav.activeBoardId`; the fallback is matching
+  the hydrating action itself in an effects middleware.
 
 Persistence (`LocalStore`) and network (`RemoteApi`) are deliberately separate seams.
 Models are deeply immutable. The `ModelState` key set is fixed at construction (no runtime

--- a/redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/RememberSaveableState.kt
+++ b/redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/RememberSaveableState.kt
@@ -29,6 +29,16 @@ private const val KEY_RADIX = 36
  * The persisted store must accept main-thread reads and dispatch (the
  * Compose-facing store: concurrent/threadsafe, or main-confined).
  *
+ * A restore replays no events — it dispatches exactly one action (the
+ * saver's restore action). Data your app loads in response to a navigation
+ * *event* therefore never loads on the restore path. Key load effects on the
+ * restored **state** (e.g. an effect keyed on the current route), or match
+ * the restore action in an effects middleware; state-keyed effects also
+ * survive every other state-only entry point (deep links, DevTools
+ * time-travel, replay). Because the restore is applied synchronously during
+ * composition, a state-keyed effect's first key evaluation already sees the
+ * restored value.
+ *
  * Example:
  * ```
  * @Composable

--- a/redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/StateSaver.kt
+++ b/redux-kotlin-compose-saveable/src/commonMain/kotlin/org/reduxkotlin/compose/saveable/StateSaver.kt
@@ -11,6 +11,18 @@ import kotlinx.serialization.json.Json
  * Holds no Compose state — its serialization round-trip is unit-testable
  * without a composition. Reuse one instance across screens.
  *
+ * Restore-action contract:
+ * - The action returned by [restore] is dispatched like any other — it flows
+ *   through the **full middleware chain**, so an effects middleware may match
+ *   it to re-trigger loads (the alternative is keying load effects on the
+ *   restored state itself; see `rememberSaveableState`'s docs).
+ * - A restore replays **only** this one action; the events that originally
+ *   produced the saved state are not replayed.
+ * - A snapshot can outlive the data it references (a deleted item, a removed
+ *   screen target). Whatever handles the restore action — and anything loaded
+ *   from it — must tolerate stale references: treat "not found" as an empty
+ *   state or a navigation back, never a crash.
+ *
  * Example:
  * ```
  * @Serializable

--- a/redux-kotlin-compose-saveable/src/jvmTest/kotlin/org/reduxkotlin/compose/saveable/RestoreRetriggersEffectsTest.kt
+++ b/redux-kotlin-compose-saveable/src/jvmTest/kotlin/org/reduxkotlin/compose/saveable/RestoreRetriggersEffectsTest.kt
@@ -1,0 +1,88 @@
+package org.reduxkotlin.compose.saveable
+
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
+import androidx.compose.runtime.saveable.SaveableStateRegistry
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.runComposeUiTest
+import kotlinx.serialization.Serializable
+import org.reduxkotlin.Store
+import org.reduxkotlin.compose.fieldState
+import org.reduxkotlin.createStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the restore-safe effect pattern: a restore dispatches exactly ONE action (the saver's
+ * restore action) and replays none of the events that originally produced the saved state. A data
+ * load keyed on a navigation EVENT therefore never runs on the restore path; a load keyed on the
+ * restored STATE fires for a real navigation and for a restore alike (and for any other
+ * state-only entry point — deep links, DevTools time-travel, replay).
+ */
+@OptIn(ExperimentalTestApi::class)
+class RestoreRetriggersEffectsTest {
+
+    private data class NavState(val route: String = "list", val detail: String? = null)
+
+    private data class Navigate(val route: String)
+
+    private data class RestoreNav(val route: String)
+
+    private data class LoadDetailSucceeded(val detail: String)
+
+    @Serializable
+    private data class NavSnapshot(val route: String)
+
+    private val navReducer: (NavState, Any) -> NavState = { state, action ->
+        when (action) {
+            is Navigate -> state.copy(route = action.route)
+            is RestoreNav -> state.copy(route = action.route)
+            is LoadDetailSucceeded -> state.copy(detail = action.detail)
+            else -> state
+        }
+    }
+
+    private val navSaver: StateSaver<NavState, NavSnapshot> = StateSaver(
+        serializer = NavSnapshot.serializer(),
+        save = { state -> NavSnapshot(state.route) },
+        restore = { snapshot -> RestoreNav(snapshot.route) },
+    )
+
+    @Test
+    fun restoredRoute_firesStateKeyedLoadEffect() = runComposeUiTest {
+        // Session 1: the user navigated to the detail route; the platform saves the snapshot.
+        val store1: Store<NavState> = createStore(navReducer, NavState())
+        val registry1 = SaveableStateRegistry(restoredValues = null) { true }
+        wireSaveable(store1, registry1, "nav", navSaver)
+        store1.dispatch(Navigate("detail"))
+        val saved = registry1.performSave()
+
+        // Session 2 (process death): a FRESH store + a registry primed with the saved snapshot.
+        // The only action that will run is the saver's RestoreNav — Navigate is never replayed.
+        val store2: Store<NavState> = createStore(navReducer, NavState())
+        val registry2 = SaveableStateRegistry(restoredValues = saved) { true }
+        setContent {
+            CompositionLocalProvider(LocalSaveableStateRegistry provides registry2) {
+                store2.rememberSaveableState(navSaver, key = "nav")
+                val route by store2.fieldState(NavState::route)
+                // The load keys on STATE (the restored route), not on the Navigate event. Restore
+                // is applied synchronously during composition, so this effect's first key
+                // evaluation already sees "detail" and the load fires.
+                DisposableEffect(route) {
+                    if (route == "detail") store2.dispatch(LoadDetailSucceeded("detail-data"))
+                    onDispose { }
+                }
+                BasicText("detail=${store2.fieldState(NavState::detail).value}")
+            }
+        }
+
+        waitForIdle()
+        onAllNodesWithText("detail=detail-data").assertCountEquals(1)
+        assertEquals(NavState(route = "detail", detail = "detail-data"), store2.state)
+    }
+}

--- a/website/docs/Troubleshooting.md
+++ b/website/docs/Troubleshooting.md
@@ -36,6 +36,31 @@ Things to check, in order:
    saved-instance state — the anchor does nothing there. Test on Android
    (e.g. *"Don't keep activities"* or `adb shell am kill`) or iOS.
 
+### A restored screen renders, but its data never loads
+
+The nav stack (or route) comes back after process death, yet the screen is
+empty — lists render their empty state, detail screens show a skeleton.
+
+Restore dispatches exactly **one** action; it does not replay the events
+that originally led to the screen. If your data load is triggered by a
+navigation *event* (dispatched alongside `Navigate` in a click handler),
+the restore path never runs it — the same way a page that fetches in a
+click handler breaks on browser refresh. Fix one of two ways:
+
+- **Key the load on state, not events**: an effect keyed on the restored
+  route/selection (e.g. `DisposableEffect(route)` or a middleware watching
+  the slice) fires for a real navigation *and* for a restore — and also for
+  DevTools time-travel and any other state hydration.
+- **Handle the restore action in middleware**: the restore action flows
+  through the full middleware chain like any dispatch, so an effects
+  middleware can match it and start the loads.
+
+Also check what the data *should* be: restoration can be innocent. Verify
+the store contents (e.g. with the DevTools action log) before concluding
+state was lost — a background actor or sync may have legitimately moved the
+data. See
+[Restoration replays no events](/advanced/compose-integration#restoration-replays-no-events--key-effects-on-state).
+
 ### A restored value appears, then reverts to the initial value
 
 Compose bindings are one-directional (`store → State`). If you restore a

--- a/website/docs/advanced/Compose.md
+++ b/website/docs/advanced/Compose.md
@@ -266,6 +266,45 @@ rehydrated state. There is no intermediate frame rendered from the
 store's initial state. Place the anchor *above* the Composables that
 read the restored slice.
 
+### Restoration replays no events — key effects on state
+
+A restore dispatches exactly **one** action (your `restore` action). None
+of the user events that originally produced the saved state are replayed:
+no clicks, no `Navigate`-style actions. Anything your app loads *in
+response to an event* therefore never loads on the restore path.
+
+This is the same bug class as a web page that fetches in a click handler
+and breaks on browser refresh: restoration — like a deep link — enters a
+screen without the events that normally precede it. Redux adds more entry
+points with the same shape: DevTools time-travel, replay, and hydrating an
+account switch all *set* state without re-running events.
+
+Two patterns survive all of them:
+
+- **Derive the effect from state** (preferred). Key the load on the state
+  the restore produces, not on the action that usually produces it:
+
+  ```kotlin
+  val route by store.fieldState(NavState::route)
+  DisposableEffect(route) {
+      if (route is Route.Detail) store.dispatch(LoadDetailRequested(route.id))
+      onDispose { /* cancel / close */ }
+  }
+  ```
+
+  Because the restore is applied synchronously during composition, the
+  effect's first key evaluation already sees the restored route and the
+  load fires — exactly as it would after a real navigation.
+
+- **React to the restore action in middleware** (fallback). The restore
+  action is a normal dispatch through the **full middleware chain**, so an
+  effects middleware can match it and kick the loads explicitly.
+
+Either way, write the `restore` action's downstream handling to tolerate
+**stale references** — a snapshot can outlive the data it points at (a
+deleted item, a removed board). Treat "referenced entity not found" as a
+navigate-away or empty state, never a crash.
+
 ### Threading & platforms
 
 The snapshot is read and the restore action dispatched on the **main

--- a/website/docs/ai-agents/BuildingWithAI.md
+++ b/website/docs/ai-agents/BuildingWithAI.md
@@ -63,6 +63,7 @@ Faithful one-liners from the canonical sample app (`examples/taskflow`):
 - **Rule F — Delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
 - **Rule G — Mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
 - **Rule H — Single inset point.** Window insets are applied once at the shell root.
+- **Rule I — State-keyed lifecycle effects.** Screen-data loads key on **state** (the nav-derived slice, e.g. `BoardLifecycleEffect` on `nav.activeBoardId`), never on navigation events — state-only entry points (process-death restore, deep links, DevTools time-travel, account-switch hydration) set state without replaying events, so an event-keyed load silently never runs. Fallback: match the hydrating action in middleware.
 
 Full architecture + rules:
 https://github.com/reduxkotlin/redux-kotlin/blob/master/examples/taskflow/ARCHITECTURE.md


### PR DESCRIPTION
## Summary

Generalizes the lessons from the TaskFlow death-restore investigation (#343) into the library's documentation, agent-knowledge system, and test suite. No behavioral library changes — KDoc, docs, one new test.

## The core lesson → Rule I

A restore dispatches exactly **one** action (the saver's restore action) and replays none of the events that produced the saved state. A data load triggered by a navigation *event* therefore silently never runs on **state-only entry points**: process-death restore, deep links, DevTools time-travel, account-switch hydration. This is the deep-link bug class (a web page that fetches in a click handler breaks on refresh) — restoration is just another entry point that bypasses event handlers.

Two restore-safe patterns, now documented everywhere an agent or human would look:
1. **Key the load effect on state** (preferred) — fires for real navigation, restore, and every other hydration path alike.
2. **Match the restore action in middleware** (fallback) — the restore action flows through the full middleware chain like any dispatch.

Promoted to a named design rule (**Rule I — state-keyed lifecycle effects**) in `ARCHITECTURE.md` §17 and the rules fragment, assembled into `AGENTS.md`, `AGENTS-external.md`, the `redux-kotlin` skill, and the website AI page.

## Changes

**`redux-kotlin-compose-saveable`**
- New `RestoreRetriggersEffectsTest` (jvmTest): registry-primed restore in a real composition re-fires a state-keyed load — pins the pattern end-to-end.
- `StateSaver` / `rememberSaveableState` KDoc: restore-action contract — single action, flows through the full middleware chain, downstream handling must tolerate stale references (a snapshot can outlive the data it points at).

**Agent knowledge (`docs/agent/`)**
- `state-persistence.md`: new *"Restore replays no events — key load effects on state"* section, dangling-reference contract, DevTools-before-blaming-restoration tip, TaskFlow lesson #7, provenance updated.
- `effects-sync.md`: Rule I cross-link under Rule E.
- `testing.md`: two harness traps — (1) `TestScope.backgroundScope` work is skipped by `advanceUntilIdle` (it drains only until no *foreground* tasks remain), which can fake exactly this bug; (2) test restore through a primed `SaveableStateRegistry`, not a hand-dispatched action.
- Rules fragment + assembly: `scripts/assemble-agent-knowledge.sh --check` and `scripts/check-agent-refs.sh` both green.

**Website**
- `advanced/Compose.md`: *"Restoration replays no events — key effects on state"* section with both patterns + stale-reference guidance.
- `Troubleshooting.md`: *"A restored screen renders, but its data never loads"* entry — including the lesson that 'missing' data may be a background actor, so verify store contents via the DevTools action log before suspecting restoration.

## Verification

- `:redux-kotlin-compose-saveable:jvmTest` green (new test included)
- `detektAll` clean
- `website yarn build` succeeds (node 22; only the pre-existing `/glossary#todo` anchor warning)
- `assemble-agent-knowledge.sh --check` + `check-agent-refs.sh` pass

Related: #343 (the bug investigation these lessons come from).

🤖 Generated with [Claude Code](https://claude.com/claude-code)