### PR TITLE
chore(version): open the 1.0 line (1.0.0-SNAPSHOT; alpha-publishable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> **Heading toward 1.0.** The development baseline is now `1.0.0-SNAPSHOT`. The
+> first 1.0 release is planned as a pre-release, `1.0.0-alpha01`, published from
+> a `v1.0.0-alpha01` tag via the release workflow. DevTools modules ship
+> alongside but remain experimental and exempt from semver.
+
 ### Added
 
 - New module `redux-kotlin-thunk`: ported from the standalone

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ gh.owner.organization.url=http://www.reduxkotlin.org
 #======================================= Project ========================================
 group=org.reduxkotlin
 description=Redux implementation for Kotlin. Multiplatform supported.
-version=0.6.2-SNAPSHOT
+version=1.0.0-SNAPSHOT
 #======================================== Build =========================================
 project.enableSnapshots=true
 # linux | macos | windows


### PR DESCRIPTION
Bumps the development baseline `0.6.2-SNAPSHOT` → `1.0.0-SNAPSHOT`, opening the 1.0 release line. Issues #165 and #169 — the two correctness/compat blockers flagged in the v1 review — are now closed.

## Is a 1.0-alpha practical / publishable? Yes.
Publishing is **tag/dispatch-driven**, not baseline-driven: `release.yml` → `resolve-version.yml` resolves the published version from the release tag (or `workflow_dispatch` `version` input) and passes it as `-Pversion`, overriding `gradle.properties`. So:

- **This PR** sets the dev baseline to `1.0.0-SNAPSHOT` (SNAPSHOT per `project.enableSnapshots=true`).
- **To cut the alpha**, create a GitHub Release tagged `v1.0.0-alpha01` (or run the Release workflow with `version=1.0.0-alpha01` and `skipMavenCentral=n`). All 21 published modules go to the Central Portal in one macOS-runner deployment; signing + Central credentials are already wired as repo secrets.
- A non-SNAPSHOT alpha is a real Maven Central release (not the snapshot repo), so it is installable by consumers.

DevTools modules publish alongside but stay experimental / semver-exempt.

## Notes for the reviewer
- Pairs well with #358 (v1 docs) and the API-consistency PR.
- The auto-snapshot bot drops the `-alphaNN` qualifier when computing the next dev snapshot (`resolve-version.yml` increments the patch) — fine for a first alpha; revisit if cutting multiple alphas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)