### PR TITLE
fix(cli-release): brew formula path (Homebrew strips rk.app) + chmod launcher

### DIFF
--- a/redux-kotlin-cli-dist/src/jreleaser/distributions/rk/brew/formula-multi.rb.tpl
+++ b/redux-kotlin-cli-dist/src/jreleaser/distributions/rk/brew/formula-multi.rb.tpl
@@ -22,18 +22,20 @@ class {{brewFormulaName}} < Formula
   depends_on {{.}}
   {{/brewDependencies}}
 
-  # The archives are jpackage app-images with a top-level wrapper dir — macOS: `rk.app` (launcher at
-  # Contents/MacOS/rk), others: `rk/bin/rk` — not a flattened `bin/` layout. Symlink the launcher at
-  # its real path inside the bundle; jpackage launchers self-locate through the symlink and find
-  # their sibling bundled runtime. (The default JLINK formula assumes `#{libexec}/bin/rk`, which does
-  # not exist here.) post_install dylib re-signing is dropped: the .app is already signed by jpackage
-  # and its dylibs live inside the bundle, not in `#{libexec}/lib`.
+  # The archives are jpackage app-images with a single top-level wrapper dir, which Homebrew strips
+  # on unpack: macOS `rk.app/` -> `Contents/` lands at libexec root (launcher at Contents/MacOS/rk);
+  # Linux `rk/` -> `bin/` lands at libexec root (launcher at bin/rk). The default JLINK formula's
+  # `#{libexec}/bin/rk` is therefore right for Linux but wrong for macOS. The macOS zip also loses
+  # the launcher's exec bit (Gradle Zip doesn't preserve unix perms), so restore it. post_install
+  # dylib re-signing is dropped: the .app's dylibs live inside the bundle, not in `#{libexec}/lib`,
+  # and the bundled runtime + Skiko load fine as-is (verified: `rk snapshot render` works).
   def install
     libexec.install Dir["*"]
     if OS.mac?
-      bin.install_symlink "#{libexec}/rk.app/Contents/MacOS/rk" => "rk"
+      chmod 0755, "#{libexec}/Contents/MacOS/rk"
+      bin.install_symlink "#{libexec}/Contents/MacOS/rk" => "rk"
     else
-      bin.install_symlink "#{libexec}/rk/bin/rk" => "rk"
+      bin.install_symlink "#{libexec}/bin/rk" => "rk"
     end
   end
 


### PR DESCRIPTION
Local `brew install reduxkotlin/tap/rk` revealed the real macOS issues (this is the Task 5 close-out):

1. **Homebrew strips the single top-level dir** on unpack — `rk.app/` is removed, so the launcher lands at `#{libexec}/Contents/MacOS/rk` (my previous `rk.app/...` path was wrong). Linux's `rk/` is likewise stripped → `#{libexec}/bin/rk` (the default), so only macOS needs the override.
2. **Gradle Zip drops the launcher's exec bit** → `chmod 0755` it in the formula.

Verified end-to-end from a real brew install: `rk --version`, `rk --help` (both groups), and `rk snapshot render` (Skiko/Compose → PNG) all work from the bundled JRE on Apple Silicon. No signature/dylib issues.

After merge: re-dispatch → confirm the published formula installs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)