### PR TITLE
feat(thunk): port redux-kotlin-thunk into the monorepo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New module `redux-kotlin-thunk`: ported from the standalone
+  [reduxkotlin/redux-kotlin-thunk](https://github.com/reduxkotlin/redux-kotlin-thunk) repo into
+  the monorepo — `Thunk` typealias + `createThunkMiddleware`. Published under the same maven
+  coordinates `org.reduxkotlin:redux-kotlin-thunk` and added to the BOM; the standalone repo
+  will be archived.
 - New module `redux-kotlin-compose-saveable`: `StateSaver` + `rememberSaveableState` —
   store-anchored snapshot persistence via Compose `SaveableStateRegistry` +
   kotlinx.serialization. Survives rotation and process death on Android; restore is applied

--- a/docs/agent/api-map.md
+++ b/docs/agent/api-map.md
@@ -18,6 +18,7 @@ Read the committed `.api` dump for a module's public surface; regenerate with `.
 | `:redux-kotlin` | `redux-kotlin/api/redux-kotlin.klib.api` | Core contract: `Store`/`TypedStore`, `Reducer`, `Middleware`, `createStore`, `applyMiddleware`, `combineReducers`, `compose`. |
 | `:redux-kotlin-threadsafe` | `redux-kotlin-threadsafe/api/redux-kotlin-threadsafe.klib.api` | `createThreadSafeStore` (atomicfu-locked store wrapper). |
 | `:redux-kotlin-concurrent` | `redux-kotlin-concurrent/api/redux-kotlin-concurrent.klib.api` | `createConcurrentStore` (lock-free reads + reentrant-lock-serialized writes; CallerSerialized strategy) + `NotificationContext` notify control (`coalescingNotificationContext` runs the callback inline when already on the target thread, else posts — one callback per subscriber per dispatch, no burst collapsing). |
+| `:redux-kotlin-thunk` | `redux-kotlin-thunk/api/redux-kotlin-thunk.klib.api` | `Thunk<State>` typealias + `createThunkMiddleware(extraArgument)` async action middleware (ported from the standalone repo, same coordinates). |
 | `:redux-kotlin-granular` | `redux-kotlin-granular/api/redux-kotlin-granular.klib.api` | `subscribeTo` / `subscribeFields` field-level subscriptions. |
 | `:redux-kotlin-registry` | `redux-kotlin-registry/api/redux-kotlin-registry.klib.api` | `StoreRegistry<K,S>` / `TypedStoreRegistry` keyed multi-store container. |
 | `:redux-kotlin-multimodel` | `redux-kotlin-multimodel/api/redux-kotlin-multimodel.klib.api` | `ModelState` typesafe heterogeneous model bag (incl. `withAll` bulk merge). |

--- a/redux-kotlin-bom/build.gradle.kts
+++ b/redux-kotlin-bom/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
         api("$g:redux-kotlin:$v")
         api("$g:redux-kotlin-threadsafe:$v")
         api("$g:redux-kotlin-concurrent:$v")
+        api("$g:redux-kotlin-thunk:$v")
         api("$g:redux-kotlin-granular:$v")
         api("$g:redux-kotlin-registry:$v")
         api("$g:redux-kotlin-multimodel:$v")

--- a/redux-kotlin-thunk/api/jvm/redux-kotlin-thunk.api
+++ b/redux-kotlin-thunk/api/jvm/redux-kotlin-thunk.api
@@ -1,0 +1,5 @@
+public final class org/reduxkotlin/thunk/ThunkKt {
+	public static final fun createThunkMiddleware (Ljava/lang/Object;)Lkotlin/jvm/functions/Function1;
+	public static synthetic fun createThunkMiddleware$default (Ljava/lang/Object;ILjava/lang/Object;)Lkotlin/jvm/functions/Function1;
+}
+

--- a/redux-kotlin-thunk/api/redux-kotlin-thunk.klib.api
+++ b/redux-kotlin-thunk/api/redux-kotlin-thunk.klib.api
@@ -1,0 +1,9 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, js, linuxX64, macosArm64, mingwX64, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <org.reduxkotlin:redux-kotlin-thunk>
+final fun <#A: kotlin/Any?> org.reduxkotlin.thunk/createThunkMiddleware(kotlin/Any? = ...): kotlin/Function1<org.reduxkotlin/TypedStore<#A, kotlin/Any>, kotlin/Function1<kotlin/Function1<kotlin/Any, kotlin/Any>, kotlin/Function1<kotlin/Any, kotlin/Any>>> // org.reduxkotlin.thunk/createThunkMiddleware|createThunkMiddleware(kotlin.Any?){0§<kotlin.Any?>}[0]

--- a/redux-kotlin-thunk/build.gradle.kts
+++ b/redux-kotlin-thunk/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    id("convention.library-mpp-loved")
+    id("convention.publishing-mpp")
+}
+
+val hasAndroidSdk: Boolean = run {
+    val localProps = rootProject.file("local.properties")
+    val hasSdkInLocalProperties = localProps.exists() && localProps.readText().lineSequence().any {
+        it.trim().startsWith("sdk.dir=") && it.substringAfter("sdk.dir=").isNotBlank()
+    }
+    val hasSdkInEnv =
+        !System.getenv("ANDROID_HOME").isNullOrBlank() ||
+            !System.getenv("ANDROID_SDK_ROOT").isNullOrBlank()
+    hasSdkInLocalProperties || hasSdkInEnv
+}
+
+kotlin {
+    if (hasAndroidSdk) {
+        android {
+            namespace = "org.reduxkotlin.thunk"
+        }
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":redux-kotlin"))
+            }
+        }
+    }
+}

--- a/redux-kotlin-thunk/src/commonMain/kotlin/org/reduxkotlin/thunk/Thunk.kt
+++ b/redux-kotlin-thunk/src/commonMain/kotlin/org/reduxkotlin/thunk/Thunk.kt
@@ -1,0 +1,64 @@
+package org.reduxkotlin.thunk
+
+import org.reduxkotlin.Dispatcher
+import org.reduxkotlin.GetState
+import org.reduxkotlin.Middleware
+
+/**
+ * Specialised async action type that can be dispatched to a store with a registered [ThunkMiddleware].
+ *
+ * A thunk is a function receiving the store's `dispatch` and `getState` plus the optional
+ * `extraArg` configured on [createThunkMiddleware]; its return value is returned from `dispatch`.
+ */
+public typealias Thunk<State> = (dispatch: Dispatcher, getState: GetState<State>, extraArg: Any?) -> Any
+
+/**
+ * Middleware that intercepts dispatched [Thunk] functions and executes them.
+ *
+ * @see createThunkMiddleware
+ */
+public typealias ThunkMiddleware<State> = Middleware<State>
+
+/**
+ * Creates a thunk middleware for async action dispatches.
+ *
+ * Usage:
+ * ```
+ * val thunk = createThunkMiddleware<AppState>()
+ * val store = createStore(myReducer, initialState, applyMiddleware(thunk, myMiddleware))
+ *
+ * fun myNetworkThunk(query: String): Thunk<AppState> = { dispatch, getState, extraArgument ->
+ *     launch {
+ *         dispatch(LoadingAction())
+ *         // do async stuff
+ *         val result = api.fetch(query)
+ *         dispatch(CompleteAction(result))
+ *     }
+ * }
+ *
+ * store.dispatch(myNetworkThunk("query"))
+ * ```
+ *
+ * @param State the store's state type.
+ * @param extraArgument optional dependency (e.g. an api client) passed to every thunk as `extraArg`.
+ */
+public fun <State> createThunkMiddleware(extraArgument: Any? = null): ThunkMiddleware<State> = { store ->
+    { next: Dispatcher ->
+        { action: Any ->
+            if (action is Function<*>) {
+                @Suppress("UNCHECKED_CAST")
+                val thunk = try {
+                    (action as Thunk<*>)
+                } catch (e: ClassCastException) {
+                    throw IllegalArgumentException(
+                        "Dispatching functions must use type Thunk<State>",
+                        e,
+                    )
+                }
+                thunk(store.dispatch, store.getState, extraArgument)
+            } else {
+                next(action)
+            }
+        }
+    }
+}

--- a/redux-kotlin-thunk/src/commonTest/kotlin/org/reduxkotlin/thunk/ThunkMiddlewareTest.kt
+++ b/redux-kotlin-thunk/src/commonTest/kotlin/org/reduxkotlin/thunk/ThunkMiddlewareTest.kt
@@ -1,0 +1,89 @@
+package org.reduxkotlin.thunk
+
+import org.reduxkotlin.applyMiddleware
+import org.reduxkotlin.createStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ThunkMiddlewareTest {
+    data class TestState(val counter: Int = 0)
+
+    object Increment
+
+    private val counterReducer = { state: TestState, action: Any ->
+        when (action) {
+            is Increment -> state.copy(counter = state.counter + 1)
+            else -> state
+        }
+    }
+
+    private fun store(extraArgument: Any? = null) = createStore(
+        counterReducer,
+        TestState(),
+        applyMiddleware(createThunkMiddleware(extraArgument)),
+    )
+
+    @Test
+    fun thunkIsInvokedWithDispatchAndGetState() {
+        val store = store()
+        var observedCounter = -1
+        val thunk: Thunk<TestState> = { dispatch, getState, _ ->
+            dispatch(Increment)
+            observedCounter = getState().counter
+        }
+
+        store.dispatch(thunk)
+
+        assertEquals(1, observedCounter)
+        assertEquals(1, store.state.counter)
+    }
+
+    @Test
+    fun thunkReturnValueIsReturnedFromDispatch() {
+        val store = store()
+        val thunk: Thunk<TestState> = { _, _, _ -> "thunk-result" }
+
+        assertEquals("thunk-result", store.dispatch(thunk))
+    }
+
+    @Test
+    fun nonFunctionActionsPassThroughToReducer() {
+        val store = store()
+
+        store.dispatch(Increment)
+        store.dispatch(Increment)
+
+        assertEquals(2, store.state.counter)
+    }
+
+    @Test
+    fun extraArgumentIsForwardedToThunk() {
+        val api = object {
+            val name = "fake-api"
+        }
+        val store = store(extraArgument = api)
+        var received: Any? = null
+        val thunk: Thunk<TestState> = { _, _, extraArg ->
+            received = extraArg
+        }
+
+        store.dispatch(thunk)
+
+        assertTrue(received === api)
+    }
+
+    @Test
+    fun thunkCanDispatchAnotherThunk() {
+        val store = store()
+        val inner: Thunk<TestState> = { dispatch, _, _ -> dispatch(Increment) }
+        val outer: Thunk<TestState> = { dispatch, _, _ ->
+            dispatch(Increment)
+            dispatch(inner)
+        }
+
+        store.dispatch(outer)
+
+        assertEquals(2, store.state.counter)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ include(
     ":redux-kotlin",
     ":redux-kotlin-threadsafe",
     ":redux-kotlin-concurrent",
+    ":redux-kotlin-thunk",
     ":redux-kotlin-registry",
     ":redux-kotlin-granular",
     ":redux-kotlin-multimodel",


### PR DESCRIPTION
## Summary

Part of the v1 org consolidation: moves the standalone [redux-kotlin-thunk](https://github.com/reduxkotlin/redux-kotlin-thunk) library into the monorepo as the `:redux-kotlin-thunk` module.

- `Thunk<State>` typealias + `createThunkMiddleware(extraArgument)` ported verbatim (package `org.reduxkotlin.thunk`, same maven coordinates `org.reduxkotlin:redux-kotlin-thunk`)
- Module added to `settings.gradle.kts` and the BOM
- API dumps committed (`apiDump`)
- Tests rewritten: the original JVM-only test asserted inside a `timerTask` and could never fail; replaced with synchronous `commonTest` coverage (thunk invocation with dispatch/getState, return value, non-function pass-through, extraArgument forwarding, nested thunk dispatch) running on all targets

## Verification

- `:redux-kotlin-thunk:jvmTest`, `jsNodeTest`, `wasmJsNodeTest`, `macosArm64Test`, `iosSimulatorArm64Test` — green locally (`jsBrowserTest` needs a local Chromium; fails identically for existing modules on this box — CI covers it)
- `detektAll` + `apiCheck` — green

## Follow-up

Once merged: archive the standalone repo with a moved-to-monorepo banner (same coordinates, no consumer action needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)