### PR TITLE
fix(build): green the CI check matrix (klib ABI host-gate + single Karma browser)

### DIFF
--- a/build-conventions/src/main/kotlin/convention.mpp-loved-composeui.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.mpp-loved-composeui.gradle.kts
@@ -15,15 +15,12 @@ kotlin {
     // `./gradlew apiDump` after an intentional public-API change.
     @OptIn(ExperimentalAbiValidation::class)
     abiValidation {
-        enabled.set(true)
-        // CI only builds every native target on the main host (macOS); ubuntu/windows
-        // build a subset, so without this their klib dump would drop the unbuilt
-        // targets and `checkKotlinAbi` would fail on a spurious `Targets:` header diff.
-        // Infer the missing targets from the committed reference so the check is
-        // host-independent.
-        klib {
-            keepUnsupportedTargets.set(true)
-        }
+        // The klib ABI dump covers every native target, but CI only builds them all on
+        // the main host (macOS, per convention.control); ubuntu/windows build a subset,
+        // so their dump drops apple/mingw and checkKotlinAbi fails on a spurious
+        // `Targets:` header diff. Validate ABI only where the full target set exists
+        // (locally, or the main host on CI).
+        enabled.set(!CI || isMainHost)
     }
 
     @OptIn(ExperimentalKotlinGradlePluginApi::class)

--- a/build-conventions/src/main/kotlin/convention.mpp-loved-composeui.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.mpp-loved-composeui.gradle.kts
@@ -34,11 +34,12 @@ kotlin {
 
     js {
         useCommonJs()
-        // Default Karma launcher is ChromiumHeadless, which isn't installed on the
-        // Windows runner and can't start its sandbox on Ubuntu 24.04 (AppArmor blocks
-        // unprivileged user namespaces). Chrome ships on every GitHub runner, and
-        // --no-sandbox clears the Ubuntu restriction.
-        browser { testTask { useKarma { useChromeHeadlessNoSandbox() } } }
+        // Karma's default ChromiumHeadless launcher isn't on the Windows runner and
+        // can't start its sandbox on Ubuntu 24.04. The shared `karma.config.d` rewrites
+        // the browser list to a single Chrome-headless `--no-sandbox` launcher (see
+        // that file); the DSL's `useChromeHeadlessNoSandbox()` only appends and would
+        // leave the failing ChromiumHeadless in the list.
+        browser { testTask { useKarma { useConfigDirectory(rootDir.resolve("karma.config.d")) } } }
         nodejs()
     }
     @OptIn(ExperimentalWasmDsl::class)

--- a/build-conventions/src/main/kotlin/convention.mpp-loved.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.mpp-loved.gradle.kts
@@ -15,15 +15,12 @@ kotlin {
     // `./gradlew apiDump` after an intentional public-API change.
     @OptIn(ExperimentalAbiValidation::class)
     abiValidation {
-        enabled.set(true)
-        // CI only builds every native target on the main host (macOS); ubuntu/windows
-        // build a subset, so without this their klib dump would drop the unbuilt
-        // targets and `checkKotlinAbi` would fail on a spurious `Targets:` header diff.
-        // Infer the missing targets from the committed reference so the check is
-        // host-independent.
-        klib {
-            keepUnsupportedTargets.set(true)
-        }
+        // The klib ABI dump covers every native target, but CI only builds them all on
+        // the main host (macOS, per convention.control); ubuntu/windows build a subset,
+        // so their dump drops apple/mingw and checkKotlinAbi fails on a spurious
+        // `Targets:` header diff. Validate ABI only where the full target set exists
+        // (locally, or the main host on CI).
+        enabled.set(!CI || isMainHost)
     }
 
     @OptIn(ExperimentalKotlinGradlePluginApi::class)

--- a/build-conventions/src/main/kotlin/convention.mpp-loved.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.mpp-loved.gradle.kts
@@ -34,11 +34,12 @@ kotlin {
 
     js {
         useCommonJs()
-        // Default Karma launcher is ChromiumHeadless, which isn't installed on the
-        // Windows runner and can't start its sandbox on Ubuntu 24.04 (AppArmor blocks
-        // unprivileged user namespaces). Chrome ships on every GitHub runner, and
-        // --no-sandbox clears the Ubuntu restriction.
-        browser { testTask { useKarma { useChromeHeadlessNoSandbox() } } }
+        // Karma's default ChromiumHeadless launcher isn't on the Windows runner and
+        // can't start its sandbox on Ubuntu 24.04. The shared `karma.config.d` rewrites
+        // the browser list to a single Chrome-headless `--no-sandbox` launcher (see
+        // that file); the DSL's `useChromeHeadlessNoSandbox()` only appends and would
+        // leave the failing ChromiumHeadless in the list.
+        browser { testTask { useKarma { useConfigDirectory(rootDir.resolve("karma.config.d")) } } }
         nodejs()
     }
     @OptIn(ExperimentalWasmDsl::class)

--- a/karma.config.d/chrome-headless-no-sandbox.js
+++ b/karma.config.d/chrome-headless-no-sandbox.js
@@ -1,0 +1,21 @@
+// Force a single Karma browser for every Kotlin/JS module.
+//
+// The Kotlin Gradle plugin's default launcher is `ChromiumHeadless`, which the
+// `useKarma { useChromeHeadlessNoSandbox() }` DSL only *appends* to — leaving the
+// browser list as `[ChromiumHeadless, ChromeHeadlessNoSandbox]`. Karma launches
+// every listed browser, and `ChromiumHeadless` fails on CI (not installed on the
+// Windows runner; no usable sandbox on Ubuntu 24.04), failing the whole test task.
+//
+// This file is appended after the generated karma config, so `config.set` here
+// overwrites the browser list with exactly one launcher: Chrome headless with
+// `--no-sandbox` (Chrome ships on every GitHub runner; the flag clears the
+// Ubuntu 24.04 AppArmor restriction).
+config.set({
+    browsers: ['ChromeHeadlessNoSandbox'],
+    customLaunchers: {
+        ChromeHeadlessNoSandbox: {
+            base: 'ChromeHeadless',
+            flags: ['--no-sandbox'],
+        },
+    },
+});


### PR DESCRIPTION
Two pre-existing failures that kept the `check` matrix red on ubuntu/windows and blocked publishing 1.0.0-alpha01. They were stacked — the first masked the second.

## 1. klib ABI check is host-sensitive
`:redux-kotlin:checkKotlinAbi` failed on ubuntu/windows with only a `Targets:` header diff: CI builds every native target only on the main host (macOS, per `convention.control`); other hosts build a subset and mismatch the committed all-targets reference. (`keepUnsupportedTargets` from #378 did not fix it.)

Fix: `abiValidation { enabled.set(!CI || isMainHost) }` — validate ABI locally and on the macOS lane; skip it on reduced-target lanes.

## 2. jsBrowserTest launches two browsers
`useChromeHeadlessNoSandbox()` (from #377) only *appends* to Karma's default `ChromiumHeadless`, leaving `browsers: [ChromiumHeadless, ChromeHeadlessNoSandbox]`. Karma launches both; ChromiumHeadless fails (absent on Windows, no sandbox on Ubuntu 24.04). Masked until the ABI check stopped failing first.

Fix: point `useKarma` at a shared `karma.config.d` whose `config.set` overwrites the browser list to a single Chrome-headless `--no-sandbox` launcher.

## Verification
build-conventions compiles; `:redux-kotlin:checkKotlinAbi` and `:redux-kotlin:jsBrowserTest` both pass locally (Mac launches Chrome --no-sandbox). CI dispatch confirms ubuntu/windows/macos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)