### PR TITLE
fix(cli-release): Windows MSI version + workflow_dispatch version input

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [created]
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build/publish the CLI under (e.g. 1.0.0-alpha02). Use to (re)publish the CLI for an existing release without re-running the Maven Central release."
+        required: true
 
 jobs:
   build:
@@ -22,7 +26,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
       - name: Build + archive the app-image
         # -Pversion=<tag> so the archive filename uses the release version (matches JReleaser).
-        run: ./gradlew :redux-kotlin-cli-dist:packageRkArchive -Pversion=${{ github.event.release.tag_name || github.ref_name }} --stacktrace
+        run: ./gradlew :redux-kotlin-cli-dist:packageRkArchive -Pversion=${{ github.event.inputs.version || github.event.release.tag_name || github.ref_name }} --stacktrace
       - uses: actions/upload-artifact@v7
         with:
           name: rk-dist-${{ matrix.os }}
@@ -52,9 +56,9 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
       - name: JReleaser full-release
         # -Pversion so the Gradle-interpolated artifact paths match the downloaded archive names.
-        run: ./gradlew :redux-kotlin-cli-dist:jreleaserFullRelease -Pversion=${{ github.event.release.tag_name || github.ref_name }} --stacktrace
+        run: ./gradlew :redux-kotlin-cli-dist:jreleaserFullRelease -Pversion=${{ github.event.inputs.version || github.event.release.tag_name || github.ref_name }} --stacktrace
         env:
-          JRELEASER_PROJECT_VERSION: ${{ github.event.release.tag_name || github.ref_name }}
+          JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.version || github.event.release.tag_name || github.ref_name }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_HOMEBREW_GITHUB_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
           JRELEASER_SCOOP_GITHUB_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}

--- a/redux-kotlin-devtools-standalone/build.gradle.kts
+++ b/redux-kotlin-devtools-standalone/build.gradle.kts
@@ -58,8 +58,14 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "ReduxKotlinDevTools"
-            // Compose packaging wants plain MAJOR.MINOR.PATCH — strip any -SNAPSHOT suffix.
+            // Compose validates every declared targetFormat's version eagerly at configuration on
+            // its host OS (e.g. MSI on Windows requires a strict integer MAJOR.MINOR.BUILD). Strip
+            // any -SNAPSHOT/-alpha qualifier AND normalize to exactly three integer components so an
+            // incomplete/odd version (e.g. "1") can't produce an invalid MSI version on Windows.
             val distVersion = project.version.toString().substringBefore("-")
+                .split(".").mapNotNull { it.toIntOrNull() }
+                .let { p -> listOf(p.getOrElse(0) { 1 }, p.getOrElse(1) { 0 }, p.getOrElse(2) { 0 }) }
+                .joinToString(".")
             packageVersion = distVersion
             macOS {
                 // Dmg additionally requires MAJOR > 0; lift 0.x.y until the project reaches 1.0.


### PR DESCRIPTION
The first `rk CLI Release` run (for `1.0.0-alpha02`) **failed on the Windows build** while configuring `:redux-kotlin-devtools-standalone` (a transitive dependency via `rk devtools serve --ui`):

```
A problem occurred configuring project ':redux-kotlin-devtools-standalone'.
> * Illegal version for 'Msi': '1' is not a valid version.
```

Compose validates **every** declared `targetFormat` eagerly at configuration on its host OS. The standalone declares `Msi`, and on Windows its `packageVersion` resolved to `1` (invalid for MSI's strict `MAJOR.MINOR.BUILD`). macOS + Linux builds succeeded; only Windows. (The separate Maven Central release workflow was unaffected — `1.0.0-alpha02` published fine.)

**Fixes:**
1. Normalize `:redux-kotlin-devtools-standalone` `packageVersion` to exactly three integer components (`1` → `1.0.0`, `1.0.0` → `1.0.0`, `0.6.1` → `0.6.1`), so any odd/incomplete version can't produce an invalid MSI version.
2. Add a `version` input to `cli-release.yml`'s `workflow_dispatch` so the CLI can be (re)published for an existing release without re-triggering the Maven Central release — used to ship the CLI for `1.0.0-alpha02` once this merges.

After merge: dispatch `rk CLI Release` with `version=1.0.0-alpha02` to publish the CLI to brew/scoop (no Maven Central re-publish), then validate the Homebrew formula (Task 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)