### PR TITLE
feat(taskflow): redux-state-driven headless render CLI (renderUi)

### DIFF
--- a/examples/taskflow/composeApp/build.gradle.kts
+++ b/examples/taskflow/composeApp/build.gradle.kts
@@ -120,3 +120,16 @@ compose.desktop {
         mainClass = "org.reduxkotlin.sample.taskflow.MainKt"
     }
 }
+
+// `redux-ui render` primitive: headless-render a screen from seeded Redux state to PNG.
+//   ./gradlew :examples:taskflow:composeApp:renderUi --args="--screen board --out board.png --theme dark"
+tasks.register<JavaExec>("renderUi") {
+    group = "render"
+    description = "Headless-render a TaskFlow screen from seeded state to PNG (see RenderCli.kt)."
+    val jvmMainCompilation = kotlin.jvm().compilations.getByName("main")
+    dependsOn(jvmMainCompilation.compileTaskProvider)
+    classpath(jvmMainCompilation.output.allOutputs, jvmMainCompilation.runtimeDependencyFiles)
+    mainClass.set("org.reduxkotlin.sample.taskflow.render.RenderCliKt")
+    // Resolve a relative --out against the repo root, not this module dir.
+    workingDir = rootProject.projectDir
+}

--- a/examples/taskflow/composeApp/src/jvmMain/kotlin/org/reduxkotlin/sample/taskflow/render/RenderCli.kt
+++ b/examples/taskflow/composeApp/src/jvmMain/kotlin/org/reduxkotlin/sample/taskflow/render/RenderCli.kt
@@ -1,0 +1,181 @@
+package org.reduxkotlin.sample.taskflow.render
+
+import androidx.compose.runtime.Composable
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import org.reduxkotlin.sample.taskflow.core.Theme
+import java.io.File
+import kotlin.system.exitProcess
+
+/**
+ * `redux-ui render` — the headless render primitive: turn a (screen, state, theme) triple into a
+ * PNG on the JVM with no Android, no emulator, no SqlDelight, no network. This is the reusable
+ * shape behind the agent loop the architecture spike validated; the in-screen content is purely a
+ * function of the seeded Redux state, so an agent can synthesize states and inspect pixels in a
+ * tight loop.
+ *
+ * Usage:
+ *   renderUi --screen <settings|board> --out <path.png> [--theme light|dark|system]
+ *            [--state <preset>] [--width <px>] [--height <px>]
+ *
+ * Settings presets: default | offline-failing | online-bot. Board presets: seeded | empty.
+ */
+public fun main(rawArgs: Array<String>) {
+    val args = parseArgs(rawArgs)
+    when {
+        args.containsKey("list") -> printCapabilities()
+
+        args["batch"] != null -> runBatch(File(args.getValue("batch")))
+
+        else -> renderOne(
+            screen = args["screen"] ?: fail("missing --screen (settings|board), or pass --batch <file> / --list"),
+            state = args["state"],
+            theme = args["theme"],
+            out = args["out"],
+            width = args["width"]?.toIntOrNull(),
+            height = args["height"]?.toIntOrNull(),
+            stateJson = resolveStateJson(args["state-json"], args["state-file"]),
+        )
+    }
+    // Compose/skiko leave non-daemon threads alive; force a clean exit once work is done.
+    exitProcess(0)
+}
+
+/** Renders a single (screen, state, theme) to [out] (defaulted if null) and prints a one-line report. */
+private fun renderOne(
+    screen: String,
+    state: String?,
+    theme: String?,
+    out: String?,
+    width: Int?,
+    height: Int?,
+    stateJson: JsonElement?,
+) {
+    val st = state ?: defaultState(screen)
+    val th = parseTheme(theme)
+    val w = width ?: DEFAULT_WIDTH_PX
+    val h = height ?: DEFAULT_HEIGHT_PX
+    val label = if (stateJson != null) "json" else st
+    val outPath = out ?: "render-$screen-$label-${th.name.lowercase()}.png"
+    val content = sceneFor(screen, st, th, stateJson)
+    val start = System.nanoTime()
+    val png = renderToPng(w, h, content)
+    val ms = (System.nanoTime() - start) / 1_000_000
+    File(outPath).apply { absoluteFile.parentFile?.mkdirs() }.writeBytes(png)
+    println("[redux-ui] screen=$screen state=$label theme=${th.name} ${w}x${h}px -> $outPath (${png.size} B, ${ms}ms)")
+}
+
+/** Resolves a screen name + state (preset or agent-supplied [json]) to its composable scene. */
+private fun sceneFor(screen: String, state: String, theme: Theme, json: JsonElement?): @Composable () -> Unit =
+    when (screen) {
+        "settings" -> settingsScene(state, theme, json)
+        "board" -> boardScene(state, theme, json)
+        else -> fail("unknown --screen '$screen' (settings|board)")
+    }
+
+/** The default state preset per screen when `--state` is omitted. */
+private fun defaultState(screen: String): String = when (screen) {
+    "board" -> "seeded"
+    else -> "default"
+}
+
+/** Prints the machine-readable capability manifest (screens, presets, themes) for agent discovery. */
+private fun printCapabilities() {
+    val caps = Capabilities(
+        screens = listOf(
+            ScreenCap("settings", SETTINGS_PRESETS, Json.parseToJsonElement(SETTINGS_STATE_EXAMPLE)),
+            ScreenCap("board", BOARD_PRESETS, Json.parseToJsonElement(BOARD_STATE_EXAMPLE)),
+        ),
+        themes = listOf("light", "dark", "system"),
+    )
+    println(Json { prettyPrint = true }.encodeToString(caps))
+}
+
+/**
+ * Renders every job in a `--batch` file in ONE process. Only the first render pays the skiko
+ * classload (~600ms); the rest land at the warm ~50ms — the throughput an agent loop needs.
+ */
+private fun runBatch(file: File) {
+    if (!file.exists()) fail("batch file not found: ${file.absolutePath}")
+    val jobs = Json { ignoreUnknownKeys = true }.decodeFromString<List<RenderJob>>(file.readText())
+    println("[redux-ui] batch: ${jobs.size} job(s) from ${file.name}")
+    jobs.forEach { renderOne(it.screen, it.state, it.theme, it.out, it.width, it.height, it.stateJson) }
+}
+
+/** Resolves agent-supplied state: a `--state-file` path wins over inline `--state-json`; null if neither. */
+private fun resolveStateJson(inline: String?, file: String?): JsonElement? = when {
+    file != null -> Json.parseToJsonElement(File(file).readText())
+    inline != null -> Json.parseToJsonElement(inline)
+    else -> null
+}
+
+internal fun parseTheme(raw: String?): Theme = when (raw?.lowercase()) {
+    null, "light" -> Theme.Light
+    "dark" -> Theme.Dark
+    "system" -> Theme.System
+    else -> fail("unknown --theme '$raw' (light|dark|system)")
+}
+
+/** Parses `--key value` / `--key=value` flags into a map; bare `--flag` becomes `flag=true`. */
+private fun parseArgs(args: Array<String>): Map<String, String> {
+    val map = mutableMapOf<String, String>()
+    var i = 0
+    while (i < args.size) {
+        val a = args[i]
+        if (a.startsWith("--")) {
+            val key = a.removePrefix("--")
+            if (key.contains('=')) {
+                map[key.substringBefore('=')] = key.substringAfter('=')
+            } else if (i + 1 < args.size && !args[i + 1].startsWith("--")) {
+                map[key] = args[i + 1]
+                i++
+            } else {
+                map[key] = "true"
+            }
+        }
+        i++
+    }
+    return map
+}
+
+internal fun fail(msg: String): Nothing {
+    System.err.println("[redux-ui] error: $msg")
+    exitProcess(1)
+}
+
+/** One render job in a `--batch` JSON array. */
+@Serializable
+private data class RenderJob(
+    val screen: String,
+    val out: String,
+    val state: String? = null,
+    val theme: String? = null,
+    val width: Int? = null,
+    val height: Int? = null,
+    val stateJson: JsonObject? = null,
+)
+
+/** A renderable screen, its state presets, and an example agent-authored state, for `--list`. */
+@Serializable
+private data class ScreenCap(val name: String, val presets: List<String>, val stateExample: JsonElement)
+
+/** The `--list` capability manifest emitted as JSON for agent discovery. */
+@Serializable
+private data class Capabilities(val screens: List<ScreenCap>, val themes: List<String>)
+
+private val SETTINGS_PRESETS = listOf("default", "offline-failing", "online-bot")
+private val BOARD_PRESETS = listOf("seeded", "empty")
+
+private const val SETTINGS_STATE_EXAMPLE =
+    """{"theme":"dark","online":false,"botEnabled":true,"failureRate":0.5,"latencyMinMs":0,"latencyMaxMs":1500}"""
+private const val BOARD_STATE_EXAMPLE =
+    """{"columns":[{"name":"To Do","cards":[""" +
+        """{"title":"Write the spec","labels":["docs","backend"],"assignee":"ann"}]},""" +
+        """{"name":"Done","cards":[]}]}"""
+
+private const val DEFAULT_WIDTH_PX = 822
+private const val DEFAULT_HEIGHT_PX = 1782

--- a/examples/taskflow/composeApp/src/jvmMain/kotlin/org/reduxkotlin/sample/taskflow/render/RenderScenes.kt
+++ b/examples/taskflow/composeApp/src/jvmMain/kotlin/org/reduxkotlin/sample/taskflow/render/RenderScenes.kt
@@ -1,0 +1,162 @@
+@file:OptIn(ExperimentalComposeUiApi::class)
+
+package org.reduxkotlin.sample.taskflow.render
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Density
+import coil3.compose.setSingletonImageLoaderFactory
+import kotlinx.collections.immutable.toPersistentMap
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
+import org.jetbrains.skia.EncodedImageFormat
+import org.reduxkotlin.Store
+import org.reduxkotlin.bundle.createConcurrentModelStore
+import org.reduxkotlin.concurrent.NotificationContext
+import org.reduxkotlin.multimodel.ModelState
+import org.reduxkotlin.sample.taskflow.app.createAppStore
+import org.reduxkotlin.sample.taskflow.core.Theme
+import org.reduxkotlin.sample.taskflow.feature.activity.ActivityModel
+import org.reduxkotlin.sample.taskflow.feature.board.BoardModel
+import org.reduxkotlin.sample.taskflow.feature.board.BoardScreen
+import org.reduxkotlin.sample.taskflow.feature.board.FilterModel
+import org.reduxkotlin.sample.taskflow.feature.board.LoadBoardSucceeded
+import org.reduxkotlin.sample.taskflow.feature.board.SyncModel
+import org.reduxkotlin.sample.taskflow.feature.board.boardReducer
+import org.reduxkotlin.sample.taskflow.feature.boardlist.BoardListModel
+import org.reduxkotlin.sample.taskflow.feature.collaborators.CollaboratorsModel
+import org.reduxkotlin.sample.taskflow.feature.settings.SetBotEnabled
+import org.reduxkotlin.sample.taskflow.feature.settings.SetFailureRate
+import org.reduxkotlin.sample.taskflow.feature.settings.SetLatency
+import org.reduxkotlin.sample.taskflow.feature.settings.SetOnline
+import org.reduxkotlin.sample.taskflow.feature.settings.SetTheme
+import org.reduxkotlin.sample.taskflow.feature.settings.SettingsScreen
+import org.reduxkotlin.sample.taskflow.feature.undo.UndoModel
+import org.reduxkotlin.sample.taskflow.infra.SeedData
+import org.reduxkotlin.sample.taskflow.infra.util.FakeIdGenerator
+import org.reduxkotlin.sample.taskflow.ui.LocalClock
+import org.reduxkotlin.sample.taskflow.ui.LocalIdGenerator
+import org.reduxkotlin.sample.taskflow.ui.image.fakeNoNetworkImageLoader
+import org.reduxkotlin.sample.taskflow.ui.theme.TaskFlowTheme
+
+/** Renders [content] off-screen at [width]x[height] device pixels (2x density) and PNG-encodes it. */
+internal fun renderToPng(width: Int, height: Int, content: @Composable () -> Unit): ByteArray {
+    val scene = ImageComposeScene(width = width, height = height, density = Density(RENDER_DENSITY)) {
+        content()
+    }
+    return try {
+        scene.render().encodeToData(EncodedImageFormat.PNG)!!.bytes
+    } finally {
+        scene.close()
+    }
+}
+
+/**
+ * Settings screen scene. With [json] present the state is fully agent-driven via a [SettingsSpec]
+ * (each non-null field dispatched; `theme` in the spec overrides the [theme] flag); otherwise the
+ * named [state] preset is applied.
+ */
+internal fun settingsScene(state: String, theme: Theme, json: JsonElement?): @Composable () -> Unit {
+    val store = createAppStore(NotificationContext.Inline)
+    var resolvedTheme = theme
+    if (json != null) {
+        val spec = LENIENT_JSON.decodeFromJsonElement<SettingsSpec>(json)
+        resolvedTheme = spec.theme?.let { parseTheme(it) } ?: theme
+        store.dispatch(SetTheme(resolvedTheme))
+        spec.online?.let { store.dispatch(SetOnline(it)) }
+        spec.botEnabled?.let { store.dispatch(SetBotEnabled(it)) }
+        spec.failureRate?.let { store.dispatch(SetFailureRate(it)) }
+        if (spec.latencyMinMs != null || spec.latencyMaxMs != null) {
+            store.dispatch(SetLatency(spec.latencyMinMs ?: 0, spec.latencyMaxMs ?: DEFAULT_LATENCY_MAX_MS))
+        }
+    } else {
+        store.dispatch(SetTheme(theme))
+        applySettingsPreset(store, state)
+    }
+    val finalTheme = resolvedTheme
+    return { Themed(finalTheme) { SettingsScreen(store) } }
+}
+
+/** Applies a named settings preset by dispatching the corresponding actions. */
+private fun applySettingsPreset(store: Store<ModelState>, preset: String) {
+    when (preset) {
+        "default" -> Unit
+
+        "offline-failing" -> {
+            store.dispatch(SetOnline(false))
+            store.dispatch(SetBotEnabled(false))
+            store.dispatch(SetFailureRate(FAILING_RATE))
+            store.dispatch(SetLatency(0, OFFLINE_MAX_LATENCY_MS))
+        }
+
+        "online-bot" -> {
+            store.dispatch(SetOnline(true))
+            store.dispatch(SetBotEnabled(true))
+            store.dispatch(SetFailureRate(0f))
+        }
+
+        else -> fail("unknown settings --state '$preset' (default|offline-failing|online-bot)")
+    }
+}
+
+/**
+ * Board screen scene: a minimal account-shaped concurrent store wired to the real [boardReducer],
+ * seeded from [SeedData] (the `empty` preset leaves [BoardModel] unloaded to render the empty
+ * state). Demonstrates the harder case — a rich screen with cards, labels, avatars — still renders
+ * purely from seeded state, with the singleton image loader swapped for a no-network one.
+ */
+internal fun boardScene(state: String, theme: Theme, json: JsonElement?): @Composable () -> Unit {
+    val seeded = SeedData.seededAccounts().first()
+    val owner = seeded.owner.id
+    // BoardScreen reads all of these slices via fieldStateOf/selectorState; every model it reads
+    // MUST be registered or ModelState.get throws inside composition and the recomposer spins.
+    val store: Store<ModelState> = createConcurrentModelStore(notificationContext = NotificationContext.Inline) {
+        model(BoardModel()) {
+            on<LoadBoardSucceeded> { s, a -> boardReducer(s, a, owner) }
+        }
+        model(CollaboratorsModel(byId = seeded.collaborators.associateBy { it.id }.toPersistentMap())) {}
+        model(BoardListModel()) {}
+        model(FilterModel()) {}
+        model(SyncModel()) {}
+        model(ActivityModel()) {}
+        model(UndoModel()) {}
+    }
+    // With json present the agent fully authors the board; otherwise the named preset is used.
+    val board = when {
+        json != null -> buildBoardFromSpec(LENIENT_JSON.decodeFromJsonElement<BoardSpec>(json))
+        state == "seeded" -> seeded.board
+        state == "empty" -> null
+        else -> fail("unknown board --state '$state' (seeded|empty)")
+    }
+    if (board != null) store.dispatch(LoadBoardSucceeded(board))
+    return {
+        CompositionLocalProvider(
+            LocalIdGenerator provides FakeIdGenerator(),
+            LocalClock provides { SeedData.SEED_INSTANT },
+        ) {
+            setSingletonImageLoaderFactory { ctx -> fakeNoNetworkImageLoader(ctx) }
+            Themed(theme) { BoardScreen(store) }
+        }
+    }
+}
+
+/** Wraps [body] in the app theme + a full-bleed surface so the captured frame has an opaque bg. */
+@Composable
+private fun Themed(theme: Theme, body: @Composable () -> Unit) {
+    TaskFlowTheme(theme = theme, dynamic = false) {
+        Surface(modifier = Modifier.fillMaxSize()) { body() }
+    }
+}
+
+private val LENIENT_JSON = Json { ignoreUnknownKeys = true }
+
+private const val RENDER_DENSITY = 2f
+private const val FAILING_RATE = 0.9f
+private const val OFFLINE_MAX_LATENCY_MS = 3000
+private const val DEFAULT_LATENCY_MAX_MS = 800

--- a/examples/taskflow/composeApp/src/jvmMain/kotlin/org/reduxkotlin/sample/taskflow/render/RenderStateSpec.kt
+++ b/examples/taskflow/composeApp/src/jvmMain/kotlin/org/reduxkotlin/sample/taskflow/render/RenderStateSpec.kt
@@ -1,0 +1,80 @@
+package org.reduxkotlin.sample.taskflow.render
+
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+import kotlinx.serialization.Serializable
+import org.reduxkotlin.sample.taskflow.core.AccountId
+import org.reduxkotlin.sample.taskflow.core.Board
+import org.reduxkotlin.sample.taskflow.core.BoardId
+import org.reduxkotlin.sample.taskflow.core.Card
+import org.reduxkotlin.sample.taskflow.core.CardId
+import org.reduxkotlin.sample.taskflow.core.Column
+import org.reduxkotlin.sample.taskflow.core.ColumnId
+import org.reduxkotlin.sample.taskflow.core.Label
+import org.reduxkotlin.sample.taskflow.core.LabelId
+import org.reduxkotlin.sample.taskflow.infra.SeedData
+
+/*
+ * Agent-facing JSON state contracts. These are deliberately NOT the internal `ModelState` models —
+ * they are small, stable DTOs an agent authors directly, then mapped to real domain objects and
+ * dispatched. This keeps the wire format simple (strings/ints/lists) and decoupled from internal
+ * value classes / persistent collections.
+ */
+
+/** Settings screen state. Every field is optional; omitted fields keep the model default. */
+@Serializable
+internal data class SettingsSpec(
+    val theme: String? = null,
+    val online: Boolean? = null,
+    val botEnabled: Boolean? = null,
+    val failureRate: Float? = null,
+    val latencyMinMs: Int? = null,
+    val latencyMaxMs: Int? = null,
+)
+
+/** Board screen state: ordered columns, each with ordered cards. */
+@Serializable
+internal data class BoardSpec(val columns: List<ColumnSpec> = emptyList())
+
+/** A board column. */
+@Serializable
+internal data class ColumnSpec(val name: String, val cards: List<CardSpec> = emptyList(), val wipLimit: Int? = null)
+
+/** A card; [labels] reference label names (e.g. "backend"), [assignee] an account id (e.g. "ann"). */
+@Serializable
+internal data class CardSpec(
+    val title: String,
+    val description: String = "",
+    val labels: List<String> = emptyList(),
+    val assignee: String? = null,
+)
+
+/** Maps a [BoardSpec] to a real [Board], minting deterministic ids and resolving label names. */
+internal fun buildBoardFromSpec(spec: BoardSpec): Board {
+    val owner = SeedData.seededAccounts().first().owner.id
+    val cards = mutableMapOf<CardId, Card>()
+    val columns = spec.columns.mapIndexed { ci, col ->
+        val cardIds = col.cards.mapIndexed { idx, c ->
+            val id = CardId("c$ci-$idx")
+            cards[id] = Card(
+                id = id,
+                title = c.title,
+                description = c.description,
+                labels = c.labels.map(::resolveLabel).toPersistentList(),
+                assigneeId = c.assignee?.let { AccountId(it) },
+                createdBy = owner,
+                createdAt = SeedData.SEED_INSTANT,
+                updatedAt = SeedData.SEED_INSTANT,
+            )
+            id
+        }.toPersistentList()
+        Column(id = ColumnId("col-$ci"), title = col.name, cardIds = cardIds, wipLimit = col.wipLimit)
+    }.toPersistentList()
+    return Board(boardId = BoardId("json-board"), columns = columns, cards = cards.toPersistentMap())
+}
+
+/** Resolves a label name to a seeded [Label], or synthesizes a neutral one if unknown. */
+private fun resolveLabel(name: String): Label =
+    SeedData.labels.firstOrNull { it.name == name } ?: Label(LabelId(name), name, DEFAULT_LABEL_COLOR)
+
+private const val DEFAULT_LABEL_COLOR = 0xFFDDDDDDL

--- a/examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/spike/RenderSpikeTest.kt
+++ b/examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/spike/RenderSpikeTest.kt
@@ -1,0 +1,130 @@
+package org.reduxkotlin.sample.taskflow.spike
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asSkiaBitmap
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
+import org.junit.Test
+import org.reduxkotlin.Store
+import org.reduxkotlin.concurrent.NotificationContext
+import org.reduxkotlin.multimodel.ModelState
+import org.reduxkotlin.sample.taskflow.app.createAppStore
+import org.reduxkotlin.sample.taskflow.core.Theme
+import org.reduxkotlin.sample.taskflow.feature.settings.SetBotEnabled
+import org.reduxkotlin.sample.taskflow.feature.settings.SetFailureRate
+import org.reduxkotlin.sample.taskflow.feature.settings.SetLatency
+import org.reduxkotlin.sample.taskflow.feature.settings.SetOnline
+import org.reduxkotlin.sample.taskflow.feature.settings.SetTheme
+import org.reduxkotlin.sample.taskflow.feature.settings.SettingsScreen
+import org.reduxkotlin.sample.taskflow.ui.theme.TaskFlowTheme
+import java.io.File
+import kotlin.test.assertTrue
+
+/**
+ * THESIS-VALIDATION SPIKE (not a real test): can a Compose screen be rendered headlessly on the
+ * JVM purely as a function of hand-seeded Redux state — no Android, no SqlDelight, no network, no
+ * emulator — fast enough for an agent loop, with legible pixels?
+ *
+ * Each variant builds a root store via [createAppStore] with [NotificationContext.Inline], seeds a
+ * distinct [org.reduxkotlin.sample.taskflow.core.AppSettingsModel] by dispatching settings actions,
+ * then renders [SettingsScreen] off-screen and encodes a PNG. The seeded `theme` drives BOTH the
+ * in-screen segmented-button selection AND the [TaskFlowTheme] color scheme, so different state ->
+ * visibly different pixels. Timings (cold first render + warm renders) are printed; PNGs land in
+ * build/render-spike for human/VLM inspection.
+ */
+@OptIn(ExperimentalTestApi::class)
+class RenderSpikeTest {
+
+    private val outDir = File("build/render-spike").apply { mkdirs() }
+
+    private data class Variant(val name: String, val seed: (Store<ModelState>) -> Unit, val theme: Theme)
+
+    private val variants = listOf(
+        Variant("light-default", seed = {}, theme = Theme.Light),
+        Variant("dark-default", seed = { it.dispatch(SetTheme(Theme.Dark)) }, theme = Theme.Dark),
+        Variant(
+            "dark-offline-failing",
+            seed = {
+                it.dispatch(SetTheme(Theme.Dark))
+                it.dispatch(SetOnline(false))
+                it.dispatch(SetBotEnabled(false))
+                it.dispatch(SetFailureRate(0.9f))
+                it.dispatch(SetLatency(0, 3000))
+            },
+            theme = Theme.Dark,
+        ),
+        Variant(
+            "light-online-bot",
+            seed = {
+                it.dispatch(SetTheme(Theme.Light))
+                it.dispatch(SetOnline(true))
+                it.dispatch(SetBotEnabled(true))
+                it.dispatch(SetFailureRate(0.0f))
+            },
+            theme = Theme.Light,
+        ),
+    )
+
+    @Test
+    fun renderSettingsAcrossSeededStates() {
+        val timingsMs = mutableListOf<Pair<String, Long>>()
+
+        variants.forEachIndexed { index, v ->
+            val start = System.nanoTime()
+            renderVariant(v)
+            val elapsedMs = (System.nanoTime() - start) / 1_000_000
+            timingsMs += v.name to elapsedMs
+            // index 0 is the cold render (Compose/skiko classload + first composition warmup).
+            println("[render-spike] ${v.name}: ${elapsedMs}ms ${if (index == 0) "(cold)" else "(warm)"}")
+        }
+
+        val warm = timingsMs.drop(1).map { it.second }
+        if (warm.isNotEmpty()) {
+            println("[render-spike] warm avg: ${warm.average().toLong()}ms  min=${warm.min()}ms max=${warm.max()}ms")
+        }
+        println("[render-spike] PNGs written to: ${outDir.absolutePath}")
+
+        variants.forEach { v ->
+            val f = File(outDir, "${v.name}.png")
+            assertTrue(f.exists() && f.length() > 0, "expected non-empty PNG for ${v.name}")
+        }
+    }
+
+    private fun renderVariant(v: Variant) = runComposeUiTest {
+        val store = createAppStore(NotificationContext.Inline)
+        v.seed(store)
+
+        setContent {
+            // Fixed phone-ish canvas so the captured root has known, non-zero bounds.
+            Box(modifier = Modifier.size(411.dp, 891.dp)) {
+                Screen(store = store, theme = v.theme)
+            }
+        }
+        waitForIdle()
+
+        val bmp = onRoot().captureToImage()
+        val pngBytes = Image.makeFromBitmap(bmp.asSkiaBitmap())
+            .encodeToData(EncodedImageFormat.PNG)!!
+            .bytes
+        File(outDir, "${v.name}.png").writeBytes(pngBytes)
+    }
+
+    @Composable
+    private fun Screen(store: Store<ModelState>, theme: Theme) {
+        TaskFlowTheme(theme = theme, dynamic = false) {
+            Surface(modifier = Modifier.fillMaxSize()) {
+                SettingsScreen(store)
+            }
+        }
+    }
+}

--- a/examples/taskflow/docs/redux-ui-render.md
+++ b/examples/taskflow/docs/redux-ui-render.md
@@ -1,0 +1,272 @@
+# `redux-ui render` — headless screen rendering for AI agents
+
+A spike that turns a TaskFlow Compose screen into a PNG from **seeded Redux state
+only** — no Android, no emulator, no SqlDelight, no network. Because every screen
+is a pure function of `ModelState`, an agent can synthesize a state, render it,
+look at the pixels, and iterate in a tight loop.
+
+```
+f(State) → Pixels        # deterministic, headless, ~50ms warm
+```
+
+This document shows the commands, an example agent session, and the actual output
+images.
+
+---
+
+## Quick start
+
+The renderer is wired as a Gradle `JavaExec` task on the TaskFlow sample:
+
+```bash
+# one screen → one PNG
+./gradlew :examples:taskflow:composeApp:renderUi \
+  --args="--screen board --state seeded --theme dark --out board.png"
+
+# discover what can be rendered, with a state example per screen (machine-readable)
+./gradlew :examples:taskflow:composeApp:renderUi --args="--list"
+
+# render many states in ONE warm JVM (the agent-loop path)
+./gradlew :examples:taskflow:composeApp:renderUi \
+  --args="--batch states.json"
+
+# drive ARBITRARY state from JSON (not just presets)
+./gradlew :examples:taskflow:composeApp:renderUi \
+  --args="--screen board --state-file my-board.json --theme dark --out board.png"
+```
+
+### Flags
+
+| Flag | Meaning | Default |
+|------|---------|---------|
+| `--screen` | `settings` \| `board` | — (required for single) |
+| `--state` | screen-specific preset | `settings`→`default`, `board`→`seeded` |
+| `--theme` | `light` \| `dark` \| `system` | `light` |
+| `--out` | output PNG path (relative to repo root) | `render-<screen>-<state>-<theme>.png` |
+| `--width` / `--height` | device pixels (2× density) | `822` × `1782` |
+| `--list` | print capability manifest (incl. a `stateExample` per screen) as JSON | — |
+| `--batch` | render every job in a JSON file (each job may carry an inline `stateJson`) | — |
+| `--state-json` | inline JSON state the agent authors (overrides `--state`) | — |
+| `--state-file` | path to a JSON state file (wins over `--state-json`) | — |
+
+---
+
+## Discovery — `--list`
+
+So an agent never has to guess what exists:
+
+```bash
+./gradlew :examples:taskflow:composeApp:renderUi --args="--list"
+```
+
+```json
+{
+    "screens": [
+        {
+            "name": "settings",
+            "presets": ["default", "offline-failing", "online-bot"],
+            "stateExample": { "theme": "dark", "online": false, "failureRate": 0.5, "latencyMaxMs": 1500 }
+        },
+        {
+            "name": "board",
+            "presets": ["seeded", "empty"],
+            "stateExample": { "columns": [{ "name": "To Do", "cards": [{ "title": "Write the spec", "labels": ["docs"], "assignee": "ann" }] }] }
+        }
+    ],
+    "themes": ["light", "dark", "system"]
+}
+```
+
+The `stateExample` is the schema an agent copies and edits — it never has to guess
+the JSON shape.
+
+---
+
+## Example: an agent iterating on UI
+
+> A design-review agent is asked to *"check the Settings and Board screens look
+> right in light and dark, including the offline + empty edge states."* It has the
+> `renderUi` CLI and a vision model. Here is the loop.
+
+---
+
+**🧑 User:** Verify the TaskFlow Settings and Board screens across themes and the
+key edge states. Flag anything visually off.
+
+**🤖 Agent:** Discovering what's renderable.
+
+```bash
+$ renderUi --list
+{ "screens": [ {"name":"settings",...}, {"name":"board",...} ], "themes":[...] }
+```
+
+Two screens, with `offline-failing` and `empty` edge presets. I'll batch every
+combination I care about in one warm process.
+
+```bash
+$ cat states.json
+[
+  {"screen":"settings","state":"default",        "theme":"light","out":"out/settings-light.png"},
+  {"screen":"settings","state":"offline-failing", "theme":"dark", "out":"out/settings-dark-offline.png"},
+  {"screen":"board",   "state":"seeded",          "theme":"dark", "out":"out/board-seeded-dark.png"},
+  {"screen":"board",   "state":"empty",           "theme":"light","out":"out/board-empty-light.png"}
+]
+
+$ renderUi --batch states.json
+[redux-ui] batch: 4 job(s) from states.json
+[redux-ui] screen=settings state=default          theme=Light 822x1782px -> out/settings-light.png (55768 B, 662ms)
+[redux-ui] screen=settings state=offline-failing  theme=Dark  822x1782px -> out/settings-dark-offline.png (58131 B, 91ms)
+[redux-ui] screen=board    state=seeded           theme=Dark  822x1782px -> out/board-seeded-dark.png (58786 B, 271ms)
+[redux-ui] screen=board    state=empty            theme=Light 822x1782px -> out/board-empty-light.png (25641 B, 70ms)
+```
+
+Four renders, ~1.1s total (first pays JVM/skiko warmup; the rest are 70–270ms).
+Inspecting each.
+
+---
+
+**🤖 Agent:** **Settings — light, default.** Theme picker shows `System`
+selected, latency `300–800 ms`, failure `10%`, bot + online on. Clean, controls
+aligned, label hierarchy correct. ✅
+
+![Settings, light, default](assets/settings-light-default.png)
+
+---
+
+**🤖 Agent:** **Settings — dark, offline-failing.** State seeded with
+`SetOnline(false)`, `SetFailureRate(0.9)`, `SetLatency(0,3000)`. The render tracks
+it exactly: `Dark` segment selected + dark scheme, latency `0–3000 ms`, failure
+`90%` (error-tinted track), bot off, and the row label flipped `Online → Offline`
+with the switch off. Edge state renders correctly. ✅
+
+![Settings, dark, offline + failing](assets/settings-dark-offline.png)
+
+---
+
+**🤖 Agent:** **Board — dark, seeded.** Full kanban from `LoadBoardSucceeded`:
+"To Do" column, count badge `2`, two cards with colored label chips
+(`backend` / `docs`), `AP` avatar monograms (no-network image loader → deterministic
+fallback, as designed), search field, green online dot, undo/redo, FAB. ✅
+
+![Board, dark, seeded](assets/board-seeded-dark.png)
+
+---
+
+**🤖 Agent:** **Board — light, empty.** Same screen, `BoardModel` left unloaded →
+the light-theme loading skeleton (shimmer placeholders), no cards. The empty/loading
+path renders correctly and doesn't collapse. ✅
+
+![Board, light, empty (loading skeleton)](assets/board-empty-light.png)
+
+---
+
+**🤖 Agent:** **Summary.** 4/4 states render correctly and are faithful to the
+seeded Redux state — including both edge cases. No visual defects found. Theme,
+failure-rate styling, label colors, avatar fallback, and the empty-state skeleton
+all behave. (Note: headless JVM render is high-fidelity triage, not pixel-identical
+to a physical Android device — confirm final polish on-device.)
+
+---
+
+## Driving arbitrary state from JSON
+
+Presets cover the demo states; for everything else the agent authors state directly
+as JSON. The wire format is a small, stable DTO per screen (not the internal
+`ModelState`), mapped to real domain objects and dispatched through the real
+reducers.
+
+**🤖 Agent:** I want a board that isn't in the seed data — three columns, my own
+cards and labels. I'll write the state and render it.
+
+```bash
+$ cat my-board.json
+{
+  "columns": [
+    { "name": "Backlog", "cards": [
+      { "title": "Agent-authored card", "labels": ["p1", "design"], "assignee": "ann" },
+      { "title": "Wire up the daemon",  "labels": ["backend", "infra"], "assignee": "raj" }
+    ]},
+    { "name": "In Progress", "cards": [ { "title": "Ship JSON state", "labels": ["frontend"] } ] },
+    { "name": "Done", "cards": [] }
+  ]
+}
+
+$ renderUi --screen board --state-file my-board.json --theme dark --out out/board.png
+[redux-ui] screen=board state=json theme=Dark 822x1782px -> out/board.png (57595 B, 740ms)
+```
+
+The render is exactly the authored state: column **Backlog** (badge `2`), the two
+cards with `p1`/`design` and `backend`/`infra` chips (label names resolved to their
+palette colors), assignee avatars, and three columns in the pager. None of this is
+seed data — it came entirely from the JSON.
+
+![Board rendered from agent-authored JSON](assets/board-json-agent.png)
+
+In a `--batch` file each job can embed its own `stateJson`, so an agent sweeps a
+whole set of hand-authored states in one warm process:
+
+```json
+[
+  { "screen": "board",    "theme": "dark",  "out": "out/a.png",
+    "stateJson": { "columns": [ { "name": "Ideas", "cards": [ { "title": "From batch", "labels": ["design"] } ] } ] } },
+  { "screen": "settings", "theme": "light", "out": "out/b.png",
+    "stateJson": { "theme": "light", "online": false, "failureRate": 0.7 } }
+]
+```
+
+---
+
+## Performance
+
+Measured on the TaskFlow sample (per-render timer around the off-screen render):
+
+| Mode | First render | Subsequent renders |
+|------|--------------|--------------------|
+| Per-process CLI invoke | ~0.5–0.7 s | n/a (new JVM each time) |
+| **`--batch` (one warm JVM)** | ~0.6 s | **~70–110 ms** |
+| In-JVM (test harness) | 861 ms (cold) | **~50 ms** |
+
+The dominant cost is one-time **JVM boot + skiko classload**, not the render. Keep
+the process warm (batch, or a future daemon) and throughput is ~10–20 renders/sec —
+fast enough for an agent to sweep dozens of states per turn.
+
+> A Rust/Go rewrite would **not** help: Compose/skiko render only on the JVM, so a
+> rewrite can't touch the dominant cost. The lever is a warm process, not a language.
+
+---
+
+## Why this works — and the two gotchas the spike surfaced
+
+The whole property comes from Redux: a screen takes a `Store<ModelState>` and reads
+slices via `fieldStateOf` / `selectorState`. Seed the state by dispatching pure
+actions, render, done — no platform needed. Two non-obvious constraints fell out:
+
+1. **Register every model a screen reads.** `ModelState.get` throws on an
+   unregistered model, and `selectorState` swallows + retries the read, so a missing
+   slice sends the recomposer into an infinite loop (the render never settles). The
+   board scene registers all seven slices it reads.
+2. **`exitProcess(0)` when done.** Compose/skiko leave non-daemon threads alive, so
+   `main()` returning isn't enough — the JVM would hang after writing the PNG.
+
+---
+
+## Limitations & next steps
+
+- **Fidelity:** desktop/JVM Compose render ≈ Android, not pixel-identical (fonts,
+  ripple, insets, system bars). Great for fast triage; confirm final on-device.
+- **JSON state ✅ done** via `--state-json` / `--state-file` / batch `stateJson`. The
+  schema is a per-screen DTO (`SettingsSpec` / `BoardSpec`), intentionally simpler
+  than the internal `ModelState`. Extending a screen's authorable surface = adding
+  fields to its spec.
+- **Two screens** wired (settings, board). Adding BoardList / Profile / CardDetail /
+  Login is a few lines each in the scene registry.
+- **Warm daemon:** a persistent process reading jobs on stdin/socket would hold the
+  ~50 ms render with zero per-invoke boot.
+- **MCP wrapper:** expose `render_ui(screen, state) → image` so an agent calls it
+  natively and gets the PNG straight into vision.
+
+---
+
+*Source: `composeApp/src/jvmMain/.../render/RenderCli.kt` (+ `RenderScenes.kt`),
+Gradle task `:examples:taskflow:composeApp:renderUi`. Validation test:
+`composeApp/src/jvmTest/.../spike/RenderSpikeTest.kt`.*


### PR DESCRIPTION
Resurrects the render spike (from the unmerged `worktree-taskflow-render-spike` branch) onto master and lands it as a real feature.

## What it is
A **redux-state-driven, headless Compose→PNG** primitive in the TaskFlow sample. `renderUi` turns a `(screen, state, theme)` triple into a PNG on the JVM — no Android, emulator, SqlDelight, or network. The screen content is a **pure function of seeded Redux state**, so an agent (or CI) can synthesize states and inspect pixels in a tight loop.

```
./gradlew :examples:taskflow:composeApp:renderUi \
  --args="--screen board --state seeded --theme dark --out board.png"
```

## Pieces
- `render/RenderStateSpec.kt` — agent-facing **JSON state DTOs** (`SettingsSpec`/`BoardSpec`/`CardSpec`, deliberately *not* internal `ModelState`) mapped to domain objects.
- `render/RenderScenes.kt` — seeds the store from the spec and hosts `BoardScreen`/`SettingsScreen`.
- `render/RenderCli.kt` — `--screen settings|board`, `--state <preset>`, `--theme`, `--out`, plus `--list` (capability discovery JSON), `--batch <file>`, and `--state-json`/`--state-file` for arbitrary state.
- Gradle `renderUi` JavaExec task.
- `spike/RenderSpikeTest.kt` — proves state → PNG without a platform.
- `docs/redux-ui-render.md` — report + example agent session.

## Verified locally (on master)
- `board` (seeded, dark) → 822×1782 PNG, ~735ms; `settings` (offline-failing, light) → PNG, ~628ms — both render real content.
- `--list` emits the capability/preset JSON.
- `RenderSpikeTest` passes (1/1); `:examples:taskflow:composeApp:compileKotlinJvm` clean; pre-commit `detektAll` passed.

## Notes
- All symbols it needs already exist on master (the spike was based on the same package-by-feature layout), so this was a near drop-in port — only the `renderUi` Gradle task needed re-adding.
- Solves the headless-screenshot problem from the DevTools CLI how-to: the TaskFlow board image can be generated deterministically from seeded state, no live GUI/display required.
- Relationship to `rk-devtools`: **separate** — this renders UI from state; `rk-devtools` queries action/state captures. Neither overlaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)