### PR TITLE
docs(rk): fix stale binary refs + complete rk CLI docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ The ten published core modules (each "use for X"):
 <!-- assemble:modules:end -->
 
 More modules exist (routing/bundle/bom/devtools/codegen) and unpublished dev tools
-(`rk-devtools`, `rk-snapshot` golden UI snapshots) → see `docs/agent/api-map.md`.
+(the unified `rk` CLI — `rk devtools` + `rk snapshot`; built by `redux-kotlin-cli`) → see `docs/agent/api-map.md`.
 
 `examples/` = sample apps; `examples/taskflow` is the canonical app.
 
@@ -72,5 +72,6 @@ Canonical example: `examples/taskflow`.
 ## Deeper knowledge
 
 - **T1** per-concern guides → `docs/agent/references/` (all eleven live: feature-slice, store-setup, compose-binding, effects-sync, testing, platform-shims, modularization, devtools, store-consistency-model, state-persistence, snapshot — see `docs/agent/references/README.md`).
+  - Snapshot / golden UI testing → `docs/agent/references/snapshot.md`.
 - Task → guide routing (decision table) → `docs/agent/references/README.md`.
 - **T2** → `examples/taskflow/ARCHITECTURE.md` (full architecture + design rules) and `docs/agent/api-map.md` (module → `.api` index).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,13 @@ plugin): `redux-kotlin-routing-codegen` (KSP `@Reduce`/`@ReduxInitial`
 processor — JVM-only, consumed via `project(...)`, listed in the BOM but
 publishing is a pre-release follow-up), `redux-kotlin-routing-codegen-sample`,
 `redux-kotlin-devtools-standalone` (Compose desktop monitor),
-`redux-kotlin-devtools-cli` (the `rk-devtools` terminal tool),
-`redux-kotlin-snapshot` (the `rk-snapshot` headless Compose UI snapshot/golden
-tool — renders `f(state) → PNG`, diffs against goldens, emits an HTML dashboard).
+`redux-kotlin-devtools-cli` (library — powers `rk devtools`; exposes `devToolsCommand()`),
+`redux-kotlin-snapshot` (library — powers `rk snapshot`; renders `f(state) → PNG`,
+diffs against goldens, emits an HTML dashboard; exposes `snapshotCommand(app)` / `SnapshotApp.runCli`),
+`redux-kotlin-cli` (the unified `rk` binary; `./gradlew :redux-kotlin-cli:installDist`
+→ `redux-kotlin-cli/build/install/rk/bin/rk`),
+`redux-kotlin-cli-dist` (Compose bundled-JRE packaging → `brew install reduxkotlin/tap/rk`
+/ `scoop install rk`).
 
 `examples/` holds sample apps (`convention.control`, not published) — 
 `examples/taskflow` is the canonical bundle showcase. `website/`

--- a/docs/agent/AGENTS-external.md
+++ b/docs/agent/AGENTS-external.md
@@ -74,6 +74,7 @@ nav), and `ui` (theme, locals, widgets).
 - DevTools debugging loop — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/devtools.md
 - Store consistency model (sync writes, async notify) — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/store-consistency-model.md
 - State persistence & restore (process death, preloadedState, saveable) — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/state-persistence.md
+- Snapshot / golden UI testing — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/snapshot.md
 
 ## DevTools CLI — `rk`
 
@@ -105,6 +106,11 @@ Add `redux-kotlin-cli/build/install/rk/bin` to your `PATH`, then use:
 - `rk snapshot --scene <name> --preset <name> --out shot.png` — render a Compose screen from state.
 
 Full guide: https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/devtools.md
+
+> **Note:** `rk snapshot` only renders the binary's built-in scenes. To render
+> **your own app's screens**, depend on `redux-kotlin-snapshot` as a library and
+> call `yourRegistry.runCli(args)` from your `main` (then `exitProcess(0)` — Skiko
+> leaves non-daemon threads alive).
 
 ## Verify loop
 

--- a/docs/agent/api-map.md
+++ b/docs/agent/api-map.md
@@ -49,5 +49,8 @@ capture queries: `serve`/`stores`/`actions`/`diff`/`state`/`tail`); the installa
 headlessly from a known state (`f(state) → PNG`), diffs against a committed golden, and emits an HTML
 dashboard. Run it via `rk snapshot` or a consuming app's `main` (which calls `runCli`) or the TaskFlow `snapshotUi`
 task; see `docs/agent/references/snapshot.md`.
+`redux-kotlin-cli-dist` is the Compose app-image + JReleaser packaging module: `createDistributable` builds
+a per-OS bundled-JRE app-image and `packageRkArchive` archives it; JReleaser publishes the archives to the
+Homebrew tap (`reduxkotlin/homebrew-tap`) and Scoop bucket (`reduxkotlin/scoop-bucket`) on a tagged release.
 
 `examples/*` are `convention.control` (not published, no `.api`).

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -20,7 +20,7 @@ the agent-oriented CLI walkthrough lives at
 The DevTools ship as separate artifacts so release builds can link none of
 the debug infrastructure. Published libraries: `-core`, `-bridge`, `-remote`,
 `-inapp`, `-inapp-noop`, `-ui`. Unpublished repo tools: `-standalone` (the
-desktop monitor app) and `-cli` (the `rk-devtools` terminal tool).
+desktop monitor app) and `-cli` (library — powers `rk devtools`).
 
 ### `redux-kotlin-devtools-core`
 
@@ -367,26 +367,40 @@ state off the loopback interface requires a non-loopback `host` **and** a shared
 `token` (sent in the handshake, verified by the monitor against the connecting
 peer). The bridge is debug-only — never ship it in a release build.
 
-## The `rk-devtools` CLI
+## The `rk` CLI
 
-`redux-kotlin-devtools-cli` wraps the same bridge receiver in a terminal tool —
-ideal for agents, scripts, and headless debugging. It is unpublished; install it
-from the repository:
+`redux-kotlin-devtools-cli` is a library that powers the `rk devtools` command
+group in the unified `rk` binary — ideal for agents, scripts, and headless
+debugging. It is unpublished; install `rk` via a package manager (recommended)
+or build it from source:
+
+**Homebrew / Scoop (bundled JRE — no Java required):**
+
+```bash
+# macOS / Linux
+brew install reduxkotlin/tap/rk
+
+# Windows
+scoop bucket add reduxkotlin https://github.com/reduxkotlin/scoop-bucket
+scoop install rk
+```
+
+**From source (needs JDK 17+):**
 
 ```
-./gradlew :redux-kotlin-devtools-cli:installDist
+./gradlew :redux-kotlin-cli:installDist
 # binary:
-redux-kotlin-devtools-cli/build/install/rk-devtools/bin/rk-devtools
+redux-kotlin-cli/build/install/rk/bin/rk
 ```
 
 | Command | What it does |
 |---|---|
-| `rk-devtools serve` | Hosts the receiver on `127.0.0.1:9090`; writes one `<storeKey>.jsonl` capture per connected store into `.rk-devtools/`. Options: `--port`, `--host`, `--token`, `--out`, `--ui` (also launch the GUI monitor). |
-| `rk-devtools stores` | Lists captured stores (`clientId::storeInstanceId`). |
-| `rk-devtools actions` | Action log. Filters: `--store`, `--type '*Card*'`, `--since`/`--until`, `--last N`, `--format actions\|diff\|full`, `--pretty`. |
-| `rk-devtools diff` | Same filters; each line includes the per-field JSON diff. |
-| `rk-devtools state --at <id>` | Full state snapshot at an actionId. |
-| `rk-devtools tail [--follow]` | Recent actions; `--follow` polls live. |
+| `rk devtools serve` | Hosts the receiver on `127.0.0.1:9090`; writes one `<storeKey>.jsonl` capture per connected store into `.rk-devtools/`. Options: `--port`, `--host`, `--token`, `--out`, `--ui` (also launch the GUI monitor). |
+| `rk devtools stores` | Lists captured stores (`clientId::storeInstanceId`). |
+| `rk devtools actions` | Action log. Filters: `--store`, `--type '*Card*'`, `--since`/`--until`, `--last N`, `--format actions\|diff\|full`, `--pretty`. |
+| `rk devtools diff` | Same filters; each line includes the per-field JSON diff. |
+| `rk devtools state --at <id>` | Full state snapshot at an actionId. |
+| `rk devtools tail [--follow]` | Recent actions; `--follow` polls live. |
 
 The agent-oriented walkthrough of the full debugging loop lives in
 [docs/agent/references/devtools.md](agent/references/devtools.md).

--- a/examples/taskflow/ARCHITECTURE.md
+++ b/examples/taskflow/ARCHITECTURE.md
@@ -966,7 +966,7 @@ TaskFlow ships with the Redux-Kotlin DevTools wired in (see the repo-level
   launch and each account store appears in the store picker as it logs in.
 
 The bridge is loopback-only by default; run `./gradlew :redux-kotlin-devtools-standalone:run`
-(or `rk-devtools serve`) before launching TaskFlow to capture its streams.
+(or `rk devtools serve`) before launching TaskFlow to capture its streams.
 
 ---
 

--- a/redux-kotlin-cli-dist/README.md
+++ b/redux-kotlin-cli-dist/README.md
@@ -1,0 +1,33 @@
+# redux-kotlin-cli-dist
+
+Unpublished repo tool. Packages the `rk` binary into a per-OS bundled-JRE app-image
+and publishes it via JReleaser to the Homebrew tap and Scoop bucket on a tagged release.
+
+## What it does
+
+- `createDistributable` — builds a per-OS Compose app-image (macOS `.app`, Linux `rk/`, Windows `rk/`)
+  with a bundled JRE, so end users need no local Java.
+- `packageRkArchive` — zips the app-image into a distributable archive ready for JReleaser.
+- JReleaser (workflow `.github/workflows/cli-release.yml`) picks up the archives on a tagged release
+  and publishes them to:
+  - Homebrew tap: `reduxkotlin/homebrew-tap` (`brew install reduxkotlin/tap/rk`)
+  - Scoop bucket: `reduxkotlin/scoop-bucket` (`scoop install rk`)
+
+## End-user install
+
+```bash
+# macOS / Linux
+brew install reduxkotlin/tap/rk
+
+# Windows
+scoop bucket add reduxkotlin https://github.com/reduxkotlin/scoop-bucket
+scoop install rk
+```
+
+No Java installation required — the JRE is bundled.
+
+## Developer notes
+
+This module is not published to Maven Central. It is a `convention.control` Gradle project
+that depends on `redux-kotlin-cli` and uses the Compose Multiplatform packaging tasks.
+Run `./gradlew :redux-kotlin-cli-dist:packageRkArchive` to produce the archives locally.

--- a/redux-kotlin-cli-dist/src/jreleaser/distributions/rk/brew/formula-multi.rb.tpl
+++ b/redux-kotlin-cli-dist/src/jreleaser/distributions/rk/brew/formula-multi.rb.tpl
@@ -28,7 +28,7 @@ class {{brewFormulaName}} < Formula
   # `#{libexec}/bin/rk` is therefore right for Linux but wrong for macOS. The macOS zip also loses
   # the launcher's exec bit (Gradle Zip doesn't preserve unix perms), so restore it. post_install
   # dylib re-signing is dropped: the .app's dylibs live inside the bundle, not in `#{libexec}/lib`,
-  # and the bundled runtime + Skiko load fine as-is (verified: `rk snapshot render` works).
+  # and the bundled runtime + Skiko load fine as-is (verified: `rk snapshot --scene counter --preset n3 --out /tmp/test.png` renders).
   def install
     libexec.install Dir["*"]
     if OS.mac?

--- a/redux-kotlin-cli/README.md
+++ b/redux-kotlin-cli/README.md
@@ -35,3 +35,14 @@ rk --version
 ```
 
 Add `redux-kotlin-cli/build/install/rk/bin` to your `PATH`, or symlink the binary.
+
+## Commands
+
+- **`rk devtools`** — inspect a running app: `serve` (start bridge receiver + capture), `stores`,
+  `actions`, `diff`, `state`, `tail`. See [`../redux-kotlin-devtools-cli/README.md`](../redux-kotlin-devtools-cli/README.md).
+- **`rk snapshot`** — render built-in or manifest Compose scenes to PNG with golden diffing.
+  See [`../redux-kotlin-snapshot/README.md`](../redux-kotlin-snapshot/README.md).
+
+> **Rendering your own app's screens** is a library use: depend on `redux-kotlin-snapshot` and
+> call `yourRegistry.runCli(args)` from your own `main` (then `exitProcess(0)` — Skiko leaves
+> non-daemon threads alive). The `rk` binary only renders its built-in demo scenes.

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/RootCommand.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/RootCommand.kt
@@ -8,7 +8,20 @@ internal class DevToolsRootCommand : CliktCommand(name = "devtools") {
     override fun run() = Unit
 }
 
-/** Builds the `devtools` command group used by the unified `rk` CLI. */
+/**
+ * Builds the `devtools` command group used by the unified `rk` CLI.
+ *
+ * This is a library aggregator: it wires together the six `rk devtools` subcommands —
+ * `serve` (start the bridge receiver and write `.jsonl` captures),
+ * `stores` (list captured stores),
+ * `actions` (query the action log),
+ * `diff` (per-field JSON diffs per action),
+ * `state` (full state snapshot at a given actionId), and
+ * `tail` (stream recent/live actions).
+ *
+ * The returned [CliktCommand] is mounted as a subcommand by `redux-kotlin-cli`'s root `rk` command.
+ * Consumers that build their own CLI tool can mount it the same way.
+ */
 public fun devToolsCommand(): CliktCommand = DevToolsRootCommand().subcommands(
     ServeCommand(),
     StoresCommand(),

--- a/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/DemoScene.kt
+++ b/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/DemoScene.kt
@@ -29,7 +29,8 @@ internal val counterReducer: Reducer<CounterState> = { state, action ->
 }
 
 /**
- * A redux-free, deterministic demo registry used to self-test the whole pipe in CI.
+ * A self-contained, deterministic demo registry used to self-test the whole pipe in CI.
+ * Each scene builds its own store from the preset, no external store injected.
  *
  * - `counter` proves `f(redux-state) -> UI`: it builds a real redux-kotlin [createStore], dispatches
  *   N `"inc"` actions from the input, and renders `count` solid bars (no text -> font-independent ->

--- a/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/cli/Cli.kt
+++ b/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/cli/Cli.kt
@@ -29,14 +29,18 @@ import java.io.File
 
 /**
  * Builds the `snapshot` command for [app]. Exit codes: 0 ok, 1 render/verify failure, 2 usage.
- * Public so the unified `rk` CLI can mount it as a subcommand; in-project callers should prefer
- * [runCli], which keeps the Clikt dependency off this module's public API.
+ * Public so the unified `rk` CLI can mount it as a subcommand; library consumers building their
+ * OWN binary should call [runCli] instead — it avoids leaking the [CliktCommand] return type and
+ * the Clikt dependency into their public API.
  */
 public fun snapshotCommand(app: SnapshotApp): CliktCommand = SnapshotCommand(app)
 
 /**
  * Runs the snapshot CLI for this registry — the entry point a consuming app calls from its own
  * `main`. Keeps Clikt types from leaking across the module boundary.
+ *
+ * Callers should follow this with `exitProcess(0)`: Skiko / Compose leave non-daemon threads alive
+ * after the command returns, which would prevent the process from exiting cleanly.
  */
 public fun SnapshotApp.runCli(argv: Array<String>) {
     snapshotCommand(this).main(argv)

--- a/website/docs/advanced/DevToolsCLITutorial.md
+++ b/website/docs/advanced/DevToolsCLITutorial.md
@@ -45,9 +45,20 @@ the in-flight bookkeeping behaves.
 
 ---
 
-## Step 1 — Build the CLI
+## Step 1 — Install the CLI
 
-`rk` installs from the repo with Gradle's `installDist`:
+**Homebrew / Scoop (recommended — bundled JRE, no Java required):**
+
+```bash
+# macOS / Linux
+brew install reduxkotlin/tap/rk
+
+# Windows
+scoop bucket add reduxkotlin https://github.com/reduxkotlin/scoop-bucket
+scoop install rk
+```
+
+**From source (any OS, needs JDK 17+):**
 
 ```bash
 ./gradlew :redux-kotlin-cli:installDist

--- a/website/docs/advanced/Snapshot.md
+++ b/website/docs/advanced/Snapshot.md
@@ -73,7 +73,18 @@ dimensions without touching the scene.
 
 ## The CLI: `rk snapshot`
 
-Install the unified `rk` CLI from the repository:
+**Homebrew / Scoop (recommended — bundled JRE, no Java required):**
+
+```bash
+# macOS / Linux
+brew install reduxkotlin/tap/rk
+
+# Windows
+scoop bucket add reduxkotlin https://github.com/reduxkotlin/scoop-bucket
+scoop install rk
+```
+
+**From source (needs JDK 17+):**
 
 ```
 ./gradlew :redux-kotlin-cli:installDist

--- a/website/docs/ai-agents/BuildingWithAI.md
+++ b/website/docs/ai-agents/BuildingWithAI.md
@@ -87,6 +87,7 @@ nav), and `ui` (theme, locals, widgets).
 - DevTools debugging loop — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/devtools.md
 - Store consistency model (sync writes, async notify) — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/store-consistency-model.md
 - State persistence & restore (process death, preloadedState, saveable) — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/state-persistence.md
+- Snapshot / golden UI testing — https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/snapshot.md
 
 ## DevTools CLI — `rk`
 
@@ -118,6 +119,11 @@ Add `redux-kotlin-cli/build/install/rk/bin` to your `PATH`, then use:
 - `rk snapshot --scene <name> --preset <name> --out shot.png` — render a Compose screen from state.
 
 Full guide: https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/devtools.md
+
+> **Note:** `rk snapshot` only renders the binary's built-in scenes. To render
+> **your own app's screens**, depend on `redux-kotlin-snapshot` as a library and
+> call `yourRegistry.runCli(args)` from your `main` (then `exitProcess(0)` — Skiko
+> leaves non-daemon threads alive).
 
 ## Verify loop
 

--- a/website/docs/introduction/Ecosystem.md
+++ b/website/docs/introduction/Ecosystem.md
@@ -70,6 +70,8 @@ and are not published to Maven.
 |---|---|
 | `redux-kotlin-devtools-*` | [DevTools family](../advanced/devtools) — action/state inspection, diffing, and pipeline timing for a running app. Published (experimental — exempt from semver until the surface stabilizes): `core`, `bridge`, `remote`, `inapp`, `inapp-noop` (release no-op facade), `ui`. Unpublished repo tools: `standalone` (Compose desktop monitor app) and `cli` (library behind `rk devtools`). |
 | `redux-kotlin-snapshot` | [Snapshot testing](../advanced/snapshot-testing) — headlessly render Compose Multiplatform screens from redux-kotlin state to PNG (`f(state) -> UI`), with golden-image diffing and an HTML dashboard. Accessed via `rk snapshot` (from `redux-kotlin-cli`). Unpublished repo tool. |
+| `redux-kotlin-cli` | Produces the unified `rk` binary — `rk devtools` (bridge receiver + capture queries) and `rk snapshot` (headless Compose renderer). Install from source: `./gradlew :redux-kotlin-cli:installDist` (binary: `redux-kotlin-cli/build/install/rk/bin/rk`; needs JDK 17+). Or install via brew/scoop (see `redux-kotlin-cli-dist`). Unpublished repo tool. |
+| `redux-kotlin-cli-dist` | Compose bundled-JRE packaging for `rk` — produces per-OS app-images via `createDistributable` and archives via `packageRkArchive`; published to the Homebrew tap and Scoop bucket on a tagged release. End users install via `brew install reduxkotlin/tap/rk` / `scoop install rk` (no Java required). Unpublished repo tool. |
 
 ## Community
 


### PR DESCRIPTION
Applies fixes from a multi-agent documentation review of the unified `rk` CLI (website, AI-agent integration, READMEs/CLAUDE.md, KDocs).

## HIGH — correctness (stale retired-binary refs / wrong commands)
- **`docs/devtools.md`** — the entire "rk-devtools CLI" section was stale (heading, `:redux-kotlin-devtools-cli:installDist`, `…/rk-devtools/bin/rk-devtools`, all `rk-devtools <cmd>` commands). Rewritten to `rk` / `rk devtools …` + brew/scoop install. (This file was outside the earlier doc sweep.)
- **`AGENTS.md`** static line — retired `rk-devtools`/`rk-snapshot` binary names → unified `rk` framing.
- **`CLAUDE.md`** "Unpublished repo tools" — described the two as libraries + added `redux-kotlin-cli` / `redux-kotlin-cli-dist`.
- **`examples/taskflow/ARCHITECTURE.md`** — `rk-devtools serve` → `rk devtools serve`.
- **`rk snapshot render` is not a valid command** (snapshot is a flat command) → fixed the formula comment to a real `rk snapshot --scene … --preset … --out …` invocation.

## MEDIUM — completeness
- Brew/scoop install added to `DevToolsCLITutorial.md` + `Snapshot.md`.
- `Ecosystem.md` + `api-map.md`: `redux-kotlin-cli` / `redux-kotlin-cli-dist` modules added.
- `AGENTS-external.md` (+ assembled `AGENTS.md` / `BuildingWithAI.md`): snapshot guide link + the `rk snapshot` built-in-vs-library-render note.
- `redux-kotlin-cli/README.md`: command overview; new `redux-kotlin-cli-dist/README.md`.
- KDoc: `demoSnapshots` "redux-free" contradiction; `snapshotCommand`/`runCli`/`devToolsCommand` library-role wording.

## Gates
assemble `--check` OK · `detektAll` + snapshot/devtools-cli build SUCCESSFUL · `yarn build` SUCCESS · stale-ref grep empty. `docs/superpowers/**` (historical records) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)