### PR TITLE
feat(bom): add devtools modules to the BOM, marked experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `./gradlew :redux-kotlin-devtools-cli:installDist`, then run
   `redux-kotlin-devtools-cli/build/install/rk-devtools/bin/rk-devtools`).
   See [docs/devtools.md](docs/devtools.md) for the integration guide.
+
+  The six published DevTools modules are version-aligned by `redux-kotlin-bom` but
+  marked **experimental**: they are exempt from the semver guarantee until the
+  devtools surface stabilizes and may change in minor releases.
 ### Fixed
 
 - `redux-kotlin-concurrent`: the state mirror is now published **before**

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -7,9 +7,11 @@ published on the website at
 the agent-oriented CLI walkthrough lives at
 [docs/agent/references/devtools.md](agent/references/devtools.md).
 
-> **Availability:** the DevTools modules are new and experimental — they are not
-> part of any published release yet and will be available from the next release.
-> Until then, build them from source (this repo).
+> **Availability:** the DevTools modules are **experimental**. They are published
+> alongside the other modules and version-aligned by `redux-kotlin-bom`, but they
+> are exempt from the semantic-versioning guarantee until the devtools surface
+> stabilizes — the API may change in minor releases. Everything else under the
+> BOM carries the full stability promise.
 
 ---
 

--- a/redux-kotlin-bom/build.gradle.kts
+++ b/redux-kotlin-bom/build.gradle.kts
@@ -24,5 +24,13 @@ dependencies {
         api("$g:redux-kotlin-bundle:$v")
         api("$g:redux-kotlin-bundle-compose:$v")
         api("$g:redux-kotlin-compose-saveable:$v")
+        // DevTools family — experimental: aligned by the BOM but exempt from
+        // semver until the devtools surface stabilizes (see docs/devtools.md).
+        api("$g:redux-kotlin-devtools-core:$v")
+        api("$g:redux-kotlin-devtools-bridge:$v")
+        api("$g:redux-kotlin-devtools-remote:$v")
+        api("$g:redux-kotlin-devtools-inapp:$v")
+        api("$g:redux-kotlin-devtools-inapp-noop:$v")
+        api("$g:redux-kotlin-devtools-ui:$v")
     }
 }

--- a/redux-kotlin-devtools-bridge/README.md
+++ b/redux-kotlin-devtools-bridge/README.md
@@ -1,5 +1,9 @@
 # redux-kotlin-devtools-bridge
 
+> **Experimental:** published and version-aligned by `redux-kotlin-bom`, but exempt
+> from the semver guarantee until the devtools surface stabilizes — the API may
+> change in minor releases.
+
 The app→monitor transport of the Redux-Kotlin DevTools. `BridgeOutput` streams a
 `DevToolsSession`'s feed over WebSocket to the
 [standalone monitor](../redux-kotlin-devtools-standalone) or the

--- a/redux-kotlin-devtools-core/README.md
+++ b/redux-kotlin-devtools-core/README.md
@@ -1,5 +1,9 @@
 # redux-kotlin-devtools-core
 
+> **Experimental:** published and version-aligned by `redux-kotlin-bom`, but exempt
+> from the semver guarantee until the devtools surface stabilizes — the API may
+> change in minor releases.
+
 The recording core of the Redux-Kotlin DevTools. Provides the `devTools(config)`
 store enhancer that records actions, state snapshots, and JSON diffs into a
 `DevToolsSession`; the process-global `DevToolsHub` where sessions and outputs

--- a/redux-kotlin-devtools-inapp-noop/README.md
+++ b/redux-kotlin-devtools-inapp-noop/README.md
@@ -1,5 +1,9 @@
 # redux-kotlin-devtools-inapp-noop
 
+> **Experimental:** published and version-aligned by `redux-kotlin-bom`, but exempt
+> from the semver guarantee until the devtools surface stabilizes — the API may
+> change in minor releases.
+
 The zero-overhead release sibling of the DevTools. It mirrors the
 [`redux-kotlin-devtools-inapp`](../redux-kotlin-devtools-inapp) API **and** the
 core facade (`devTools`, `devToolsMiddleware`, `devToolsCombineReducers`,

--- a/redux-kotlin-devtools-inapp/README.md
+++ b/redux-kotlin-devtools-inapp/README.md
@@ -1,5 +1,9 @@
 # redux-kotlin-devtools-inapp
 
+> **Experimental:** published and version-aligned by `redux-kotlin-bom`, but exempt
+> from the semver guarantee until the devtools surface stabilizes — the API may
+> change in minor releases.
+
 The in-app Redux-Kotlin DevTools drawer for Compose Multiplatform. Wrapping your
 app root in `ReduxDevToolsHost` adds a floating bubble and a right-edge swipe
 tab that open a drawer with **Actions**, **State**, **Diff**, **Pipeline**, and

--- a/redux-kotlin-devtools-remote/README.md
+++ b/redux-kotlin-devtools-remote/README.md
@@ -1,5 +1,9 @@
 # redux-kotlin-devtools-remote
 
+> **Experimental:** published and version-aligned by `redux-kotlin-bom`, but exempt
+> from the semver guarantee until the devtools surface stabilizes — the API may
+> change in minor releases.
+
 Streams a `DevToolsSession` feed to an external Redux DevTools monitor — the
 browser extension or `@redux-devtools/cli` — over WebSocket, so you can inspect
 a redux-kotlin app in the same monitor UI the JS ecosystem uses.

--- a/redux-kotlin-devtools-ui/README.md
+++ b/redux-kotlin-devtools-ui/README.md
@@ -1,5 +1,9 @@
 # redux-kotlin-devtools-ui
 
+> **Experimental:** published and version-aligned by `redux-kotlin-bom`, but exempt
+> from the semver guarantee until the devtools surface stabilizes — the API may
+> change in minor releases.
+
 The shared Compose UI layer of the Redux-Kotlin DevTools: the panels (action
 log, State, Diff, Pipeline, Outputs), view models, and theme used by **both**
 the [in-app drawer](../redux-kotlin-devtools-inapp) and the

--- a/website/docs/advanced/DevTools.md
+++ b/website/docs/advanced/DevTools.md
@@ -11,11 +11,15 @@ middleware-pipeline timing, and time-ordered multi-store views for a running
 redux-kotlin app — in-app, on the desktop, from the terminal, or in the
 classic Redux DevTools browser monitor.
 
-> **Availability:** the DevTools modules are new and experimental; they are not
-> part of any published release yet and will ship with the next release. Until
-> then, build them from source (the repository's
-> [docs/devtools.md](https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/devtools.md)
-> tracks the same content against the working tree).
+:::caution Experimental
+
+The DevTools modules are **experimental**. They are published alongside the
+other modules and version-aligned by `redux-kotlin-bom`, but they are exempt
+from the semantic-versioning guarantee until the devtools surface stabilizes —
+the API may change in minor releases. Everything else under the BOM carries the
+full stability promise.
+
+:::
 
 ## Artifacts overview
 


### PR DESCRIPTION
## Summary

Implements the devtools×v1 decision (middle path): the 6 published devtools library modules join `redux-kotlin-bom`, marked **experimental**.

- BOM gains constraints for devtools-{core,bridge,remote,inapp,inapp-noop,ui} (the inapp/inapp-noop debug↔release pairing requires version alignment) — verified in the generated POM
- Experimental semantics stated consistently: exempt from the semver guarantee until the devtools surface stabilizes, may change in minor releases; everything else under the BOM keeps the full promise
- Marked in: BOM build comment, all 6 module READMEs, website guide (`:::caution Experimental`), docs/devtools.md availability note, CHANGELOG
- `standalone` + `cli` stay unpublished repo tools

**Stacked on #351** — retargets when it merges.

## Verification
BOM POM generation green (6 devtools constraints present); website `yarn build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)