### PR TITLE
fix(threadsafe): add ReplaceWith to deprecated store factories

### DIFF
--- a/redux-kotlin-threadsafe/src/commonMain/kotlin/org/reduxkotlin/threadsafe/CreateThreadSafeStore.kt
+++ b/redux-kotlin-threadsafe/src/commonMain/kotlin/org/reduxkotlin/threadsafe/CreateThreadSafeStore.kt
@@ -39,6 +39,10 @@ import org.reduxkotlin.typedReducer
         "createConcurrentStore(reducer, preloadedState, enhancer = enhancer) keeps the same contract " +
         "with lock-free reads and serialized writes. " +
         "See https://reduxkotlin.org/introduction/threading for migration notes.",
+    replaceWith = ReplaceWith(
+        "createConcurrentStore(reducer, preloadedState, enhancer = enhancer)",
+        "org.reduxkotlin.concurrent.createConcurrentStore",
+    ),
 )
 public fun <State> createThreadSafeStore(
     reducer: Reducer<State>,
@@ -53,6 +57,10 @@ public fun <State> createThreadSafeStore(
     "redux-kotlin-threadsafe is deprecated in favor of redux-kotlin-concurrent: " +
         "use createTypedConcurrentStore from org.reduxkotlin.concurrent. " +
         "See https://reduxkotlin.org/introduction/threading for migration notes.",
+    replaceWith = ReplaceWith(
+        "createTypedConcurrentStore(reducer, preloadedState, enhancer = enhancer)",
+        "org.reduxkotlin.concurrent.createTypedConcurrentStore",
+    ),
 )
 public inline fun <State, reified Action : Any> createTypedThreadSafeStore(
     crossinline reducer: TypedReducer<State, Action>,
@@ -67,5 +75,9 @@ public inline fun <State, reified Action : Any> createTypedThreadSafeStore(
     "redux-kotlin-threadsafe is deprecated in favor of redux-kotlin-concurrent: " +
         "use Store.asConcurrent() from org.reduxkotlin.concurrent. " +
         "See https://reduxkotlin.org/introduction/threading for migration notes.",
+    replaceWith = ReplaceWith(
+        "this.asConcurrent()",
+        "org.reduxkotlin.concurrent.asConcurrent",
+    ),
 )
 public fun <State> Store<State>.asThreadSafe(): ThreadSafeStore<State> = ThreadSafeStore(store)


### PR DESCRIPTION
The `redux-kotlin-threadsafe` deprecations point users to `redux-kotlin-concurrent`, but three of them carried only a message — no `ReplaceWith` — so the IDE offered no one-click migration. Adds `ReplaceWith` (with fully-qualified imports) to:

- `createThreadSafeStore` → `createConcurrentStore(reducer, preloadedState, enhancer = enhancer)`
- `createTypedThreadSafeStore` → `createTypedConcurrentStore(reducer, preloadedState, enhancer = enhancer)`
- `Store.asThreadSafe()` → `this.asConcurrent()`

(`Enhancers.kt` and `ThreadSafeStore.kt` deprecations already had `ReplaceWith`; this closes the gap.) All three replacement symbols were verified to exist with compatible signatures. Metadata-only change — `:redux-kotlin-threadsafe:checkKotlinAbi` passes, so no ABI dump update is needed.

From the v1 review's API-consistency findings. The other flagged item — `createConcurrentModelStore` parameter order vs `createConcurrentStore` — was intentionally left as-is: it is a builder/block factory (trailing `RoutingBuilder` lambda, optional nullable `preloadedState`) rather than a reducer factory, so the shapes legitimately differ and reordering would only churn the surface and break positional callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)