### PR TITLE
fix(cli-release): shell: bash so Windows doesn't split -Pversion

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -25,6 +25,9 @@ jobs:
           java-version: 17
       - uses: gradle/actions/setup-gradle@v6
       - name: Build + archive the app-image
+        # shell: bash so the -Pversion=<x.y.z-...> arg parses identically on Windows (the default
+        # PowerShell splits it on the dots, turning the version into "1"). Matches ci.yml/check.yml.
+        shell: bash
         # -Pversion=<tag> so the archive filename uses the release version (matches JReleaser).
         run: ./gradlew :redux-kotlin-cli-dist:packageRkArchive -Pversion=${{ github.event.inputs.version || github.event.release.tag_name || github.ref_name }} --stacktrace
       - uses: actions/upload-artifact@v7
@@ -55,6 +58,7 @@ jobs:
           path: redux-kotlin-cli-dist/build/distributions
       - uses: gradle/actions/setup-gradle@v6
       - name: JReleaser full-release
+        shell: bash
         # -Pversion so the Gradle-interpolated artifact paths match the downloaded archive names.
         run: ./gradlew :redux-kotlin-cli-dist:jreleaserFullRelease -Pversion=${{ github.event.inputs.version || github.event.release.tag_name || github.ref_name }} --stacktrace
         env:


### PR DESCRIPTION
**Actual root cause of the Windows CLI-release failures.** The build step ran `./gradlew ... -Pversion=1.0.0-alpha02` with no `shell:`, so Windows used PowerShell, which split the argument into `-Pversion=1` + a phantom task `.0.0-alpha02`. So `project.version` became `1` — which is exactly what tripped the standalone MSI validation in the first run (`Illegal version for 'Msi': '1'`), and after #392 normalized that, the second run failed at task selection on `.0.0-alpha02`.

Fix: add `shell: bash` to both gradle steps (matches the repo's `ci.yml`/`check.yml` convention) so the `-Pversion` arg parses identically on every OS. With bash, `version` is correctly `1.0.0-alpha02` and the standalone never sees `1`.

(The #392 standalone version-normalization stays — it's good defensive code.)

After merge: re-dispatch `rk CLI Release` with `version=1.0.0-alpha02`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)