### PR TITLE
fix(cli-release): custom Homebrew formula for jpackage .app layout

### DIFF
--- a/redux-kotlin-cli-dist/build.gradle.kts
+++ b/redux-kotlin-cli-dist/build.gradle.kts
@@ -96,6 +96,10 @@ jreleaser {
             repoOwner.set("reduxkotlin")
             name.set("redux-kotlin")
             overwrite.set(true)
+            // Reuse the existing release tag as-is (e.g. 1.0.0-alpha02). JReleaser's default
+            // tagName is `v{{projectVersion}}`, which would create a duplicate `v`-prefixed release.
+            tagName.set("{{projectVersion}}")
+            releaseName.set("{{tagName}}")
         }
     }
     distributions {

--- a/redux-kotlin-cli-dist/src/jreleaser/distributions/rk/brew/formula-multi.rb.tpl
+++ b/redux-kotlin-cli-dist/src/jreleaser/distributions/rk/brew/formula-multi.rb.tpl
@@ -1,0 +1,44 @@
+# {{jreleaserCreationStamp}}
+{{#brewRequireRelative}}
+require_relative "{{.}}"
+{{/brewRequireRelative}}
+
+class {{brewFormulaName}} < Formula
+  desc "{{projectDescription}}"
+  homepage "{{projectLinkHomepage}}"
+  version "{{projectVersion}}"
+  license "{{projectLicense}}"
+
+  {{brewMultiPlatform}}
+
+  {{#brewHasLivecheck}}
+  livecheck do
+    {{#brewLivecheck}}
+    {{.}}
+    {{/brewLivecheck}}
+  end
+  {{/brewHasLivecheck}}
+  {{#brewDependencies}}
+  depends_on {{.}}
+  {{/brewDependencies}}
+
+  # The archives are jpackage app-images with a top-level wrapper dir — macOS: `rk.app` (launcher at
+  # Contents/MacOS/rk), others: `rk/bin/rk` — not a flattened `bin/` layout. Symlink the launcher at
+  # its real path inside the bundle; jpackage launchers self-locate through the symlink and find
+  # their sibling bundled runtime. (The default JLINK formula assumes `#{libexec}/bin/rk`, which does
+  # not exist here.) post_install dylib re-signing is dropped: the .app is already signed by jpackage
+  # and its dylibs live inside the bundle, not in `#{libexec}/lib`.
+  def install
+    libexec.install Dir["*"]
+    if OS.mac?
+      bin.install_symlink "#{libexec}/rk.app/Contents/MacOS/rk" => "rk"
+    else
+      bin.install_symlink "#{libexec}/rk/bin/rk" => "rk"
+    end
+  end
+
+  test do
+    output = shell_output("#{bin}/rk --version")
+    assert_match "{{projectVersion}}", output
+  end
+end


### PR DESCRIPTION
First real `brew install` validation (Task 5) exposed two issues:

1. **Broken macOS install.** JReleaser's default JLINK formula symlinks `#{libexec}/bin/rk`, but our archives are jpackage app-images with a top-level wrapper dir (`rk.app/Contents/MacOS/rk` on macOS, `rk/bin/rk` on Linux) — no `#{libexec}/bin/rk`. So `brew install` produced a broken `rk`. Fix: a custom JReleaser `formula-multi.rb.tpl` that symlinks the launcher at its real path inside the bundle (jpackage launchers self-locate through the symlink), and drops the `post_install` dylib re-signing (the `.app` is already jpackage-signed; its dylibs are inside the bundle, not in `#{libexec}/lib`).
2. **Duplicate release.** JReleaser's default `v`-prefix tag created a separate `v1.0.0-alpha02` release. Set `release.github.tagName` to `{{projectVersion}}` so it reuses the canonical `1.0.0-alpha02` release. (The duplicate `v1.0.0-alpha02` release+tag were already deleted.)

After merge: re-dispatch `rk CLI Release` for `1.0.0-alpha02`, then `brew install reduxkotlin/tap/rk` is run locally to confirm `rk --version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)