### PR TITLE
test(devtools-cli): guard the CLI command tree + assembled binary in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,23 @@ jobs:
           echo "Tests failed after ${max_attempts} attempts"
           exit 1
 
+      - name: Smoke-test the assembled rk-devtools CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Build the distribution the how-to / README tell users to install, then
+          # launch the real launcher. Catches breakage the in-process unit tests
+          # cannot: a broken `application`/mainClass block, a missing runtime jar in
+          # the install lib dir, or a dropped subcommand — none of which surface
+          # from `test` alone.
+          ./gradlew --no-daemon --stacktrace :redux-kotlin-devtools-cli:installDist
+          bin=redux-kotlin-devtools-cli/build/install/rk-devtools/bin/rk-devtools
+          out="$("$bin" --help)"
+          echo "$out"
+          for cmd in serve stores actions diff state tail; do
+            echo "$out" | grep -q "$cmd" || { echo "rk-devtools --help is missing subcommand: $cmd"; exit 1; }
+          done
+
       - name: Upload test reports on failure
         if: failure()
         uses: actions/upload-artifact@v7

--- a/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/command/CliSmokeTest.kt
+++ b/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/command/CliSmokeTest.kt
@@ -1,0 +1,45 @@
+package org.reduxkotlin.devtools.cli.command
+
+import com.github.ajalt.clikt.testing.test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Runtime smoke test for the assembled `rk-devtools` command tree.
+ *
+ * This guards against the class of breakage where the CLI compiles but the
+ * tool is unusable — a subcommand dropped from the tree, the root command
+ * throwing during construction, or `--help` failing at runtime. Because it
+ * runs under the JVM `test` task (the task PR CI executes), it ALSO fails to
+ * compile — and therefore fails CI — if the CLI main source set stops
+ * compiling (e.g. a removed Compose dependency for the `--ui` path or a moved
+ * monitor type). [EndToEndTest] covers capture/query logic but never exercises
+ * the command layer.
+ */
+internal class CliSmokeTest {
+    private val expectedSubcommands = listOf("serve", "stores", "actions", "diff", "state", "tail")
+
+    @Test
+    fun root_registers_every_expected_subcommand() {
+        val names = rootCommand().registeredSubcommands().map { it.commandName }
+        assertEquals(expectedSubcommands, names, "rk-devtools subcommand tree changed")
+    }
+
+    @Test
+    fun root_help_runs_and_lists_every_subcommand() {
+        val result = rootCommand().test("--help")
+        assertEquals(0, result.statusCode, "rk-devtools --help should exit 0")
+        expectedSubcommands.forEach { name ->
+            assertTrue(name in result.output, "rk-devtools --help omits subcommand: $name")
+        }
+    }
+
+    @Test
+    fun every_subcommand_help_is_reachable() {
+        expectedSubcommands.forEach { name ->
+            val result = rootCommand().test("$name --help")
+            assertEquals(0, result.statusCode, "rk-devtools $name --help should exit 0")
+        }
+    }
+}


### PR DESCRIPTION
## Context
While preparing the TaskFlow capture walkthrough I checked whether `rk-devtools` builds. **It builds fine on `master`** — the compile failure I first saw was on a stale local branch (`feat/taskflow-bundle-sample`, 300+ commits behind) that predates the `rk-devtools cli hardening` fix. So this PR is **not** a bug fix; it adds the missing CI safety net so a real future regression of that kind can't merge silently.

## The gap
- PR CI (`ci.yml`) runs `detektAll` + `./gradlew test`. `test` *does* compile the CLI (so a pure compile break is already caught), but:
  - No test exercised the **command layer** — `EndToEndTest` only covers capture/query logic. A dropped subcommand or a root command that throws at startup would pass CI.
  - PR CI never ran `installDist`, so a broken `application`/`mainClass` block or a missing runtime jar in the install lib dir — i.e. the exact `installDist` flow the how-to/README document — was unguarded.

## Changes
1. **`CliSmokeTest`** (runs under `test`, so it executes in PR CI): asserts the root command still registers `serve/stores/actions/diff/state/tail` and that `--help` is reachable for the root and every subcommand. Because it lives in the CLI test source set, it also fails to compile — failing CI — if CLI main stops compiling (e.g. a removed Compose dep for `--ui`, or a moved monitor type).
2. **`ci.yml` step** on the test job's success path: runs `:redux-kotlin-devtools-cli:installDist` and launches the assembled launcher, asserting all six subcommands appear in `--help`. Catches distribution/runtime-classpath breakage the in-process test can't.

Verified locally: 3/3 smoke tests pass; `installDist` + `rk-devtools --help` lists all six subcommands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)