### PR TITLE
build: auto-release Maven Central, drop GitHub Packages, fix Dokka deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,13 +94,12 @@ jobs:
       fail-fast: false
       matrix:
         repository:
-          - name: GitHub Packages
-            tasks: publishAllPublicationsToGitHubRepository
-            enabled: ${{ github.event.inputs.skipGitHub != 'y' }}
+          # GitHub Packages is intentionally not published: it rejects the Compose
+          # Android AAR publications with HTTP 422, and Maven Central is the canonical
+          # distribution channel. Re-add a matrix entry here if that changes.
           - name: Maven Central
-            # Uploads all modules to the Central Publisher Portal and leaves the
-            # deployment for a manual Drop/Publish in the Portal UI. Swap for
-            # `publishAndReleaseToMavenCentral` to auto-release once the flow is trusted.
+            # Uploads all modules to the Central Publisher Portal and auto-releases
+            # them (automaticRelease = true in convention.publishing).
             tasks: publishToMavenCentral
             enabled: ${{ github.event.inputs.skipMavenCentral != 'y' }}
     steps:
@@ -138,7 +137,13 @@ jobs:
         run: |
           REPO_NAME=${{ github.repository }}
           REPO_NAME=${REPO_NAME#${{ github.repository_owner }}/}
-          cp -avr build/dokka/html/ public;
+          # The `dokka` artifact uploads `**/build/dokka`, and download-artifact strips
+          # the common ancestor, so the HTML lands at `html/` rather than the old
+          # `build/dokka/html/`. Locate the generated html dir (the one with index.html)
+          # rather than hardcoding a path.
+          DOKKA_HTML="$(find . -type d -name html -exec test -e '{}/index.html' ';' -print | head -1)"
+          test -n "$DOKKA_HTML" || { echo "no Dokka html/ with index.html found"; find . -type d -name html; exit 1; }
+          cp -avr "${DOKKA_HTML}/" public;
           find public -type f -regex '.*\.\(htm\|html\|txt\|text\|js\|css\)$' -exec gzip -f -k {} \;
           echo "/${REPO_NAME} /${REPO_NAME}/${REPO_NAME}/index.html 301" > public/_redirects;
           echo "/${REPO_NAME}/index.html /${REPO_NAME}/${REPO_NAME}/index.html 301" >> public/_redirects;

--- a/build-conventions/src/main/kotlin/convention.publishing.gradle.kts
+++ b/build-conventions/src/main/kotlin/convention.publishing.gradle.kts
@@ -32,10 +32,10 @@ mavenPublishing {
     )
     coordinates(project.group.toString(), project.name, project.version.toString())
 
-    // No-arg targets the Central Publisher Portal (the OSSRH replacement). Release is
-    // left manual (drop/publish from the Portal UI); pass automaticRelease = true to
-    // fully automate once the flow is trusted.
-    publishToMavenCentral()
+    // Targets the Central Publisher Portal (the OSSRH replacement). automaticRelease
+    // = true publishes the deployment automatically once validation passes, instead of
+    // leaving it staged for a manual Drop/Publish in the Portal UI.
+    publishToMavenCentral(automaticRelease = true)
 
     // Only sign when a key is configured. Locally (publishToLocal / publishToMavenLocal)
     // no key is present and Maven Central doesn't require signatures for local repos, so


### PR DESCRIPTION
Finalizes the release pipeline after the first successful 1.0.0-alpha01 publish.

1. **Auto-release to Maven Central** — `publishToMavenCentral(automaticRelease = true)`, so the Central Portal deployment publishes automatically once validation passes (no manual Drop/Publish click).
2. **Drop GitHub Packages** — its publish 422'd on the Compose Android AAR (`redux-kotlin-compose-android-…aar`). Maven Central is the canonical channel; removed the matrix entry.
3. **Fix release-Dokka** — `cp build/dokka/html/` failed (`No such file or directory`); the dokka artifact extracts `html/` at the root, so locate the html dir containing index.html instead.

Verified: build-conventions compiles with the new signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)