### PR TITLE
fix(bom): drop unpublished routing-codegen constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hub-global output state — toggles act on the hub's outputs, not a per-drawer
   copy.
 
+- `redux-kotlin-bom`: no longer constrains `redux-kotlin-routing-codegen` — the KSP
+  processor is not published yet (in-repo only); the constraint returns when it ships.
+
 ### Deprecated
 
 - `redux-kotlin-threadsafe` is deprecated in favor of `redux-kotlin-concurrent`. All public

--- a/redux-kotlin-bom/build.gradle.kts
+++ b/redux-kotlin-bom/build.gradle.kts
@@ -20,7 +20,8 @@ dependencies {
         api("$g:redux-kotlin-compose:$v")
         api("$g:redux-kotlin-compose-multimodel:$v")
         api("$g:redux-kotlin-routing:$v")
-        api("$g:redux-kotlin-routing-codegen:$v")
+        // redux-kotlin-routing-codegen is intentionally absent: the KSP
+        // processor is not published yet (in-repo only) — re-add when it ships.
         api("$g:redux-kotlin-bundle:$v")
         api("$g:redux-kotlin-bundle-compose:$v")
         api("$g:redux-kotlin-compose-saveable:$v")


### PR DESCRIPTION
## Summary

Resolves the release-prep oddity found during the bundle-first docs pass (#353): `redux-kotlin-bom` constrained `redux-kotlin-routing-codegen`, but the KSP processor applies no publishing convention — the constraint pointed at an artifact that doesn't exist on Maven. Dropped with an in-place comment; re-add when the processor ships.

## Verification
Generated BOM POM: `routing-codegen` 0 occurrences, `redux-kotlin-routing` still present. Docs already describe codegen as in-repo-only (no doc changes needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)