### PR TITLE
fix(build): no-sandbox Karma browser for all js/wasm browser tests

### DIFF
--- a/build-conventions/src/main/kotlin/convention.mpp-loved-composeui.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.mpp-loved-composeui.gradle.kts
@@ -44,7 +44,10 @@ kotlin {
     }
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
-        browser()
+        // Same Karma browser fix as the js target: force the single Chrome-headless
+        // --no-sandbox launcher via the shared karma.config.d, else wasmJsBrowserTest
+        // launches the default ChromiumHeadless and fails on CI.
+        browser { testTask { useKarma { useConfigDirectory(rootDir.resolve("karma.config.d")) } } }
         nodejs()
     }
     jvm {

--- a/build-conventions/src/main/kotlin/convention.mpp-loved.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.mpp-loved.gradle.kts
@@ -44,7 +44,10 @@ kotlin {
     }
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
-        browser()
+        // Same Karma browser fix as the js target: force the single Chrome-headless
+        // --no-sandbox launcher via the shared karma.config.d, else wasmJsBrowserTest
+        // launches the default ChromiumHeadless and fails on CI.
+        browser { testTask { useKarma { useConfigDirectory(rootDir.resolve("karma.config.d")) } } }
         nodejs()
     }
     jvm {

--- a/examples/counter/common/build.gradle.kts
+++ b/examples/counter/common/build.gradle.kts
@@ -7,7 +7,10 @@ kotlin {
     jvm()
     js {
         useCommonJs()
-        browser()
+        // Force the single Chrome-headless --no-sandbox Karma launcher (shared
+        // karma.config.d) so jsBrowserTest works on CI; the default ChromiumHeadless
+        // isn't on the Windows runner and can't sandbox on Ubuntu 24.04.
+        browser { testTask { useKarma { useConfigDirectory(rootDir.resolve("karma.config.d")) } } }
         binaries.executable()
     }
 

--- a/examples/taskflow/composeApp/build.gradle.kts
+++ b/examples/taskflow/composeApp/build.gradle.kts
@@ -27,7 +27,10 @@ kotlin {
     jvm()
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
-        browser()
+        // Force the single Chrome-headless --no-sandbox Karma launcher (shared
+        // karma.config.d) so wasmJsBrowserTest works on CI; the default
+        // ChromiumHeadless isn't on the Windows runner and can't sandbox on Ubuntu 24.04.
+        browser { testTask { useKarma { useConfigDirectory(rootDir.resolve("karma.config.d")) } } }
         binaries.executable()
     }
     // The AGP-9 KMP-library `android {}` accessor is only generated when the plugin sits in plugins{}.

--- a/examples/todos/common/build.gradle.kts
+++ b/examples/todos/common/build.gradle.kts
@@ -8,7 +8,10 @@ kotlin {
     iosSimulatorArm64()
     js {
         useCommonJs()
-        browser()
+        // Force the single Chrome-headless --no-sandbox Karma launcher (shared
+        // karma.config.d) so jsBrowserTest works on CI; the default ChromiumHeadless
+        // isn't on the Windows runner and can't sandbox on Ubuntu 24.04.
+        browser { testTask { useKarma { useConfigDirectory(rootDir.resolve("karma.config.d")) } } }
         binaries.executable()
     }
     jvm()


### PR DESCRIPTION
## Problem
With the ABI check gated, the remaining `check`-matrix failures on ubuntu/windows were all Karma browser tests still launching the default `ChromiumHeadless` (absent on Windows; no sandbox on Ubuntu 24.04):
- library `wasmJs { browser() }` (the `js {}` fix in #379 didn't cover wasm)
- example apps' own `browser()` blocks: counter (js), todos (js), taskflow (wasmJs)

Each surfaced one-at-a-time because Gradle stops at the first failure.

## Fix
Point every js/wasm browser test task at the shared `karma.config.d` (single Chrome-headless `--no-sandbox` launcher): both KMP conventions' wasmJs target + the three example modules.

## Verification
Full-project local sweep `./gradlew jsBrowserTest wasmJsBrowserTest --continue` → **BUILD SUCCESSFUL** (every module, Mac Chrome). CI dispatch confirms ubuntu/windows/macos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)