### PR TITLE
build(devtools-cli): pin compile JDK + guard runtime Java version

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Pins the JDK for building/running redux-kotlin (the tree targets Java 17).
+# With SDKMAN installed, run `sdk env` (or `sdk env install`) in the repo root to select it.
+java=17.0.13-tem

--- a/redux-kotlin-devtools-cli/README.md
+++ b/redux-kotlin-devtools-cli/README.md
@@ -17,6 +17,22 @@ from the repository:
 redux-kotlin-devtools-cli/build/install/rk-devtools/bin/rk-devtools
 ```
 
+### Requires Java 17+
+
+The tool is compiled to Java 17 bytecode, so the launcher needs a **JDK 17 or
+newer** on `JAVA_HOME`/`PATH`. The build itself is pinned to JDK 17 via a Gradle
+toolchain (auto-provisioned), so `installDist` is deterministic regardless of
+your default Java. The repo ships a [`.sdkmanrc`](../.sdkmanrc) pinning Temurin
+17 — run `sdk env` in the repo root to select it.
+
+If you launch `rk-devtools` with an older Java it fails fast with a clear
+message instead of an `UnsupportedClassVersionError`. To pick a JDK explicitly:
+
+```
+JAVA_HOME=/path/to/jdk17+ rk-devtools --help
+# macOS, if registered: JAVA_HOME=$(/usr/libexec/java_home -v 17) rk-devtools --help
+```
+
 ## Subcommands
 
 | Command | What it does |

--- a/redux-kotlin-devtools-cli/build.gradle.kts
+++ b/redux-kotlin-devtools-cli/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     id("convention.common")
     kotlin("jvm")
@@ -9,20 +7,41 @@ plugins {
     alias(libs.plugins.compose.multiplatform)
 }
 
+// Pin the compile JDK (not just the bytecode target) so the build is deterministic regardless of
+// the developer's default Java, and so we never accidentally compile against a >17 JDK API. The
+// foojay resolver (settings.gradle.kts) auto-downloads JDK 17 when it isn't already installed.
 kotlin {
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_17)
-    }
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    jvmToolchain(17)
 }
 
 application {
     applicationName = "rk-devtools"
     mainClass.set("org.reduxkotlin.devtools.cli.MainKt")
+}
+
+// The installDist launcher resolves its runtime Java from JAVA_HOME/PATH, which may be older than
+// the required 17. Guard the generated unix launcher so it fails with a clear message instead of a
+// cryptic UnsupportedClassVersionError (which is thrown at class-load, before main() can react).
+tasks.startScripts {
+    doLast {
+        val q = "\""
+        val d = "\$"
+        val guard = listOf(
+            "",
+            "# rk-devtools requires Java 17+ (see redux-kotlin-devtools-cli/README.md).",
+            "RKDT_JV=$d($q${d}JAVACMD$q -version 2>&1 \\",
+            "  | awk -F'[$q.]' '/version/{print (${d}2==${q}1$q?${d}3:${d}2);exit}')",
+            "if [ -n $q${d}RKDT_JV$q ] && [ $q${d}RKDT_JV$q -lt 17 ] 2>/dev/null; then",
+            "    echo ${q}rk-devtools requires Java 17+, but '${d}JAVACMD' is Java ${d}RKDT_JV.$q >&2",
+            "    echo ${q}Point JAVA_HOME at a JDK 17 or newer and re-run.$q >&2",
+            "    exit 1",
+            "fi",
+            "",
+            "",
+        ).joinToString("\n")
+        val execLine = "exec $q${d}JAVACMD$q $q$d@$q"
+        unixScript.writeText(unixScript.readText().replace(execLine, guard + execLine))
+    }
 }
 
 dependencies {

--- a/redux-kotlin-devtools-standalone/build.gradle.kts
+++ b/redux-kotlin-devtools-standalone/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.compose.ExperimentalComposeLibrary
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("convention.control")
@@ -12,7 +13,13 @@ plugins {
 kotlin {
     // Desktop-only for now: the wasmJs web viewer was removed because the server had no
     // viewer-facing fanout (it only ingested); it returns when a broadcast path exists.
-    jvm()
+    // Pin bytecode to 17 (convention.control sets no jvmTarget) so consumers compiled against a
+    // JDK 17 toolchain — e.g. redux-kotlin-devtools-cli — can load these classes on a 17 JVM.
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
 
     sourceSets {
         commonMain.dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,9 @@ pluginManagement {
 
 plugins {
     id("com.gradle.develocity") version "3.19.2"
+    // Auto-provisions a matching JDK for Gradle Java toolchains (e.g. the CLI's jvmToolchain(17)),
+    // so the build JDK is deterministic regardless of the developer's default Java.
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
 }
 
 includeBuild("build-conventions/")


### PR DESCRIPTION
Fixes the developer pain point where running `rk-devtools` under a JDK < 17 throws a cryptic `UnsupportedClassVersionError`, and where the compile JDK was unpinned (only the bytecode target was set). Implements mitigations 1, 2, 4 from the review (3 — bundled JRE — tracked in #367).

### 1. Pin the compile JDK (determinism)
- `redux-kotlin-devtools-cli`: `kotlin { jvmToolchain(17) }` replaces the manual `jvmTarget` / `sourceCompatibility` / `targetCompatibility`. This pins the *compile* JDK (not just bytecode), so the build can't accidentally compile against a >17 API.
- `settings.gradle.kts`: added `org.gradle.toolchains.foojay-resolver-convention` so Gradle auto-provisions JDK 17 when it isn't already installed — the build no longer depends on the developer's default Java.

### 2. Fail fast at runtime (clear message)
The `installDist` launcher resolves its runtime Java from `JAVA_HOME`/`PATH`, which may be older than 17. The generated unix launcher now parses the resolved Java version and exits with `rk-devtools requires Java 17+, but <path> is Java N` + a `JAVA_HOME` hint — instead of `UnsupportedClassVersionError` (which is thrown at class-load, before `main()` can react).

### 4. Docs
- `.sdkmanrc` pinning Temurin 17 (`sdk env` selects it).
- CLI README "Requires Java 17+" section.

### Verification
- `installDist` builds via the toolchain (hinted at a local JDK 17).
- Launcher with a faked JDK 11 → blocked, exit 1, clear message.
- Launcher on real JDK 17 → runs normally.
- Longest build-script line 103 chars (detekt-clean); pre-commit `detektAll` passed.

### CI note
The PR-CI `test` job (matrix Java 17 + 21) and the `installDist` smoke step now resolve a JDK 17 toolchain for the CLI; on the Java-21 leg foojay provisions 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)