### PR TITLE
ci(cli): rk release workflow + brew/scoop install docs (Phase 2 Tasks 4+6)

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,67 @@
+name: rk CLI Release
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build rk (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, macos-13, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@v6
+      - name: Build + archive the app-image
+        # -Pversion=<tag> so the archive filename uses the release version (matches JReleaser).
+        run: ./gradlew :redux-kotlin-cli-dist:packageRkArchive -Pversion=${{ github.event.release.tag_name || github.ref_name }} --stacktrace
+      - uses: actions/upload-artifact@v7
+        with:
+          name: rk-dist-${{ matrix.os }}
+          path: redux-kotlin-cli-dist/build/distributions/rk-*.*
+
+  publish:
+    name: Publish (JReleaser)
+    needs: build
+    runs-on: ubuntu-latest
+    # contents: write so JReleaser's default GITHUB_TOKEN can update the release + upload assets
+    # on the main repo. (tap/bucket pushes use the GH_PUBLISH_TOKEN PAT, not this token.)
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: rk-dist-*
+          merge-multiple: true
+          path: redux-kotlin-cli-dist/build/distributions
+      - uses: gradle/actions/setup-gradle@v6
+      - name: JReleaser full-release
+        # -Pversion so the Gradle-interpolated artifact paths match the downloaded archive names.
+        run: ./gradlew :redux-kotlin-cli-dist:jreleaserFullRelease -Pversion=${{ github.event.release.tag_name || github.ref_name }} --stacktrace
+        env:
+          JRELEASER_PROJECT_VERSION: ${{ github.event.release.tag_name || github.ref_name }}
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_HOMEBREW_GITHUB_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
+          JRELEASER_SCOOP_GITHUB_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: jreleaser-logs
+          path: |
+            redux-kotlin-cli-dist/build/jreleaser/trace.log
+            redux-kotlin-cli-dist/build/jreleaser/output.properties

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ website/.docusaurus/
 .vercel
 .env*.local
 .superpowers/
+.infisical.json

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ dependencies {
 | Routing | `redux-kotlin-routing` (routed `(model, action)` reducer DSL), `redux-kotlin-routing-codegen` (KSP `@Reduce` processor — in-repo, not yet on Maven Central) |
 | Bundles | `redux-kotlin-bundle`, `redux-kotlin-bundle-compose`, `redux-kotlin-bom` (Maven BOM) |
 | DevTools (experimental) | `redux-kotlin-devtools-core`, `-bridge`, `-remote`, `-inapp`, `-inapp-noop`, `-ui` — aligned by the BOM but exempt from semver until the surface stabilizes |
-| Dev tools (in-repo, unpublished) | `redux-kotlin-cli` — the unified `rk` binary (`rk devtools` + `rk snapshot`); `redux-kotlin-devtools-standalone` |
+| Dev tools | `redux-kotlin-cli` — the unified `rk` binary (`rk devtools` + `rk snapshot`); `redux-kotlin-devtools-standalone` (in-repo). Install `rk` via Homebrew/Scoop (bundled JRE, no Java needed) or build from source — see the [CLI README](redux-kotlin-cli/README.md). |
 
 ## Core API
 

--- a/docs/agent/AGENTS-external.md
+++ b/docs/agent/AGENTS-external.md
@@ -78,14 +78,26 @@ nav), and `ui` (theme, locals, widgets).
 ## DevTools CLI — `rk`
 
 The unified `rk` binary bundles `rk devtools` (bridge receiver + capture queries) and
-`rk snapshot` (headless Compose renderer). Requires **JDK 17+**.
+`rk snapshot` (headless Compose renderer).
+
+**Install — Homebrew/Scoop (bundled JRE, no Java required):**
+
+```bash
+# macOS / Linux
+brew install reduxkotlin/tap/rk
+
+# Windows
+scoop bucket add reduxkotlin https://github.com/reduxkotlin/scoop-bucket
+scoop install rk
+```
+
+**From source (any OS, needs JDK 17+):**
 
 ```bash
 git clone https://github.com/reduxkotlin/redux-kotlin.git
 cd redux-kotlin
 ./gradlew :redux-kotlin-cli:installDist
-# binary:
-# redux-kotlin-cli/build/install/rk/bin/rk
+# binary: redux-kotlin-cli/build/install/rk/bin/rk
 ```
 
 Add `redux-kotlin-cli/build/install/rk/bin` to your `PATH`, then use:

--- a/docs/superpowers/plans/2026-06-19-unified-rk-cli-phase2.md
+++ b/docs/superpowers/plans/2026-06-19-unified-rk-cli-phase2.md
@@ -382,6 +382,10 @@ jobs:
     name: Publish (JReleaser)
     needs: build
     runs-on: ubuntu-latest
+    # contents: write so JReleaser's default GITHUB_TOKEN can update the release + upload assets
+    # on the main repo. (tap/bucket pushes use the GH_PUBLISH_TOKEN PAT, not this token.)
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/docs/superpowers/plans/2026-06-19-unified-rk-cli-phase2.md
+++ b/docs/superpowers/plans/2026-06-19-unified-rk-cli-phase2.md
@@ -20,21 +20,20 @@
 - Windows CLI needs `windows { console = true }` or stdout is invisible from a terminal.
 - App-image carries host-specific Skiko → **must build on each target OS** (no cross-compile).
 - JReleaser `distributionType = JLINK` (bundled JRE). Platform strings (underscore in arch): `osx-aarch_64`, `osx-x86_64`, `linux-x86_64`, `windows-x86_64`.
-- Tokens: `JRELEASER_GITHUB_TOKEN` (main repo release); tap/bucket need a separate PAT in `JRELEASER_HOMEBREW_GITHUB_TOKEN` / `JRELEASER_SCOOP_GITHUB_TOKEN` (the Actions default `GITHUB_TOKEN` cannot push to them).
+- Tokens: `JRELEASER_GITHUB_TOKEN` = the workflow default `GITHUB_TOKEN` (main-repo release; needs `permissions: contents: write`). The tap/bucket pushes use a fine-grained PAT mirrored from Infisical (`GITHUB_CLI_PUBLISH_TOKEN`) into the GH Actions secret **`GH_PUBLISH_TOKEN`** (GitHub forbids Actions-secret names starting with `GITHUB_`), wired to BOTH `JRELEASER_HOMEBREW_GITHUB_TOKEN` and `JRELEASER_SCOOP_GITHUB_TOKEN`.
 - Pre-commit hook runs `detektAll --auto-correct`; never `--no-verify`.
 - **Testability note:** Tasks 1–2 are fully verifiable on the dev/CI host now. Task 3 is verifiable via `jreleaserConfig` (dry run, no publish). Tasks 4–6 (actual publish, brew/scoop) can only be end-to-end validated on a real tagged release AFTER Task 0's prerequisites exist — those tasks carry explicit dry-run + first-release validation steps, not fabricated "it works" claims.
 
 ---
 
-### Task 0: Maintainer prerequisites (gating — not code)
+### Task 0: Maintainer prerequisites (gating — not code) — ✅ DONE (2026-06-19)
 
-This task is a checklist the repo owner completes; no implementer subagent. Phase 2 publish (Tasks 4–6) cannot run end-to-end until these exist. Tasks 1–3 do NOT depend on them.
+Repo-owner checklist; no implementer subagent. Phase 2 publish (Tasks 4–6) cannot run end-to-end until these exist.
 
-- [ ] Create repo `reduxkotlin/homebrew-tap` (empty, public).
-- [ ] Create a Scoop bucket repo, e.g. `reduxkotlin/scoop-bucket` (empty, public).
-- [ ] Create a PAT (classic, or fine-grained with **Contents: read+write** on both repos above).
-- [ ] Add it as repo secrets on `reduxkotlin/redux-kotlin`: `TAP_PAT` and `BUCKET_PAT` (may be the same PAT).
-- [ ] Confirm the exact bucket repo name chosen and update `name = …` in the Task 3 `scoop.repository` block if it differs from `scoop-bucket`.
+- [x] `reduxkotlin/homebrew-tap` created (public).
+- [x] `reduxkotlin/scoop-bucket` created (public) — name matches the Task 3 `scoop.repository.name`.
+- [x] Fine-grained PAT with **Contents: read+write** on both repos, stored in Infisical as `GITHUB_CLI_PUBLISH_TOKEN`.
+- [x] Mirrored into the GH Actions secret **`GH_PUBLISH_TOKEN`** on `reduxkotlin/redux-kotlin` (one secret → both `JRELEASER_HOMEBREW_GITHUB_TOKEN` + `JRELEASER_SCOOP_GITHUB_TOKEN`).
 
 ---
 
@@ -403,8 +402,8 @@ jobs:
         env:
           JRELEASER_PROJECT_VERSION: ${{ github.event.release.tag_name || github.ref_name }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JRELEASER_HOMEBREW_GITHUB_TOKEN: ${{ secrets.TAP_PAT }}
-          JRELEASER_SCOOP_GITHUB_TOKEN: ${{ secrets.BUCKET_PAT }}
+          JRELEASER_HOMEBREW_GITHUB_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
+          JRELEASER_SCOOP_GITHUB_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/redux-kotlin-cli/README.md
+++ b/redux-kotlin-cli/README.md
@@ -8,15 +8,30 @@
   diffing. (Rendering *your own* app's screens stays a library use — depend on
   `redux-kotlin-snapshot` and call `yourRegistry.runCli(args)`.)
 
-**Unpublished today** — build from this repo (needs **JDK 17+**):
+## Installation
 
+### Package managers (recommended — no Java required)
+
+Homebrew and Scoop builds bundle a JRE; no local JDK needed.
+
+```sh
+# macOS / Linux
+brew install reduxkotlin/tap/rk
+
+# Windows
+scoop bucket add reduxkotlin https://github.com/reduxkotlin/scoop-bucket
+scoop install rk
 ```
+
+Available once the first tagged release is published.
+
+### From source (any OS, needs JDK 17+)
+
+```sh
 ./gradlew :redux-kotlin-cli:installDist
 # binary: redux-kotlin-cli/build/install/rk/bin/rk
 rk --help
 rk --version
 ```
 
-Add that `bin/` directory to your `PATH`, or symlink the binary. Phase 2 will
-publish self-contained per-OS builds via Homebrew/Scoop (`brew install
-reduxkotlin/tap/rk`) with a bundled JRE — no Java required.
+Add `redux-kotlin-cli/build/install/rk/bin` to your `PATH`, or symlink the binary.

--- a/website/docs/advanced/DevTools.md
+++ b/website/docs/advanced/DevTools.md
@@ -242,16 +242,30 @@ iOS/native/JS, register a `KotlinxValueSerializer(json)` as
 
 `redux-kotlin-cli` bundles `rk devtools` (bridge receiver + capture queries) and
 `rk snapshot` (headless renderer) in a single terminal tool — ideal for agents,
-scripts, and headless debugging. It is unpublished; install it from the
-repository:
+scripts, and headless debugging.
 
+### Install
+
+Homebrew and Scoop builds bundle a JRE — no Java required:
+
+```sh
+# macOS / Linux
+brew install reduxkotlin/tap/rk
+
+# Windows
+scoop bucket add reduxkotlin https://github.com/reduxkotlin/scoop-bucket
+scoop install rk
 ```
+
+Or build from source (needs JDK 17+):
+
+```sh
 ./gradlew :redux-kotlin-cli:installDist
 # binary lands at:
-redux-kotlin-cli/build/install/rk/bin/rk
+# redux-kotlin-cli/build/install/rk/bin/rk
 ```
 
-(Add that `bin/` directory to your `PATH`, or symlink the binary.)
+Add that `bin/` directory to your `PATH`, or symlink the binary.
 
 ### Subcommands
 

--- a/website/docs/ai-agents/BuildingWithAI.md
+++ b/website/docs/ai-agents/BuildingWithAI.md
@@ -91,14 +91,26 @@ nav), and `ui` (theme, locals, widgets).
 ## DevTools CLI — `rk`
 
 The unified `rk` binary bundles `rk devtools` (bridge receiver + capture queries) and
-`rk snapshot` (headless Compose renderer). Requires **JDK 17+**.
+`rk snapshot` (headless Compose renderer).
+
+**Install — Homebrew/Scoop (bundled JRE, no Java required):**
+
+```bash
+# macOS / Linux
+brew install reduxkotlin/tap/rk
+
+# Windows
+scoop bucket add reduxkotlin https://github.com/reduxkotlin/scoop-bucket
+scoop install rk
+```
+
+**From source (any OS, needs JDK 17+):**
 
 ```bash
 git clone https://github.com/reduxkotlin/redux-kotlin.git
 cd redux-kotlin
 ./gradlew :redux-kotlin-cli:installDist
-# binary:
-# redux-kotlin-cli/build/install/rk/bin/rk
+# binary: redux-kotlin-cli/build/install/rk/bin/rk
 ```
 
 Add `redux-kotlin-cli/build/install/rk/bin` to your `PATH`, then use:


### PR DESCRIPTION
Follow-up to #388 (which squash-merged Phase 1 + Phase 2 Tasks 1–3). These are the remaining Phase 2 pieces that landed after that merge point:

- **`.github/workflows/cli-release.yml`** — on a GitHub Release, builds the bundled-JRE `rk` app-image on a per-OS matrix (macOS arm64/x64, linux, windows), then one job runs JReleaser `fullRelease` → attaches archives + pushes a Homebrew formula (`reduxkotlin/homebrew-tap`) and Scoop manifest (`reduxkotlin/scoop-bucket`). `permissions: contents: write`; tap/bucket auth via `GH_PUBLISH_TOKEN`; `-Pversion=<tag>` on both gradle steps.
- **Install docs** — `brew install reduxkotlin/tap/rk` / `scoop install rk` as the primary install (bundled JRE, no Java needed), from-source as fallback. Closes #367.
- Plan updates: Task 0 marked done (token mirrored from Infisical → `GH_PUBLISH_TOKEN`), `permissions:` added, `.infisical.json` gitignored.

**Must merge before cutting a release** — without `cli-release.yml` on master, a release tag won't publish the CLI.

Prereqs (Task 0) are already done: `homebrew-tap` + `scoop-bucket` repos exist, `GH_PUBLISH_TOKEN` secret is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)