### PR TITLE
build(cli-release): drop Intel macOS for alpha02 (runner backlog)

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -15,7 +15,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-13, ubuntu-latest, windows-latest]
+        # macos-13 (Intel) dropped for alpha02 — Intel macOS runners were backlogged. Apple Silicon
+        # (macos-14 → osx-aarch_64) covers ~all Mac users; Intel-Mac users build from source for now.
+        os: [macos-14, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/redux-kotlin-cli-dist/build.gradle.kts
+++ b/redux-kotlin-cli-dist/build.gradle.kts
@@ -106,10 +106,8 @@ jreleaser {
                 setPath(gradleDistDir.resolve("rk-$gradleVersion-osx-aarch_64.zip").absolutePath)
                 platform.set("osx-aarch_64")
             }
-            artifact {
-                setPath(gradleDistDir.resolve("rk-$gradleVersion-osx-x86_64.zip").absolutePath)
-                platform.set("osx-x86_64")
-            }
+            // osx-x86_64 (Intel Mac) dropped for alpha02 — Intel macOS CI runners were backlogged.
+            // Re-add this artifact + macos-13 to the workflow matrix when capacity allows.
             artifact {
                 setPath(gradleDistDir.resolve("rk-$gradleVersion-linux-x86_64.tar.gz").absolutePath)
                 platform.set("linux-x86_64")


### PR DESCRIPTION
Intel macOS (`macos-13`) CI runners were heavily backlogged, stalling the `rk` CLI publish for 1.0.0-alpha02. Drop Intel Mac from this release — ship arm64-mac + linux + windows now (Apple Silicon covers ~all Mac users; Intel-Mac users build from source). Removes `macos-13` from the matrix + the `osx-x86_64` JReleaser artifact. Re-add when runner capacity recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)