### PR TITLE
ci(check): fix detekt SARIF path after 2.0 migration

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,7 +36,9 @@ jobs:
         continue-on-error: true
         run: |
           ls '${{ github.workspace }}/build/reports/detekt/'
-          cp '${{ github.workspace }}/build/reports/detekt/detekt.sarif' '${{ github.workspace }}/detekt.sarif.json'
+          # detekt 2.0 names report files after the task minus its `detekt` prefix,
+          # so the root `detektAll` task emits `all.sarif` (was `detekt.sarif` in 1.x).
+          cp '${{ github.workspace }}/build/reports/detekt/all.sarif' '${{ github.workspace }}/detekt.sarif.json'
           echo "$(
             jq --arg github_workspace ${{ github.workspace }} \
               '. | ( .runs[].results[].locations[].physicalLocation.artifactLocation.uri |= if test($github_workspace) then .[($github_workspace | length | . + 1):] else . end )' \


### PR DESCRIPTION
## Problem
The `Lint the code` job in `check.yml` fails on the SARIF upload step:
```
Path does not exist: .../redux-kotlin/detekt.sarif.json
```
`detektAll` itself **passes** (no lint violations). The job dies because the "Make artifact location URIs relative" step `cp`s a file that no longer exists, then `upload-sarif` aborts on the missing file. Because `release.yml` / `pr.yml` gate on `needs: [check]`, this **blocks every publish job** (including the 1.0.0-alpha01 release run).

## Root cause
The `detekt 1.23.8 → 2.0.0-alpha.3` migration (9aa73d2b) changed report filenames: detekt 2.0 bases the output filename on the task name minus its `detekt` prefix, so the root `detektAll` task now emits `build/reports/detekt/all.sarif` (was `detekt.sarif` in 1.x). CI was never updated.

Verified locally: `./gradlew detektAll` → exit 0, produces `build/reports/detekt/all.sarif` (no `detekt.sarif`).

## Fix
Point the `cp` source at `all.sarif`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)