### PR TITLE
docs(rk): accuracy pass on rk CLI, publication, install + AI-agent docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Plus two unpublished developer tools in the repo: `redux-kotlin-devtools-standalone`
   (Compose desktop monitor app, `./gradlew :redux-kotlin-devtools-standalone:run`) and
-  `redux-kotlin-devtools-cli` (`rk-devtools` clikt tool — install with
-  `./gradlew :redux-kotlin-devtools-cli:installDist`, then run
-  `redux-kotlin-devtools-cli/build/install/rk-devtools/bin/rk-devtools`).
+  `redux-kotlin-devtools-cli` (the library behind `rk devtools` in the unified `rk` CLI —
+  `brew install reduxkotlin/tap/rk` / `scoop install rk`, or build from source with
+  `./gradlew :redux-kotlin-cli:installDist`, then run `redux-kotlin-cli/build/install/rk/bin/rk devtools`).
   See [docs/devtools.md](docs/devtools.md) for the integration guide.
 
   The six published DevTools modules are version-aligned by `redux-kotlin-bom` but

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Requirements:
 - Kotlin 1.9 or newer (the published artefacts are built with Kotlin 2.3)
 - JVM/Android consumers: JDK 17+ on Android; library bytecode is JVM 17
 - Android: `minSdk 21` or higher
-- Supported KMP targets: `jvm`, `js` (browser/node), `android`, `iosArm64`, `iosX64`,
-  `iosSimulatorArm64`, `macosArm64`, `macosX64`, `linuxArm64`, `linuxX64`, `mingwX64`
+- Supported KMP targets: `jvm`, `js` (browser/node), `wasmJs`, `android`, `iosArm64`,
+  `iosSimulatorArm64`, `macosArm64`, `linuxX64`, `mingwX64` (the core module also adds `linuxArm64`)
 
 ### Recommended: the bundles
 

--- a/docs/agent/references/devtools.md
+++ b/docs/agent/references/devtools.md
@@ -97,6 +97,7 @@ All query subcommands share a common filter/format layer
 | `--store <key>` | target store (`clientId::storeInstanceId`); auto-resolved if only one |
 | `--type '*Card*'` | glob filter on action type (`*` = any substring) |
 | `--since <id>` / `--until <id>` | inclusive actionId range |
+| `--since-time <t>` / `--until-time <t>` | inclusive timestamp range (epoch millis or ISO-8601 instant) |
 | `--last <N>` | keep only the final N results after other filters |
 | `--format actions\|diff\|full` | output tier (see below) |
 | `--pretty` | pretty-print JSON |

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -385,6 +385,8 @@ scoop bucket add reduxkotlin https://github.com/reduxkotlin/scoop-bucket
 scoop install rk
 ```
 
+The macOS bottle is **Apple Silicon only** for now; on an Intel Mac, build from source.
+
 **From source (needs JDK 17+):**
 
 ```
@@ -397,7 +399,7 @@ redux-kotlin-cli/build/install/rk/bin/rk
 |---|---|
 | `rk devtools serve` | Hosts the receiver on `127.0.0.1:9090`; writes one `<storeKey>.jsonl` capture per connected store into `.rk-devtools/`. Options: `--port`, `--host`, `--token`, `--out`, `--ui` (also launch the GUI monitor). |
 | `rk devtools stores` | Lists captured stores (`clientId::storeInstanceId`). |
-| `rk devtools actions` | Action log. Filters: `--store`, `--type '*Card*'`, `--since`/`--until`, `--last N`, `--format actions\|diff\|full`, `--pretty`. |
+| `rk devtools actions` | Action log. Filters: `--store`, `--type '*Card*'`, `--since`/`--until` (actionId), `--since-time`/`--until-time` (epoch millis or ISO-8601), `--last N`, `--format actions\|diff\|full`, `--pretty`. |
 | `rk devtools diff` | Same filters; each line includes the per-field JSON diff. |
 | `rk devtools state --at <id>` | Full state snapshot at an actionId. |
 | `rk devtools tail [--follow]` | Recent actions; `--follow` polls live. |

--- a/redux-kotlin-cli-dist/README.md
+++ b/redux-kotlin-cli-dist/README.md
@@ -24,7 +24,9 @@ scoop bucket add reduxkotlin https://github.com/reduxkotlin/scoop-bucket
 scoop install rk
 ```
 
-No Java installation required — the JRE is bundled.
+No Java installation required — the JRE is bundled. The macOS bottle is **Apple Silicon
+only** as of `1.0.0-alpha02` (Intel runners were dropped); Intel-Mac users build `rk` from
+source via `:redux-kotlin-cli:installDist`.
 
 ## Developer notes
 

--- a/redux-kotlin-cli/README.md
+++ b/redux-kotlin-cli/README.md
@@ -23,7 +23,8 @@ scoop bucket add reduxkotlin https://github.com/reduxkotlin/scoop-bucket
 scoop install rk
 ```
 
-Available once the first tagged release is published.
+Published from `1.0.0-alpha01` onward (latest: `1.0.0-alpha02`). The macOS bottle is
+**Apple Silicon only** for now — on an Intel Mac, build from source (below).
 
 ### From source (any OS, needs JDK 17+)
 

--- a/redux-kotlin-devtools-cli/README.md
+++ b/redux-kotlin-devtools-cli/README.md
@@ -5,7 +5,10 @@ installable binary of its own. The bridge receiver and capture queries
 (`serve`/`stores`/`actions`/`diff`/`state`/`tail`) are exposed as clikt
 subcommands that the unified `rk` CLI mounts under `rk devtools`.
 
-Install the unified `rk` binary from the repository:
+End users install the `rk` binary via a package manager (bundled JRE, no Java
+required): `brew install reduxkotlin/tap/rk` (macOS Apple Silicon / Linux) or
+`scoop install rk` (Windows) — see [`../redux-kotlin-cli/README.md`](../redux-kotlin-cli/README.md).
+To build from the repository instead:
 
 ```
 ./gradlew :redux-kotlin-cli:installDist
@@ -35,7 +38,7 @@ JAVA_HOME=/path/to/jdk17+ rk devtools --help
 |---|---|
 | `rk devtools serve` | Host the receiver on `127.0.0.1:9090`; write captures. Options: `--port`, `--host`, `--token`, `--out`, `--ui` (also launch the GUI monitor). |
 | `rk devtools stores` | List captured stores (`clientId::storeInstanceId`). |
-| `rk devtools actions` | Print the action log. Filters: `--store`, `--type '*Card*'`, `--since`/`--until`, `--last N`, `--format actions\|diff\|full`, `--pretty`. |
+| `rk devtools actions` | Print the action log. Filters: `--store`, `--type '*Card*'`, `--since`/`--until` (actionId), `--since-time`/`--until-time` (epoch millis or ISO-8601), `--last N`, `--format actions\|diff\|full`, `--pretty`. |
 | `rk devtools diff` | Same filters; each line includes the per-field JSON diff. |
 | `rk devtools state --at <id>` | Full state snapshot at an actionId. |
 | `rk devtools tail [--follow]` | Recent actions; `--follow` polls live. |

--- a/redux-kotlin-snapshot/README.md
+++ b/redux-kotlin-snapshot/README.md
@@ -10,8 +10,10 @@ people.
 
 **Unpublished.** This is a developer tool, not a Maven artifact — it is not on
 Maven Central and not in `redux-kotlin-bom`. In-repo, example apps depend on it
-as a test-scoped `project(":redux-kotlin-snapshot")`. To run the CLI, install
-the unified `rk` binary from the repository:
+as a test-scoped `project(":redux-kotlin-snapshot")`. To run the CLI, install the
+unified `rk` binary via a package manager (`brew install reduxkotlin/tap/rk` on
+macOS Apple Silicon / Linux, `scoop install rk` on Windows — bundled JRE), or
+build it from the repository:
 
 ```
 ./gradlew :redux-kotlin-cli:installDist

--- a/website/docs/advanced/DevTools.md
+++ b/website/docs/advanced/DevTools.md
@@ -275,6 +275,8 @@ scoop bucket add reduxkotlin https://github.com/reduxkotlin/scoop-bucket
 scoop install rk
 ```
 
+The macOS bottle is **Apple Silicon only** for now; on an Intel Mac, build from source.
+
 Or build from source (needs JDK 17+):
 
 ```sh
@@ -291,7 +293,7 @@ Add that `bin/` directory to your `PATH`, or symlink the binary.
 |---|---|
 | `rk devtools serve` | Hosts the bridge receiver on `127.0.0.1:9090` and writes one `<storeKey>.jsonl` capture per connected store into `.rk-devtools/`. Options: `--port`, `--host`, `--token`, `--out`, `--ui` (also launch the GUI monitor). |
 | `rk devtools stores` | Lists captured stores (`clientId::storeInstanceId` keys). |
-| `rk devtools actions` | Prints the action log. Filters: `--store`, `--type '*Card*'`, `--since`/`--until`, `--last N`, `--format actions\|diff\|full`, `--pretty`. |
+| `rk devtools actions` | Prints the action log. Filters: `--store`, `--type '*Card*'`, `--since`/`--until` (actionId range), `--since-time`/`--until-time` (epoch millis or ISO-8601), `--last N`, `--format actions\|diff\|full`, `--pretty`. |
 | `rk devtools diff` | Same filters; each line includes the per-field JSON-diff for the action. |
 | `rk devtools state --at <id>` | Full state snapshot recorded at an actionId. |
 | `rk devtools tail [--follow]` | Recent actions; `--follow` polls for new ones live. |

--- a/website/docs/advanced/Snapshot.md
+++ b/website/docs/advanced/Snapshot.md
@@ -84,6 +84,8 @@ scoop bucket add reduxkotlin https://github.com/reduxkotlin/scoop-bucket
 scoop install rk
 ```
 
+The macOS bottle is **Apple Silicon only** for now; on an Intel Mac, build from source.
+
 **From source (needs JDK 17+):**
 
 ```


### PR DESCRIPTION
## What

Documentation-accuracy review of the unified `rk` CLI, its publication pipeline
(JReleaser → Homebrew tap + Scoop bucket), and every doc surface that references
it — README, CHANGELOG, module READMEs, the Docusaurus site, the AI-agent
reference guides, and `docs/devtools.md`.

The `rk` command surface was verified against the Clikt sources
(`redux-kotlin-cli`, `redux-kotlin-devtools-cli`, `redux-kotlin-snapshot`); the
publication wiring against `redux-kotlin-cli-dist/build.gradle.kts`, the brew
formula template, and `.github/workflows/cli-release.yml`.

## Fixes

- **CHANGELOG** — stale `rk-devtools` binary name + `:redux-kotlin-devtools-cli:installDist`
  path (that standalone binary no longer exists) → unified `rk devtools` with brew/scoop install.
- **README** — KMP target list: add `wasmJs`, drop the removed `iosX64`/`macosX64`
  (Compose 1.11.0), note `linuxArm64` is core-only. Now matches `convention.mpp-loved`.
- **redux-kotlin-cli/README** — drop stale "available once the first tagged release is
  published" (shipped in `1.0.0-alpha01`, latest `1.0.0-alpha02`).
- **Apple-Silicon-only caveat** — added wherever brew install is shown (cli, cli-dist,
  website DevTools/Snapshot, docs/devtools); Intel macOS runners were dropped for alpha02.
- **`--since-time` / `--until-time`** action filters — documented everywhere the `actions`
  flags are listed (website, agent reference, module README, docs/devtools); previously undocumented.
- **devtools-cli / snapshot module READMEs** — point end users at brew/scoop install
  alongside the from-source path.

## Verification

- `rk` surface cross-checked against Clikt option declarations.
- Website builds clean (`yarn build`, `onBrokenLinks: throw` passes).
- Pre-commit `detektAll` passed.

## Out of scope (flagged, not changed)

- `redux-kotlin-cli-dist/src/macos-launcher/rk` is **untracked** in the repo — a real
  launcher script the publication path references. Worth a follow-up to either commit or
  remove it.
- Historical `iosX64`/`macosX64` mentions remain in `docs/superpowers/{plans,specs}` —
  point-in-time records, intentionally left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)