### PR TITLE
fix(build): keep unsupported targets in klib ABI check

### DIFF
--- a/build-conventions/src/main/kotlin/convention.mpp-loved-composeui.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.mpp-loved-composeui.gradle.kts
@@ -29,7 +29,11 @@ kotlin {
 
     js {
         useCommonJs()
-        browser { testTask { useKarma() } }
+        // Default Karma launcher is ChromiumHeadless, which isn't installed on the
+        // Windows runner and can't start its sandbox on Ubuntu 24.04 (AppArmor blocks
+        // unprivileged user namespaces). Chrome ships on every GitHub runner, and
+        // --no-sandbox clears the Ubuntu restriction.
+        browser { testTask { useKarma { useChromeHeadlessNoSandbox() } } }
         nodejs()
     }
     @OptIn(ExperimentalWasmDsl::class)

--- a/build-conventions/src/main/kotlin/convention.mpp-loved-composeui.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.mpp-loved-composeui.gradle.kts
@@ -16,6 +16,14 @@ kotlin {
     @OptIn(ExperimentalAbiValidation::class)
     abiValidation {
         enabled.set(true)
+        // CI only builds every native target on the main host (macOS); ubuntu/windows
+        // build a subset, so without this their klib dump would drop the unbuilt
+        // targets and `checkKotlinAbi` would fail on a spurious `Targets:` header diff.
+        // Infer the missing targets from the committed reference so the check is
+        // host-independent.
+        klib {
+            keepUnsupportedTargets.set(true)
+        }
     }
 
     @OptIn(ExperimentalKotlinGradlePluginApi::class)

--- a/build-conventions/src/main/kotlin/convention.mpp-loved.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.mpp-loved.gradle.kts
@@ -29,7 +29,11 @@ kotlin {
 
     js {
         useCommonJs()
-        browser { testTask { useKarma() } }
+        // Default Karma launcher is ChromiumHeadless, which isn't installed on the
+        // Windows runner and can't start its sandbox on Ubuntu 24.04 (AppArmor blocks
+        // unprivileged user namespaces). Chrome ships on every GitHub runner, and
+        // --no-sandbox clears the Ubuntu restriction.
+        browser { testTask { useKarma { useChromeHeadlessNoSandbox() } } }
         nodejs()
     }
     @OptIn(ExperimentalWasmDsl::class)

--- a/build-conventions/src/main/kotlin/convention.mpp-loved.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.mpp-loved.gradle.kts
@@ -16,6 +16,14 @@ kotlin {
     @OptIn(ExperimentalAbiValidation::class)
     abiValidation {
         enabled.set(true)
+        // CI only builds every native target on the main host (macOS); ubuntu/windows
+        // build a subset, so without this their klib dump would drop the unbuilt
+        // targets and `checkKotlinAbi` would fail on a spurious `Targets:` header diff.
+        // Infer the missing targets from the committed reference so the check is
+        // host-independent.
+        klib {
+            keepUnsupportedTargets.set(true)
+        }
     }
 
     @OptIn(ExperimentalKotlinGradlePluginApi::class)


### PR DESCRIPTION
## Problem
After the jsBrowserTest fix, the `check` matrix still fails on ubuntu/windows at `:redux-kotlin:checkKotlinAbi`:
```
<<<ABI has changed>>>
-// Targets: [iosArm64, iosSimulatorArm64, js, linuxArm64, linuxX64, macosArm64, mingwX64, wasmJs]
+// Targets: [js, linuxArm64, linuxX64, wasmJs]
```
Only the `Targets:` header differs. Per `convention.control`, CI builds every native target only on the **main host (macOS)**; ubuntu/windows build a subset, so their klib dump drops apple/mingw and mismatches the committed all-targets reference. Pre-existing — masked until the jsBrowserTest failure was cleared.

## Fix
`abiValidation { klib { keepUnsupportedTargets.set(true) } }` in both KMP conventions — host-unbuildable targets are inferred from the committed reference, making `checkKotlinAbi` host-independent.

Verified: build-conventions compiles; `:redux-kotlin:checkKotlinAbi` passes locally; CI dispatch confirms ubuntu/windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)