### PR TITLE
fix(build): run jsBrowserTest on Chrome headless --no-sandbox

### DIFF
--- a/build-conventions/src/main/kotlin/convention.mpp-loved-composeui.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.mpp-loved-composeui.gradle.kts
@@ -29,7 +29,11 @@ kotlin {
 
     js {
         useCommonJs()
-        browser { testTask { useKarma() } }
+        // Default Karma launcher is ChromiumHeadless, which isn't installed on the
+        // Windows runner and can't start its sandbox on Ubuntu 24.04 (AppArmor blocks
+        // unprivileged user namespaces). Chrome ships on every GitHub runner, and
+        // --no-sandbox clears the Ubuntu restriction.
+        browser { testTask { useKarma { useChromeHeadlessNoSandbox() } } }
         nodejs()
     }
     @OptIn(ExperimentalWasmDsl::class)

--- a/build-conventions/src/main/kotlin/convention.mpp-loved.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.mpp-loved.gradle.kts
@@ -29,7 +29,11 @@ kotlin {
 
     js {
         useCommonJs()
-        browser { testTask { useKarma() } }
+        // Default Karma launcher is ChromiumHeadless, which isn't installed on the
+        // Windows runner and can't start its sandbox on Ubuntu 24.04 (AppArmor blocks
+        // unprivileged user namespaces). Chrome ships on every GitHub runner, and
+        // --no-sandbox clears the Ubuntu restriction.
+        browser { testTask { useKarma { useChromeHeadlessNoSandbox() } } }
         nodejs()
     }
     @OptIn(ExperimentalWasmDsl::class)


### PR DESCRIPTION
## Problem
The release `check` matrix fails `Gradle Check` on **every OS** at `jsBrowserTest` (7 modules: redux-kotlin, -concurrent, -bundle, -bundle-compose, -compose-saveable, …), blocking all publish jobs (incl. 1.0.0-alpha01).

Causes (Karma default launcher is `ChromiumHeadless`):
- **ubuntu-24.04**: `Cannot start ChromiumHeadless … No usable sandbox` — AppArmor disables unprivileged user namespaces.
- **windows**: `Can not find the binary C:\Program Files\Chromium\Application\chrome.exe … set CHROMIUM_BIN` — Chromium isn't installed.

Pre-existing on master (GitHub's `ubuntu-latest` rolled to 24.04); unrelated to the release itself.

## Fix
Switch both KMP conventions (`convention.mpp-loved`, `convention.mpp-loved-composeui`) from the default `useKarma()` (ChromiumHeadless) to:
```kotlin
browser { testTask { useKarma { useChromeHeadlessNoSandbox() } } }
```
Chrome ships on every GitHub runner, and `--no-sandbox` clears the Ubuntu 24.04 restriction. `jsNodeTest` (via `nodejs()`) is unaffected.

## Verification
- build-conventions compiles.
- Generated `karma.conf.js` now emits `browsers: [ChromeHeadlessNoSandbox]` + `{ base: ChromeHeadless, flags: [--no-sandbox] }`.
- `check.yml` dispatched on this branch (run 27654740319) to confirm the matrix is green across ubuntu/windows/macos. (Browser can't launch in the local sandbox, so CI is the real check.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)