### PR TITLE
fix(build): unblock the release path (bundle-compose klibs + Windows CliTest)

### DIFF
--- a/redux-kotlin-bundle-compose/src/commonMain/kotlin/org/reduxkotlin/bundle/compose/BundleCompose.kt
+++ b/redux-kotlin-bundle-compose/src/commonMain/kotlin/org/reduxkotlin/bundle/compose/BundleCompose.kt
@@ -1,0 +1,12 @@
+package org.reduxkotlin.bundle.compose
+
+// `redux-kotlin-bundle-compose` is a dependency-only aggregator: its public
+// surface comes entirely from the `api(...)` exports declared in build.gradle.kts
+// (the bundle + the Compose bindings), not from code in this module.
+//
+// Kotlin/Native still needs at least one source file per target to emit a klib —
+// with an empty `commonMain` the `compileKotlin<Native>` tasks are NO-SOURCE, no
+// klib lands in `build/libs/`, and `generateMetadataFileFor<Target>Publication`
+// fails with FileNotFoundException. This internal marker gives every target a
+// real compilation so publication succeeds.
+internal const val BUNDLE_COMPOSE_MODULE: String = "redux-kotlin-bundle-compose"

--- a/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/CliTest.kt
+++ b/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/CliTest.kt
@@ -22,20 +22,25 @@ internal class CliTest {
 
     @Test fun single_render_writes_a_png() {
         val out = File(tmp, "counter.png")
-        val r = snapshotCommand(demoSnapshots).test("--scene counter --preset n3 --out ${out.path}")
+        // list-argv overload: the string overload shell-tokenizes and eats the
+        // backslashes in a Windows --out path, mangling it so no PNG is written.
+        val r = snapshotCommand(demoSnapshots)
+            .test(listOf("--scene", "counter", "--preset", "n3", "--out", out.path))
         assertEquals(0, r.statusCode, r.output)
         assertTrue(out.isFile && out.length() > 0)
     }
 
     @Test fun unknown_scene_exits_2() {
-        val r = snapshotCommand(demoSnapshots).test("--scene nope --preset n3 --out ${File(tmp, "x.png").path}")
+        val r = snapshotCommand(demoSnapshots)
+            .test(listOf("--scene", "nope", "--preset", "n3", "--out", File(tmp, "x.png").path))
         assertEquals(2, r.statusCode)
     }
 
     @Test fun both_inputs_exits_2() {
-        val r = snapshotCommand(
-            demoSnapshots,
-        ).test("--scene counter --preset n3 --state-json {} --out ${File(tmp, "y.png").path}")
+        val r = snapshotCommand(demoSnapshots)
+            .test(
+                listOf("--scene", "counter", "--preset", "n3", "--state-json", "{}", "--out", File(tmp, "y.png").path),
+            )
         assertEquals(2, r.statusCode)
     }
 


### PR DESCRIPTION
Two fixes that together make the full `check` matrix + local publish green — the last items in the CI-hardening effort.

## 1. bundle-compose emits no native klibs (release blocker)
`redux-kotlin-bundle-compose` is a dependency-only aggregator with an empty `commonMain`, so `compileKotlin<Native>` was NO-SOURCE and produced no klib; `generateMetadataFileFor<Target>Publication` then failed (FileNotFoundException) for all 5 native targets — on macOS too, so it would block the real release. Fix: add an internal marker constant to `commonMain`.

## 2. Windows CliTest path mangling
`redux-kotlin-snapshot` CliTest passed `--out` paths via clikt's string `.test()` overload, which shell-tokenizes and strips backslashes in Windows paths, so no PNG was written → `AssertionError at CliTest.kt:27` on the windows lane. Fix: use the list-argv overload (as the other tests already do).

## Verification
- Full `./gradlew publishToLocal --continue` → BUILD SUCCESSFUL (all modules/targets).
- ubuntu check already green on the prior run; this adds the windows + macOS fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)