### PR TITLE
build(bundle-compose): refresh klib ABI dump after marker source

### DIFF
--- a/redux-kotlin-bundle-compose/api/redux-kotlin-bundle-compose.klib.api
+++ b/redux-kotlin-bundle-compose/api/redux-kotlin-bundle-compose.klib.api
@@ -1,0 +1,8 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, js, linuxX64, macosArm64, mingwX64, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <org.reduxkotlin:redux-kotlin-bundle-compose>


### PR DESCRIPTION
Follow-up to #382. The commonMain marker made bundle-compose emit native klibs, so it now has a header-only klib ABI dump where the committed reference was empty → `:redux-kotlin-bundle-compose:checkKotlinAbi` failed on the **macOS** check lane (the ABI check is gated to the main host, so ubuntu/windows passed without it). Regenerated the dump via `updateKotlinAbi`. Verified: `checkKotlinAbi` BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)