### PR TITLE
fix(cli-release): brew formula ships a bin/rk wrapper (absolute exec)

### DIFF
--- a/redux-kotlin-cli-dist/src/jreleaser/distributions/rk/brew/formula-multi.rb.tpl
+++ b/redux-kotlin-cli-dist/src/jreleaser/distributions/rk/brew/formula-multi.rb.tpl
@@ -24,19 +24,22 @@ class {{brewFormulaName}} < Formula
 
   # The archives are jpackage app-images with a single top-level wrapper dir, which Homebrew strips
   # on unpack: macOS `rk.app/` -> `Contents/` lands at libexec root (launcher at Contents/MacOS/rk);
-  # Linux `rk/` -> `bin/` lands at libexec root (launcher at bin/rk). The default JLINK formula's
-  # `#{libexec}/bin/rk` is therefore right for Linux but wrong for macOS. The macOS zip also loses
-  # the launcher's exec bit (Gradle Zip doesn't preserve unix perms), so restore it. post_install
-  # dylib re-signing is dropped: the .app's dylibs live inside the bundle, not in `#{libexec}/lib`,
-  # and the bundled runtime + Skiko load fine as-is (verified: `rk snapshot --scene counter --preset n3 --out /tmp/test.png` renders).
+  # Linux `rk/` -> `bin/` lands at libexec root (launcher at bin/rk). We ship a `bin/rk` WRAPPER that
+  # exec's the launcher by ABSOLUTE path instead of `bin.install_symlink`: the jpackage launcher
+  # self-locates from $0, and Homebrew's relative double-symlink (HOMEBREW/bin/rk -> ../Cellar/.../bin/rk
+  # -> libexec/...) makes it mis-resolve its app dir (it looks for Contents/app/rk.cfg in the wrong
+  # place). The macOS zip also loses the launcher's exec bit (Gradle Zip doesn't preserve unix perms),
+  # so restore it. post_install dylib re-signing is dropped: the .app's dylibs are inside the bundle,
+  # and the bundled runtime + Skiko load fine as-is (verified end-to-end via a real brew install).
   def install
     libexec.install Dir["*"]
-    if OS.mac?
-      chmod 0755, "#{libexec}/Contents/MacOS/rk"
-      bin.install_symlink "#{libexec}/Contents/MacOS/rk" => "rk"
-    else
-      bin.install_symlink "#{libexec}/bin/rk" => "rk"
-    end
+    target = OS.mac? ? "#{libexec}/Contents/MacOS/rk" : "#{libexec}/bin/rk"
+    chmod 0755, target
+    (bin/"rk").write <<~SH
+      #!/bin/sh
+      exec "#{target}" "$@"
+    SH
+    chmod 0755, bin/"rk"
   end
 
   test do


### PR DESCRIPTION
The previous `bin.install_symlink` formula installed but left a **broken `rk`**: Homebrew's relative double-symlink (`HOMEBREW/bin/rk -> ../Cellar/.../bin/rk -> libexec/Contents/MacOS/rk`) makes the jpackage launcher mis-resolve its own app dir (`Error opening .../Cellar/rk/Contents/app/rk.cfg`). (The earlier 'working' `rk --version` was a stale `~/.local/bin/rk` absolute symlink, not the brew one.)

Fix: the formula now writes a `bin/rk` **wrapper script** that `exec`s the launcher by **absolute** `libexec` path. jpackage self-locates correctly from there. Verified end-to-end via a real `brew install reduxkotlin/tap/rk`: `rk --version` → 1.0.0-alpha02, `rk --help` lists both groups, and `rk snapshot --scene … --out …` renders a PNG from any working directory.

After merge: re-dispatch → final clean `brew install` verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)