### PR TITLE
feat(threadsafe): deprecate redux-kotlin-threadsafe in favor of concurrent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   double-fire; worst case on a posting store is one redundant same-value
   callback.
 
+### Deprecated
+
+- `redux-kotlin-threadsafe` is deprecated in favor of `redux-kotlin-concurrent`. All public
+  declarations (`createThreadSafeStore`, `createTypedThreadSafeStore`, `ThreadSafeStore`,
+  `Store.asThreadSafe`, `createThreadSafeStoreEnhancer`) now carry `@Deprecated` warnings.
+  Migration: `createConcurrentStore(reducer, preloadedState, enhancer = enhancer)` /
+  `createTypedConcurrentStore` / `Store.asConcurrent()` keep the same contract with lock-free
+  reads and serialized writes. The module will be retired in a future release.
+
 ### Changed
 
 - **Behavior change:** `dispatch` from inside a reducer now throws

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ kotlin {
     sourceSets {
         commonMain { //   <---  name may vary on your project
             dependencies {
-                implementation("org.reduxkotlin:redux-kotlin-threadsafe:<version>")
+                implementation("org.reduxkotlin:redux-kotlin-concurrent:<version>")
             }
         }
     }
@@ -78,11 +78,14 @@ kotlin {
 For JVM only:
 
 ```kotlin
-implementation("org.reduxkotlin:redux-kotlin-threadsafe-jvm:<version>")
+implementation("org.reduxkotlin:redux-kotlin-concurrent-jvm:<version>")
 ```
 
-*Non threadsafe store is available. Typical usage will be with the threadsafe
-store. [More info read here](https://www.reduxkotlin.org/introduction/getting-started)
+`redux-kotlin-concurrent` provides a thread-safe store with lock-free reads and
+serialized writes (`createConcurrentStore`). The plain single-threaded store ships in the
+`redux-kotlin` core; the older `redux-kotlin-threadsafe` (one lock around every store
+function) is **deprecated** in favor of `redux-kotlin-concurrent`.
+[More info read here](https://www.reduxkotlin.org/introduction/getting-started)
 
 Usage is very similar to JS Redux and those docs will be useful https://redux.js.org/. These docs
 are not an intro to

--- a/redux-kotlin-threadsafe/src/commonMain/kotlin/org/reduxkotlin/threadsafe/CreateThreadSafeStore.kt
+++ b/redux-kotlin-threadsafe/src/commonMain/kotlin/org/reduxkotlin/threadsafe/CreateThreadSafeStore.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.reduxkotlin.threadsafe
 
 import org.reduxkotlin.Reducer
@@ -32,6 +34,12 @@ import org.reduxkotlin.typedReducer
  * @returns {Store} A Redux store that lets you read the state, dispatch actions
  * and subscribe to changes.
  */
+@Deprecated(
+    "redux-kotlin-threadsafe is deprecated in favor of redux-kotlin-concurrent: " +
+        "createConcurrentStore(reducer, preloadedState, enhancer = enhancer) keeps the same contract " +
+        "with lock-free reads and serialized writes. " +
+        "See https://reduxkotlin.org/introduction/threading for migration notes.",
+)
 public fun <State> createThreadSafeStore(
     reducer: Reducer<State>,
     preloadedState: State,
@@ -41,6 +49,11 @@ public fun <State> createThreadSafeStore(
 /**
  * Creates a thread-safe [TypedStore]. For further details see the matching [createThreadSafeStore].
  */
+@Deprecated(
+    "redux-kotlin-threadsafe is deprecated in favor of redux-kotlin-concurrent: " +
+        "use createTypedConcurrentStore from org.reduxkotlin.concurrent. " +
+        "See https://reduxkotlin.org/introduction/threading for migration notes.",
+)
 public inline fun <State, reified Action : Any> createTypedThreadSafeStore(
     crossinline reducer: TypedReducer<State, Action>,
     preloadedState: State,
@@ -50,4 +63,9 @@ public inline fun <State, reified Action : Any> createTypedThreadSafeStore(
 /**
  * Converts a given [Store] to a [ThreadSafeStore].
  */
+@Deprecated(
+    "redux-kotlin-threadsafe is deprecated in favor of redux-kotlin-concurrent: " +
+        "use Store.asConcurrent() from org.reduxkotlin.concurrent. " +
+        "See https://reduxkotlin.org/introduction/threading for migration notes.",
+)
 public fun <State> Store<State>.asThreadSafe(): ThreadSafeStore<State> = ThreadSafeStore(store)

--- a/redux-kotlin-threadsafe/src/commonMain/kotlin/org/reduxkotlin/threadsafe/Enhancers.kt
+++ b/redux-kotlin-threadsafe/src/commonMain/kotlin/org/reduxkotlin/threadsafe/Enhancers.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.reduxkotlin.threadsafe
 
 import org.reduxkotlin.StoreEnhancer
@@ -13,6 +15,11 @@ import org.reduxkotlin.StoreEnhancer
 
  * @returns {StoreEnhancer} A store enhancer that synchronizes the store.
  */
+@Deprecated(
+    "redux-kotlin-threadsafe is deprecated in favor of redux-kotlin-concurrent: " +
+        "wrap the store with Store.asConcurrent() (or build it with createConcurrentStore) instead. " +
+        "See https://reduxkotlin.org/introduction/threading for migration notes.",
+)
 public fun <State> createThreadSafeStoreEnhancer(): StoreEnhancer<State> = { storeCreator ->
     { reducer, initialState, en: Any? ->
         val store = storeCreator(reducer, initialState, en)

--- a/redux-kotlin-threadsafe/src/commonMain/kotlin/org/reduxkotlin/threadsafe/ThreadSafeStore.kt
+++ b/redux-kotlin-threadsafe/src/commonMain/kotlin/org/reduxkotlin/threadsafe/ThreadSafeStore.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.reduxkotlin.threadsafe
 
 import kotlinx.atomicfu.locks.SynchronizedObject
@@ -14,8 +16,12 @@ import org.reduxkotlin.StoreSubscription
  * kotlinx.AtomicFu [https://github.com/Kotlin/kotlinx.atomicfu]
  * Allows all store functions to be accessed from any thread.
  * This does have a performance impact for JVM/Native.
- * TODO more info at [https://ReduxKotlin.org]
  */
+@Deprecated(
+    "redux-kotlin-threadsafe is deprecated in favor of redux-kotlin-concurrent: " +
+        "ConcurrentStore offers the same thread-safety with lock-free reads and serialized writes. " +
+        "See https://reduxkotlin.org/introduction/threading for migration notes.",
+)
 public class ThreadSafeStore<State>(override val store: Store<State>) :
     SynchronizedObject(),
     Store<State> {

--- a/redux-kotlin-threadsafe/src/jvmCommonTest/kotlin/org/reduxkotlin/threadsafe/CreateThreadSafeStoreTest.kt
+++ b/redux-kotlin-threadsafe/src/jvmCommonTest/kotlin/org/reduxkotlin/threadsafe/CreateThreadSafeStoreTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package org.reduxkotlin.threadsafe
 
 import kotlinx.coroutines.Dispatchers

--- a/website/docs/api/createThreadSafeStore.md
+++ b/website/docs/api/createThreadSafeStore.md
@@ -6,10 +6,18 @@ sidebar_label: createThreadSafeStore
 
 # `createThreadSafeStore(reducer, preloadedState, enhancer)`
 
+:::caution Deprecated
+
+`redux-kotlin-threadsafe` is **deprecated** in favor of `redux-kotlin-concurrent`.
+`createConcurrentStore(reducer, preloadedState, enhancer = enhancer)` keeps the same
+contract with lock-free reads and serialized writes — for most code it is a drop-in
+replacement. See [Threading](../introduction/threading) for migration notes.
+
+:::
+
 Creates a Redux [store](./store-api) that is may be accessed from any thread.
 
-***This is the simplest thread-safe way to create a store*** — every store
-function is synchronized on one lock. If you want reads that never block
+Every store function is synchronized on one lock. If you want reads that never block
 (lock-free `getState`/`subscribe` with serialized writes), use
 `createConcurrentStore` from `redux-kotlin-concurrent` instead — see
 [Threading](../introduction/threading).


### PR DESCRIPTION
## Summary

v1-prep decision: `redux-kotlin-threadsafe` is deprecated in favor of `redux-kotlin-concurrent`.

- `@Deprecated` (WARNING) on all public declarations: `createThreadSafeStore`, `createTypedThreadSafeStore`, `ThreadSafeStore`, `Store.asThreadSafe`, `createThreadSafeStoreEnhancer` — each message names the concurrent equivalent (`createConcurrentStore(reducer, preloadedState, enhancer = enhancer)` is a drop-in for most code)
- README install snippet now recommends `redux-kotlin-concurrent`
- Website `createThreadSafeStore` page gets a `:::caution Deprecated` admonition with migration notes
- CHANGELOG `### Deprecated` entry

No ABI change (`apiDump` clean — WARNING-level deprecation doesn't alter dumps), so no api-map update needed.

## Notes

- `examples/counter` and `examples/todos` still use `createThreadSafeStore` — they compile with warnings; migrating them is part of the upcoming docs/examples overhaul
- Module retirement (removal from publishing) planned post-v1

## Verification

- `:redux-kotlin-threadsafe:jvmTest` + `detektAll` + `apiDump` — green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)