### PR TITLE
redux-kotlin-snapshot: semantics dump, semantics-golden, Maven Central

### DIFF
--- a/docs/agent/api-map.md
+++ b/docs/agent/api-map.md
@@ -44,8 +44,10 @@ Published, experimental — exempt from semver (ABI tracked in
 `redux-kotlin-snapshot/api/redux-kotlin-snapshot.api`):
 `redux-kotlin-snapshot` is the library behind `rk snapshot` — on Maven Central as
 `org.reduxkotlin:redux-kotlin-snapshot` and in the BOM. It renders a redux-kotlin Compose screen
-headlessly from a known state (`f(state) → PNG`), diffs against a committed golden, and emits an HTML
-dashboard. JVM/desktop-only (depend on it from a JVM/desktop source set + `compose.desktop.currentOs`).
+headlessly from a known state (`f(state) → PNG`), diffs against a committed golden, emits an HTML
+dashboard, and extracts a deterministic bounds-free semantics dump (text/JSON node tree) that a
+`--verify-semantics` golden can gate on — a cheaper, less flaky regression signal than the pixel diff
+for an AI-agent loop. JVM/desktop-only (depend on it from a JVM/desktop source set + `compose.desktop.currentOs`).
 Run it via `rk snapshot`, a consuming app's `main` (which calls `runCli`), or the TaskFlow `snapshotUi`
 task; see `docs/agent/references/snapshot.md`.
 

--- a/docs/agent/api-map.md
+++ b/docs/agent/api-map.md
@@ -47,7 +47,7 @@ Published, experimental — exempt from semver (ABI tracked in
 headlessly from a known state (`f(state) → PNG`), diffs against a committed golden, emits an HTML
 dashboard, and extracts a deterministic bounds-free semantics dump (text/JSON node tree) that a
 `--verify-semantics` golden can gate on — a cheaper, less flaky regression signal than the pixel diff
-for an AI-agent loop. JVM/desktop-only (depend on it from a JVM/desktop source set + `compose.desktop.currentOs`).
+for an AI-agent loop (semantics surface ships in `1.0.0-alpha04`+). JVM/desktop-only (depend on it from a JVM/desktop source set + `compose.desktop.currentOs`).
 Run it via `rk snapshot`, a consuming app's `main` (which calls `runCli`), or the TaskFlow `snapshotUi`
 task; see `docs/agent/references/snapshot.md`.
 

--- a/docs/agent/references/snapshot.md
+++ b/docs/agent/references/snapshot.md
@@ -158,7 +158,8 @@ architecture-independent (it carries no bounds), so it stays stable across dev a
   needs `--golden-dir`): it writes the canonical goldens and exits 0 without gating.
 
 Extraction is non-fatal: if the semantics can't be read, the dump degrades to empty and the PNG is
-still produced. This surface first ships in `redux-kotlin-snapshot:1.0.0-alpha03`.
+still produced. This surface first ships in `redux-kotlin-snapshot:1.0.0-alpha04` (`1.0.0-alpha03`
+released 2026-06-23, before this work).
 
 ## The batch + dashboard loop (TaskFlow)
 

--- a/docs/agent/references/snapshot.md
+++ b/docs/agent/references/snapshot.md
@@ -6,11 +6,13 @@ derives_from:
   - redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/cli/Cli.kt → runCli
   - redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/SnapshotTestSupport.kt → assertGolden
   - redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/GoldenStore.kt → GoldenStore
+  - redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/Semantics.kt → SemanticsDump
+  - redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/RenderBackend.kt → RenderResult
   - examples/taskflow/composeApp/src/jvmTest/kotlin/org/reduxkotlin/sample/taskflow/snapshot/TaskFlowSnapshots.kt → taskFlowSnapshots
 api_files: []
 rules: [C]
 assembles_into: [AGENTS.md, claude-skill]
-last_verified: { commit: b3303317, date: 2026-06-16 }
+last_verified: { commit: 6deca3bf, date: 2026-07-02 }
 ---
 
 # Snapshot / golden UI loop
@@ -84,6 +86,11 @@ fun main(args: Array<String>) = taskFlowSnapshots.runCli(args)
 | `--golden-dir <dir>` | Golden dir; its presence switches the batch to verify mode |
 | `--json` | Emit machine JSON on stdout |
 | `--dashboard` | Also write a static `index.html` over the batch report |
+| `--semantics` | Emit the semantics dump — single shot: to stdout (and a sidecar next to `--out`); batch: a `<id>.semantics.txt`/`.json` sidecar per shot |
+| `--semantics-format json\|text` | Dump format for `--semantics` / the sidecars (default `text`) |
+| `--verify-semantics-file <golden>` | Compare the semantics dump against this golden (single shot); mismatch exits 1 |
+| `--verify-semantics` | Enable the semantics golden gate for a batch (needs `--golden-dir`); a semantics mismatch counts as failure |
+| `--update-semantics` | (Re)write the semantics golden(s) instead of verifying, then exit 0 (single needs `--verify-semantics-file`; batch needs `--golden-dir`) |
 
 ### Exit codes
 
@@ -126,6 +133,32 @@ It renders, compares against `goldenDir/<name>.png` via
 mismatch throws `AssertionError` and writes the actual PNG under `build/snapshots/` for inspection.
 Run with `-Dsnapshot.record=true` to (over)write the golden instead of asserting — the standard
 "review the diff, then accept" record step.
+
+## Semantics dump & semantics golden
+
+Beside the pixels, a render also carries a **semantics dump** — a deterministic, bounds-free tree of
+the rendered nodes (role, text, contentDescription, testTag, enabled/selected/toggle), ordered stably
+(owners by node id, children in layout order). It has two forms: a compact indented `text` form
+(default) and a canonical `json` form. The JSON is a top-level array of root nodes and is the single
+form used for both `--semantics-format json` output and the stored semantics golden.
+
+Why an agent wants it: reading the dump as text is far cheaper than reading a PNG, and a **semantics
+golden** is a less flaky regression signal than the pixel diff — it ignores anti-aliasing and is
+architecture-independent (it carries no bounds), so it stays stable across dev arm64 vs CI x64.
+
+- **Single shot:** `--semantics` prints the dump (`--semantics-format text|json`) and, with `--out`,
+  also writes a `<out>.semantics.txt`/`.json` sidecar. `--verify-semantics-file <golden>` compares and
+  exits 1 on mismatch (printing a line-diff delta); a missing golden exits 2 with a fix-it message.
+- **Batch:** `--semantics` writes a per-shot sidecar; `--verify-semantics` (needs `--golden-dir`) gates
+  the run — a semantics mismatch is counted and forces exit 1, and the summary prints one terse
+  `drift <id>: pixel=… semantics=…` line per drifted shot so the agent reads the sidecar (or PNG) only
+  for shots that actually changed. `report.json` (schema v2) records per-shot `verifySemantics`
+  (verdict + delta), `semanticsSidecar`, and `semanticsBytes`.
+- **Author/refresh baselines** with `--update-semantics` (single needs `--verify-semantics-file`, batch
+  needs `--golden-dir`): it writes the canonical goldens and exits 0 without gating.
+
+Extraction is non-fatal: if the semantics can't be read, the dump degrades to empty and the PNG is
+still produced. This surface first ships in `redux-kotlin-snapshot:1.0.0-alpha03`.
 
 ## The batch + dashboard loop (TaskFlow)
 

--- a/docs/superpowers/plans/2026-07-01-snapshot-semantics-and-publish.md
+++ b/docs/superpowers/plans/2026-07-01-snapshot-semantics-and-publish.md
@@ -1,0 +1,1273 @@
+# redux-kotlin-snapshot Semantics + Publish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Populate the stubbed `SemanticsDump` with a real text/role tree, expose it (and a cheaper semantics-golden gate) through the `rk snapshot` CLI + batch report, and make the module consumable from Maven Central under a reconciled version.
+
+**Architecture:** A pure, `@Serializable` semantics data model + its text/JSON serializers (`Semantics.kt`); extraction from the live Compose scene inside the existing Skiko-only backend (`RenderBackend.kt`); a string-equality + line-diff comparator (`SemanticsDiffer.kt`); batch wiring that writes per-shot sidecars and a v2 report (`BatchRunner.kt`, `Report.kt`); new CLI options with distinct declared names (`cli/Cli.kt`); dashboard + docs updates. TDD throughout.
+
+**Tech Stack:** Kotlin 2.3.20, Compose Multiplatform 1.11.1 (Skiko 0.144.6), kotlinx.serialization, Clikt, JUnit-style `kotlin.test`, Gradle. JDK toolchain 17.
+
+## Global Constraints
+
+- **JVM/Skiko headless only.** No emulator/Robolectric. The only Skiko-touching surface is `RenderBackend.kt`.
+- **`explicitApi()` is strict.** Every new public declaration needs an explicit `public` modifier + KDoc. After any public-API change run `./gradlew apiDump` and commit `redux-kotlin-snapshot/api/redux-kotlin-snapshot.api` (done in Task 9; `:redux-kotlin-snapshot:test` does not run `apiCheck`, so intermediate tasks stay green).
+- **Preserve the CLI contract:** existing flags, `--list` JSON shape, batch manifest, exit codes (0 ok / 1 render-or-verify failure / 2 usage), and `runCli` → `exitProcess(0)`.
+- **Determinism:** the semantics dump carries **no bounds/position**. Ordering is by `SemanticsNode.id` (owners) and layout order (children) — never pixels. One JSON form (`toCanonicalJson`) is used for both `--semantics-format json` and goldens.
+- **Merged semantics tree only** (matches compose-ui-test default). Merging absorbs a descendant's semantics onto the merge boundary (e.g. a Button absorbs its child Text).
+- **Verdict vocabulary is lowercase:** `match` | `mismatch` | `missing-golden` (matches the existing report `result` strings).
+- **Report back-compat:** all new fields nullable/defaulted; new `Int` totals default `= 0`. Consumers reading with an older model must use `ignoreUnknownKeys`.
+- **Test DB note is irrelevant here** — this is `redux-kotlin`, no database. `./gradlew :redux-kotlin-snapshot:test` is safe.
+- **Do not raise the JDK toolchain above 17.**
+
+**Test command shape used throughout:**
+`./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.<Class>"` (append `.<method>` for one method).
+
+## File Structure
+
+- **Create** `redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/Semantics.kt` — `SemanticsDump`, `SemanticsDump.Node`, `toText()`, `toCanonicalJson()`, `EMPTY`. Pure data (no Compose).
+- **Create** `redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/SemanticsDiffer.kt` — `SemanticsDiffer`, `SemanticsDiffResult`. Pure strings.
+- **Modify** `.../RenderBackend.kt` — remove the old `SemanticsDump` (moved to `Semantics.kt`); add extraction in `ImageComposeSceneBackend.render`.
+- **Modify** `.../Report.kt` — `schemaVersion = 2`, new `ShotReport`/`Totals` fields, `SemanticsVerifyReport`.
+- **Modify** `.../BatchRunner.kt` — semantics params, consume `renderResult().semantics`, sidecars, semantics verify, totals.
+- **Modify** `.../cli/Cli.kt` — new options; single + batch handling; terse drift-only output.
+- **Modify** `.../DashboardGenerator.kt` — reflect semantics verdict + new totals.
+- **Modify** `redux-kotlin-snapshot/README.md` — flags table, typical loop, schemas, coordinate.
+- **Test files** under `redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/`: new `SemanticsTest.kt`, `SemanticsExtractionTest.kt`, `SemanticsDifferTest.kt`, `ReportTest.kt`; extend `BatchRunnerTest.kt`, `CliTest.kt`, `DashboardGeneratorTest.kt`.
+
+---
+
+### Task 1: Semantics data model + serialization
+
+Pure data + serializers. No Compose. Replaces the stub `SemanticsDump` (text-only) with `roots: List<Node>` + `texts`.
+
+**Files:**
+- Create: `redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/Semantics.kt`
+- Modify: `redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/RenderBackend.kt` (remove old `SemanticsDump`)
+- Test: `redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/SemanticsTest.kt`
+
+**Interfaces:**
+- Produces:
+  - `SemanticsDump.Node(role: String?, text: List<String>, contentDescription: List<String>, testTag: String?, enabled: Boolean?, selected: Boolean?, toggle: String?, children: List<Node>)` — `@Serializable`
+  - `SemanticsDump(roots: List<SemanticsDump.Node>, texts: List<String>)` with `fun toText(): String`, `fun toCanonicalJson(): String`, `companion object { val EMPTY }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `SemanticsTest.kt`:
+
+```kotlin
+package org.reduxkotlin.snapshot
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class SemanticsTest {
+    private fun leaf(text: String) = SemanticsDump.Node(
+        role = null, text = listOf(text), contentDescription = emptyList(),
+        testTag = null, enabled = null, selected = null, toggle = null, children = emptyList(),
+    )
+
+    private val sample = SemanticsDump(
+        roots = listOf(
+            SemanticsDump.Node(
+                role = "button", text = listOf("Save"), contentDescription = emptyList(),
+                testTag = "save", enabled = false, selected = null, toggle = null,
+                children = listOf(leaf("Icon")),
+            ),
+        ),
+        texts = listOf("Save", "Icon"),
+    )
+
+    @Test fun canonical_json_is_deterministic() {
+        assertEquals(sample.toCanonicalJson(), sample.toCanonicalJson())
+    }
+
+    @Test fun canonical_json_has_no_bounds_key() {
+        assertTrue("bounds" !in sample.toCanonicalJson())
+    }
+
+    @Test fun text_form_shows_fields_and_indents_children() {
+        val t = sample.toText()
+        assertTrue("role=button" in t, t)
+        assertTrue("Save" in t, t)
+        assertTrue("testTag=save" in t, t)
+        assertTrue("enabled=false" in t, t)
+        assertTrue("  " in t, "child should be indented") // 2-space indent
+    }
+
+    @Test fun empty_dump_text_and_json() {
+        assertEquals("(no semantics)", SemanticsDump.EMPTY.toText())
+        assertEquals("[]", SemanticsDump.EMPTY.toCanonicalJson().trim())
+        assertTrue(SemanticsDump.EMPTY.texts.isEmpty())
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.SemanticsTest"`
+Expected: compile failure (`SemanticsDump.Node` unresolved / `toText`/`toCanonicalJson` missing).
+
+- [ ] **Step 3: Remove the old `SemanticsDump` from `RenderBackend.kt`**
+
+Delete lines 9–23 of `RenderBackend.kt` (the KDoc + the old `public class SemanticsDump(... texts ...)` with its companion). Leave `RenderResult` (it still references `SemanticsDump` — same package). The file top keeps `@file:OptIn(...)` and the `RenderResult`/`RenderBackend`/`ImageComposeSceneBackend` declarations.
+
+- [ ] **Step 4: Create `Semantics.kt`**
+
+```kotlin
+package org.reduxkotlin.snapshot
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+
+/**
+ * A deterministic, bounds-free dump of a rendered scene's semantics, beside the pixels.
+ * Lets a consumer (e.g. an AI agent) assert content as text/JSON instead of reading the PNG.
+ * Ordering is by semantics-node id (owners) and layout order (children) — never pixel position —
+ * so the [toCanonicalJson] form is stable across architectures.
+ */
+public class SemanticsDump(
+    /** One tree per Compose `SemanticsOwner` (a Popup/Dialog gets its own). Empty when nothing captured. */
+    public val roots: List<Node>,
+    /** All rendered text strings, pre-order, flattened. Kept for simple text assertions. */
+    public val texts: List<String>,
+) {
+    /** One semantics node: its merged role/text/state plus merged children. Carries no bounds. */
+    @Serializable
+    public class Node(
+        /** Accessibility role, lowercased (e.g. `button`), or null. */
+        public val role: String?,
+        /** Text on this node, in order (a merge boundary absorbs descendants' text). */
+        public val text: List<String>,
+        /** Content descriptions on this node, in order. */
+        public val contentDescription: List<String>,
+        /** Test tag, or null. */
+        public val testTag: String?,
+        /** `false` when the node is marked disabled; otherwise null (tri-state: never `true`). */
+        public val enabled: Boolean?,
+        /** Selected state, or null if unspecified. */
+        public val selected: Boolean?,
+        /** Toggleable state name (`On`/`Off`/`Indeterminate`), or null. */
+        public val toggle: String?,
+        /** Merged child nodes, in layout order. */
+        public val children: List<Node>,
+    )
+
+    /** Compact indented tree — the default agent/human form. One node per line, 2-space indent per depth. */
+    public fun toText(): String {
+        if (roots.isEmpty()) return "(no semantics)"
+        val sb = StringBuilder()
+        roots.forEach { appendNode(it, 0, sb) }
+        return sb.toString().trimEnd('\n')
+    }
+
+    /** The single JSON form: pretty, stable field order, no bounds. Used for `--semantics-format json` and goldens. */
+    public fun toCanonicalJson(): String = CANONICAL.encodeToString(ListSerializer(Node.serializer()), roots)
+
+    private fun appendNode(n: Node, depth: Int, sb: StringBuilder) {
+        val indent = "  ".repeat(depth)
+        val fields = buildList {
+            n.role?.let { add("role=$it") }
+            if (n.text.isNotEmpty()) add("text=${n.text}")
+            if (n.contentDescription.isNotEmpty()) add("desc=${n.contentDescription}")
+            n.testTag?.let { add("testTag=$it") }
+            n.enabled?.let { add("enabled=$it") }
+            n.selected?.let { add("selected=$it") }
+            n.toggle?.let { add("toggle=$it") }
+        }
+        sb.append(indent).append("node").append(if (fields.isEmpty()) "" else " " + fields.joinToString(" ")).append('\n')
+        n.children.forEach { appendNode(it, depth + 1, sb) }
+    }
+
+    /** Shared instances. */
+    public companion object {
+        /** An empty dump (no semantics captured). */
+        public val EMPTY: SemanticsDump = SemanticsDump(roots = emptyList(), texts = emptyList())
+        private val CANONICAL = Json { prettyPrint = true; encodeDefaults = true; prettyPrintIndent = "  " }
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.SemanticsTest"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/Semantics.kt \
+        redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/RenderBackend.kt \
+        redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/SemanticsTest.kt
+git commit -m "feat(snapshot): semantics data model with text + canonical JSON forms"
+```
+
+---
+
+### Task 2: Extract semantics from the rendered scene
+
+Populate the dump inside the Skiko backend, after `scene.render()`, before `scene.close()`. Non-fatal on error.
+
+**Files:**
+- Modify: `redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/RenderBackend.kt`
+- Test: `redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/SemanticsExtractionTest.kt`
+
+**Interfaces:**
+- Consumes: `SemanticsDump`, `SemanticsDump.Node` (Task 1), `RenderSpec`, `RenderResult`.
+- Produces: `ImageComposeSceneBackend.render(spec)` now returns `RenderResult(png, populatedDump)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `SemanticsExtractionTest.kt`:
+
+```kotlin
+package org.reduxkotlin.snapshot
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class SemanticsExtractionTest {
+    private val richContent: @Composable () -> Unit = {
+        Column {
+            Text("Title")
+            Button(onClick = {}, enabled = false, modifier = Modifier.testTag("save")) { Text("Save") }
+            Text("Logo", modifier = Modifier.semantics { contentDescription = "logo image" })
+        }
+    }
+
+    private fun render() = ImageComposeSceneBackend().render(
+        RenderSpec(widthDp = 200, heightDp = 200, density = 2f, content = richContent),
+    ).semantics
+
+    @Test fun captures_text_in_traversal_order() {
+        val texts = render().texts
+        assertTrue("Title" in texts, texts.toString())
+        assertTrue("Save" in texts, texts.toString())
+    }
+
+    @Test fun button_node_carries_role_testTag_and_disabled() {
+        val dump = render()
+        val button = allNodes(dump).first { it.testTag == "save" }
+        assertEquals("button", button.role)
+        assertEquals(false, button.enabled)
+        assertTrue("Save" in button.text, button.text.toString())
+    }
+
+    @Test fun merged_tree_absorbs_the_buttons_text_child() {
+        val dump = render()
+        val button = allNodes(dump).first { it.testTag == "save" }
+        // The child Text("Save") is merged into the button; it is not a separate child node.
+        assertTrue(button.children.none { it.text == listOf("Save") }, "Text child should be absorbed")
+    }
+
+    @Test fun content_description_is_captured() {
+        assertTrue(allNodes(render()).any { it.contentDescription == listOf("logo image") })
+    }
+
+    @Test fun same_input_yields_identical_canonical_json() {
+        assertEquals(render().toCanonicalJson(), render().toCanonicalJson())
+    }
+
+    @Test fun text_free_scene_yields_empty_texts() {
+        // The 'counter' demo scene draws only bars, no semantics text.
+        val dump = ImageComposeSceneBackend().render(
+            RenderSpec(200, 200, 2f) {},
+        ).semantics
+        assertTrue(dump.texts.isEmpty())
+    }
+
+    private fun allNodes(dump: SemanticsDump): List<SemanticsDump.Node> {
+        val out = mutableListOf<SemanticsDump.Node>()
+        fun walk(n: SemanticsDump.Node) { out += n; n.children.forEach(::walk) }
+        dump.roots.forEach(::walk)
+        return out
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.SemanticsExtractionTest"`
+Expected: FAIL — dump is `EMPTY` (texts empty, no button node).
+
+- [ ] **Step 3: Add extraction to `RenderBackend.kt`**
+
+Add these imports under the existing ones:
+
+```kotlin
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+```
+
+Replace the body of `ImageComposeSceneBackend.render` so it captures semantics after render:
+
+```kotlin
+    override fun render(spec: RenderSpec): RenderResult {
+        val scene = ImageComposeScene(
+            width = spec.widthPx,
+            height = spec.heightPx,
+            density = Density(spec.density),
+        ) { spec.content() }
+        return try {
+            val png = scene.render().encodeToData(EncodedImageFormat.PNG)?.bytes
+                ?: error("PNG encode returned null")
+            RenderResult(png, extractSemantics(scene))
+        } finally {
+            scene.close()
+        }
+    }
+```
+
+Add, at the bottom of `ImageComposeSceneBackend` (or as file-private functions in the same file):
+
+```kotlin
+    // Reading the experimental semantics tree must never fail a render: pixels are the primary
+    // artifact. Any failure degrades to SemanticsDump.EMPTY while keeping the PNG.
+    @Suppress("TooGenericExceptionCaught")
+    private fun extractSemantics(scene: ImageComposeScene): SemanticsDump = try {
+        val roots = scene.semanticsOwners
+            .sortedBy { it.rootSemanticsNode.id }
+            .map { toNode(it.rootSemanticsNode) }
+        if (roots.isEmpty()) {
+            SemanticsDump.EMPTY
+        } else {
+            val texts = mutableListOf<String>()
+            roots.forEach { collectTexts(it, texts) }
+            SemanticsDump(roots, texts)
+        }
+    } catch (e: Exception) {
+        SemanticsDump.EMPTY
+    }
+
+    private fun toNode(n: SemanticsNode): SemanticsDump.Node {
+        val cfg = n.config
+        return SemanticsDump.Node(
+            role = cfg.getOrNull(SemanticsProperties.Role)?.toString()?.lowercase(),
+            text = cfg.getOrNull(SemanticsProperties.Text)?.map { it.text } ?: emptyList(),
+            contentDescription = cfg.getOrNull(SemanticsProperties.ContentDescription) ?: emptyList(),
+            testTag = cfg.getOrNull(SemanticsProperties.TestTag),
+            enabled = if (cfg.contains(SemanticsProperties.Disabled)) false else null,
+            selected = cfg.getOrNull(SemanticsProperties.Selected),
+            toggle = cfg.getOrNull(SemanticsProperties.ToggleableState)?.toString(),
+            children = n.children.map { toNode(it) },
+        )
+    }
+
+    private fun collectTexts(n: SemanticsDump.Node, out: MutableList<String>) {
+        out += n.text
+        n.children.forEach { collectTexts(it, out) }
+    }
+
+    // Public SemanticsConfiguration API is get(key) + contains(key); this pairs them safely.
+    private fun <T> SemanticsConfiguration.getOrNull(key: SemanticsPropertyKey<T>): T? =
+        if (contains(key)) get(key) else null
+```
+
+Note: `scene.semanticsOwners` is `@ExperimentalComposeUiApi`; the file already has `@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)`, so no extra annotation is needed.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.SemanticsExtractionTest"`
+Expected: PASS (6 tests). If `same_input_yields_identical_canonical_json` flakes, it indicates nondeterministic ordering — do NOT sort by anything pixel-derived; `id` order is correct.
+
+- [ ] **Step 5: Run the full module suite (guard the render/backend regression set)**
+
+Run: `./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.RenderBackendTest"`
+Expected: PASS (unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/RenderBackend.kt \
+        redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/SemanticsExtractionTest.kt
+git commit -m "feat(snapshot): extract merged semantics tree from the rendered scene"
+```
+
+---
+
+### Task 3: Semantics comparator (string equality + line diff)
+
+**Files:**
+- Create: `redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/SemanticsDiffer.kt`
+- Test: `redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/SemanticsDifferTest.kt`
+
+**Interfaces:**
+- Produces:
+  - `SemanticsDiffResult(result: String /* "match" | "mismatch" */, delta: List<String>)`
+  - `SemanticsDiffer(maxDeltaLines: Int = 40)` with `fun compare(golden: String, actual: String): SemanticsDiffResult`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `SemanticsDifferTest.kt`:
+
+```kotlin
+package org.reduxkotlin.snapshot
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class SemanticsDifferTest {
+    private val differ = SemanticsDiffer()
+
+    @Test fun equal_strings_match_with_no_delta() {
+        val r = differ.compare("a\nb\nc", "a\nb\nc")
+        assertEquals("match", r.result)
+        assertTrue(r.delta.isEmpty())
+    }
+
+    @Test fun changed_line_shows_removed_and_added() {
+        val r = differ.compare("""  "text": ["Save"]""", """  "text": ["Saved"]""")
+        assertEquals("mismatch", r.result)
+        assertTrue(r.delta.any { it.startsWith("-") && "Save" in it }, r.delta.toString())
+        assertTrue(r.delta.any { it.startsWith("+") && "Saved" in it }, r.delta.toString())
+    }
+
+    @Test fun delta_is_capped_with_overflow_marker() {
+        val golden = (1..100).joinToString("\n") { "g$it" }
+        val actual = (1..100).joinToString("\n") { "a$it" }
+        val r = SemanticsDiffer(maxDeltaLines = 10).compare(golden, actual)
+        assertEquals("mismatch", r.result)
+        assertEquals(11, r.delta.size) // 10 + overflow marker
+        assertTrue(r.delta.last().startsWith("…"), r.delta.last())
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.SemanticsDifferTest"`
+Expected: FAIL — `SemanticsDiffer` unresolved.
+
+- [ ] **Step 3: Create `SemanticsDiffer.kt`**
+
+```kotlin
+package org.reduxkotlin.snapshot
+
+/** Result of a semantics comparison: a lowercase [result] and a bounded, readable [delta]. */
+public class SemanticsDiffResult(
+    /** `match` when the canonical forms are equal, else `mismatch`. */
+    public val result: String,
+    /** Line-level delta (`-` golden-only, `+` actual-only); empty on match. Capped, may end with an overflow marker. */
+    public val delta: List<String>,
+)
+
+/**
+ * Compares two canonical semantics forms ([SemanticsDump.toCanonicalJson]) by string equality and,
+ * on mismatch, emits a bounded line diff. A structured per-node differ is intentionally deferred:
+ * the gate is equality, and the line diff is a readable-enough signal. Lines present in both forms
+ * are elided; a changed value line surfaces as a `-`/`+` pair.
+ */
+public class SemanticsDiffer(private val maxDeltaLines: Int = 40) {
+    /** Compares [golden] vs [actual] canonical strings. */
+    public fun compare(golden: String, actual: String): SemanticsDiffResult {
+        if (golden == actual) return SemanticsDiffResult("match", emptyList())
+        val g = golden.lines()
+        val a = actual.lines()
+        val gSet = g.toSet()
+        val aSet = a.toSet()
+        val lines = g.filter { it !in aSet }.map { "- $it" } + a.filter { it !in gSet }.map { "+ $it" }
+        val capped = if (lines.size > maxDeltaLines) {
+            lines.take(maxDeltaLines) + "… (${lines.size - maxDeltaLines} more)"
+        } else {
+            lines
+        }
+        return SemanticsDiffResult("mismatch", capped)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.SemanticsDifferTest"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/SemanticsDiffer.kt \
+        redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/SemanticsDifferTest.kt
+git commit -m "feat(snapshot): semantics comparator with capped line-diff delta"
+```
+
+---
+
+### Task 4: Report v2 (report types + totals)
+
+**Files:**
+- Modify: `redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/Report.kt`
+- Test: `redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/ReportTest.kt`
+
+**Interfaces:**
+- Produces (all `internal`):
+  - `SnapshotReport.schemaVersion == 2`
+  - `ShotReport(..., verifySemantics: SemanticsVerifyReport? = null, semanticsSidecar: String? = null, semanticsBytes: Int? = null)`
+  - `SemanticsVerifyReport(golden: String, result: String, delta: List<String>? = null)`
+  - `Totals(total, ok, failed, mismatched, missingGolden, semanticsMismatched = 0, semanticsMissingGolden = 0, semanticsMatched = 0, renderMsTotal = 0)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ReportTest.kt`:
+
+```kotlin
+package org.reduxkotlin.snapshot
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class ReportTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test fun schema_version_is_2() {
+        val r = SnapshotReport(runId = "r", outDir = "o", totals = Totals(0, 0, 0, 0, 0), shots = emptyList())
+        assertEquals(2, r.schemaVersion)
+    }
+
+    @Test fun new_shot_fields_default_to_null() {
+        val s = ShotReport(id = "a", scene = "counter", input = "preset=n0", status = "ok")
+        assertEquals(null, s.verifySemantics)
+        assertEquals(null, s.semanticsSidecar)
+        assertEquals(null, s.semanticsBytes)
+    }
+
+    @Test fun new_totals_fields_default_to_zero() {
+        val t = Totals(0, 0, 0, 0, 0)
+        assertEquals(0, t.semanticsMismatched)
+        assertEquals(0, t.semanticsMatched)
+        assertEquals(0L, t.renderMsTotal)
+    }
+
+    @Test fun v1_report_json_parses_under_v2_model() {
+        // A v1 file lacks the new fields; defaults fill them in.
+        val v1 = """{"schemaVersion":1,"runId":"r","outDir":"o",
+            "totals":{"total":1,"ok":1,"failed":0,"mismatched":0,"missingGolden":0},
+            "shots":[{"id":"a","scene":"counter","input":"preset=n0","status":"ok"}]}"""
+        val r = json.decodeFromString(SnapshotReport.serializer(), v1)
+        assertEquals(1, r.shots.size)
+        assertEquals(0, r.totals.semanticsMismatched)
+    }
+
+    @Test fun semantics_verify_report_round_trips() {
+        val sv = SemanticsVerifyReport(golden = "g.semantics.json", result = "mismatch", delta = listOf("- a", "+ b"))
+        val encoded = Json.encodeToString(SemanticsVerifyReport.serializer(), sv)
+        val decoded = json.decodeFromString(SemanticsVerifyReport.serializer(), encoded)
+        assertEquals("mismatch", decoded.result)
+        assertEquals(listOf("- a", "+ b"), decoded.delta)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.ReportTest"`
+Expected: FAIL — `schemaVersion` is 1, new fields/types missing.
+
+- [ ] **Step 3: Update `Report.kt`**
+
+Set `schemaVersion` default to `2`. Extend `Totals`, `ShotReport`, and add `SemanticsVerifyReport`:
+
+```kotlin
+/** Run roll-up counts. */
+@Serializable
+internal data class Totals(
+    val total: Int,
+    val ok: Int,
+    val failed: Int,
+    val mismatched: Int,
+    val missingGolden: Int,
+    val semanticsMismatched: Int = 0,
+    val semanticsMissingGolden: Int = 0,
+    val semanticsMatched: Int = 0,
+    val renderMsTotal: Long = 0,
+)
+
+/** One shot's result. [status] is `ok` or `error`; [verify]/[verifySemantics] present only when verifying. */
+@Serializable
+internal data class ShotReport(
+    val id: String,
+    val scene: String,
+    val input: String,
+    val theme: String? = null,
+    val sizePx: List<Int> = emptyList(),
+    val out: String? = null,
+    val bytes: Int? = null,
+    val renderMs: Long? = null,
+    val status: String,
+    val error: String? = null,
+    val verify: VerifyReport? = null,
+    val verifySemantics: SemanticsVerifyReport? = null,
+    val semanticsSidecar: String? = null,
+    val semanticsBytes: Int? = null,
+)
+
+/** Semantics golden comparison for one shot. [result] is `match` | `mismatch` | `missing-golden`. */
+@Serializable
+internal data class SemanticsVerifyReport(
+    val golden: String,
+    val result: String,
+    val delta: List<String>? = null,
+)
+```
+
+Change the `schemaVersion` field to `val schemaVersion: Int = 2,` in `SnapshotReport`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.ReportTest"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/Report.kt \
+        redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/ReportTest.kt
+git commit -m "feat(snapshot): report v2 with semantics verdict + measurement fields"
+```
+
+---
+
+### Task 5: BatchRunner — consume semantics, write sidecars, verify, aggregate totals
+
+**Files:**
+- Modify: `redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/BatchRunner.kt`
+- Test: `redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/BatchRunnerTest.kt` (extend)
+
+**Interfaces:**
+- Consumes: `SemanticsDump` (Task 1/2), `SemanticsDiffer`/`SemanticsDiffResult` (Task 3), `ShotReport`/`Totals`/`SemanticsVerifyReport` (Task 4).
+- Produces: `BatchRunner.run(manifest, outDir, verify, goldenDir, runId, semantics: Boolean = false, verifySemantics: Boolean = false, updateSemantics: Boolean = false, semanticsFormat: String = "text")` — writes `<id>.semantics.<ext>` sidecars, semantics goldens under `goldenDir` as `<id>.semantics.json`, and populated totals.
+
+- [ ] **Step 1: Write the failing test (append to `BatchRunnerTest.kt`)**
+
+First read the existing `BatchRunnerTest.kt` to reuse its `demoSnapshots` + tmp-dir setup, then add:
+
+```kotlin
+    @Test fun batch_writes_semantics_sidecars_when_requested() {
+        val manifest = BatchManifest(shots = listOf(ShotSpec(id = "d", scene = "demo", preset = "default")))
+        val outDir = newTmpDir()
+        val report = BatchRunner(demoSnapshots).run(
+            manifest, outDir, verify = false, goldenDir = null, runId = "r", semantics = true,
+        )
+        val sidecar = File(outDir, "d.semantics.txt")
+        assertTrue(sidecar.isFile, "sidecar missing")
+        assertEquals(sidecar.path, report.shots.single().semanticsSidecar)
+        assertTrue((report.shots.single().semanticsBytes ?: 0) > 0)
+    }
+
+    @Test fun semantics_verify_missing_golden_is_non_failing() {
+        val manifest = BatchManifest(shots = listOf(ShotSpec(id = "d", scene = "demo", preset = "default")))
+        val goldenDir = newTmpDir() // empty
+        val report = BatchRunner(demoSnapshots).run(
+            manifest, newTmpDir(), verify = false, goldenDir = goldenDir, runId = "r", verifySemantics = true,
+        )
+        assertEquals("missing-golden", report.shots.single().verifySemantics?.result)
+        assertEquals(0, report.totals.semanticsMismatched)
+    }
+
+    @Test fun update_semantics_writes_golden_then_verify_matches() {
+        val manifest = BatchManifest(shots = listOf(ShotSpec(id = "d", scene = "demo", preset = "default")))
+        val goldenDir = newTmpDir()
+        // 1) author baseline
+        BatchRunner(demoSnapshots).run(
+            manifest, newTmpDir(), verify = false, goldenDir = goldenDir, runId = "r", updateSemantics = true,
+        )
+        assertTrue(File(goldenDir, "d.semantics.json").isFile)
+        // 2) verify against it
+        val report = BatchRunner(demoSnapshots).run(
+            manifest, newTmpDir(), verify = false, goldenDir = goldenDir, runId = "r2", verifySemantics = true,
+        )
+        assertEquals("match", report.shots.single().verifySemantics?.result)
+        assertEquals(1, report.totals.semanticsMatched)
+    }
+
+    @Test fun totals_aggregate_render_ms() {
+        val manifest = BatchManifest(shots = listOf(ShotSpec(id = "d", scene = "demo", preset = "default")))
+        val report = BatchRunner(demoSnapshots).run(manifest, newTmpDir(), verify = false, goldenDir = null, runId = "r")
+        assertTrue(report.totals.renderMsTotal >= 0)
+    }
+```
+
+If `BatchRunnerTest.kt` has no `newTmpDir()` helper, add:
+
+```kotlin
+    private fun newTmpDir(): File = File.createTempFile("rkbatch", "").let { it.delete(); it.mkdirs(); it }
+```
+
+and imports: `import kotlin.test.assertEquals`, `import kotlin.test.assertTrue`, `import java.io.File` (if absent).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.BatchRunnerTest"`
+Expected: FAIL — `run(...)` has no `semantics`/`verifySemantics`/`updateSemantics` params.
+
+- [ ] **Step 3: Update `BatchRunner.kt`**
+
+Add a `SemanticsDiffer` to the constructor and extend `run`/`runShot`. New imports: none beyond existing (`java.io.File` already imported).
+
+Constructor:
+
+```kotlin
+internal class BatchRunner(
+    private val app: SnapshotApp,
+    private val backend: RenderBackend = ImageComposeSceneBackend(),
+    private val differ: Differ = Differ(),
+    private val semanticsDiffer: SemanticsDiffer = SemanticsDiffer(),
+) {
+```
+
+Replace `run(...)`:
+
+```kotlin
+    @Suppress("LongParameterList")
+    fun run(
+        manifest: BatchManifest,
+        outDir: File,
+        verify: Boolean,
+        goldenDir: File?,
+        runId: String,
+        semantics: Boolean = false,
+        verifySemantics: Boolean = false,
+        updateSemantics: Boolean = false,
+        semanticsFormat: String = "text",
+    ): SnapshotReport {
+        outDir.mkdirs()
+        val shots = manifest.shots.map {
+            runShot(it, manifest.defaults, outDir, verify, goldenDir, semantics, verifySemantics, updateSemantics, semanticsFormat)
+        }
+        return SnapshotReport(
+            runId = runId,
+            outDir = outDir.path,
+            totals = Totals(
+                total = shots.size,
+                ok = shots.count {
+                    it.status == "ok" && it.verify?.result != "mismatch" && it.verifySemantics?.result != "mismatch"
+                },
+                failed = shots.count { it.status == "error" },
+                mismatched = shots.count { it.verify?.result == "mismatch" },
+                missingGolden = shots.count { it.verify?.result == "missing-golden" },
+                semanticsMismatched = shots.count { it.verifySemantics?.result == "mismatch" },
+                semanticsMissingGolden = shots.count { it.verifySemantics?.result == "missing-golden" },
+                semanticsMatched = shots.count { it.verifySemantics?.result == "match" },
+                renderMsTotal = shots.sumOf { it.renderMs ?: 0 },
+            ),
+            shots = shots,
+        )
+    }
+```
+
+Replace `runShot(...)` so it captures the full `RenderResult` and handles semantics:
+
+```kotlin
+    @Suppress("TooGenericExceptionCaught", "LongParameterList")
+    private fun runShot(
+        spec: ShotSpec,
+        defaults: ManifestDefaults,
+        outDir: File,
+        verify: Boolean,
+        goldenDir: File?,
+        semantics: Boolean,
+        verifySemantics: Boolean,
+        updateSemantics: Boolean,
+        semanticsFormat: String,
+    ): ShotReport {
+        val inputDesc = if (spec.preset != null) "preset=${spec.preset}" else "json"
+        return try {
+            val input = when {
+                spec.preset != null -> SnapshotInput.Preset(spec.preset)
+                spec.stateJson != null -> SnapshotInput.Json(spec.stateJson)
+                else -> throw SnapshotException("shot '${spec.id}' needs 'preset' or 'stateJson'")
+            }
+            val shot = app.resolve(
+                spec.scene, input,
+                theme = spec.theme ?: defaults.theme,
+                width = spec.width ?: defaults.width,
+                height = spec.height ?: defaults.height,
+                density = spec.density ?: defaults.density,
+            )
+            val start = System.currentTimeMillis()
+            val result = app.renderResult(shot, backend)
+            val ms = System.currentTimeMillis() - start
+            val png = result.png
+            val outFile = File(outDir, spec.out ?: "${spec.id}.png").apply {
+                parentFile?.mkdirs()
+                writeBytes(png)
+            }
+            val canonical = result.semantics.toCanonicalJson()
+
+            if (updateSemantics && goldenDir != null) {
+                File(goldenDir, "${spec.id}.semantics.json").apply { parentFile?.mkdirs(); writeText(canonical) }
+            }
+            val sidecar = if (semantics) writeSidecar(spec, result.semantics, canonical, outDir, semanticsFormat) else null
+            val semVerify = if (verifySemantics) verifySemanticsShot(spec, canonical, goldenDir) else null
+
+            ShotReport(
+                id = spec.id, scene = spec.scene, input = inputDesc, theme = shot.theme,
+                sizePx = listOf(
+                    (shot.widthDp * shot.density).roundToInt(),
+                    (shot.heightDp * shot.density).roundToInt(),
+                ),
+                out = outFile.path, bytes = png.size, renderMs = ms, status = "ok",
+                verify = if (verify) verifyShot(spec, png, goldenDir, outDir) else null,
+                verifySemantics = semVerify,
+                semanticsSidecar = sidecar?.path,
+                semanticsBytes = if (semantics || verifySemantics) canonical.toByteArray().size else null,
+            )
+        } catch (e: Exception) {
+            ShotReport(id = spec.id, scene = spec.scene, input = inputDesc, status = "error", error = e.message)
+        }
+    }
+
+    private fun writeSidecar(spec: ShotSpec, dump: SemanticsDump, canonical: String, outDir: File, format: String): File {
+        val ext = if (format == "json") "semantics.json" else "semantics.txt"
+        val body = if (format == "json") canonical else dump.toText()
+        return File(outDir, "${spec.id}.$ext").apply { parentFile?.mkdirs(); writeText(body) }
+    }
+
+    private fun verifySemanticsShot(spec: ShotSpec, canonical: String, goldenDir: File?): SemanticsVerifyReport {
+        val goldenFile = File(goldenDir ?: File("."), "${spec.id}.semantics.json")
+        val golden = goldenFile.takeIf { it.isFile }?.readText()
+            ?: return SemanticsVerifyReport(goldenFile.path, "missing-golden")
+        val r = semanticsDiffer.compare(golden, canonical)
+        return SemanticsVerifyReport(goldenFile.path, r.result, r.delta.takeIf { it.isNotEmpty() })
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.BatchRunnerTest"`
+Expected: PASS (existing + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/BatchRunner.kt \
+        redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/BatchRunnerTest.kt
+git commit -m "feat(snapshot): batch semantics sidecars, golden verify, and totals"
+```
+
+---
+
+### Task 6: CLI single-shot semantics options
+
+**Files:**
+- Modify: `redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/cli/Cli.kt`
+- Test: `redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/CliTest.kt` (extend)
+
+**Interfaces:**
+- Consumes: `SemanticsDiffer` (Task 3), `RenderResult.semantics`, `SemanticsDump.toText/toCanonicalJson` (Task 1).
+- Produces: single-shot flags `--semantics`, `--semantics-format`, `--verify-semantics-file`, `--update-semantics`.
+
+- [ ] **Step 1: Write the failing test (append to `CliTest.kt`)**
+
+```kotlin
+    @Test fun single_semantics_text_prints_dump() {
+        val r = snapshotCommand(demoSnapshots)
+            .test(listOf("--scene", "demo", "--preset", "default", "--semantics"))
+        assertEquals(0, r.statusCode, r.output)
+        assertTrue("node" in r.output, r.output)
+    }
+
+    @Test fun single_semantics_json_prints_json() {
+        val r = snapshotCommand(demoSnapshots)
+            .test(listOf("--scene", "demo", "--preset", "default", "--semantics", "--semantics-format", "json"))
+        assertEquals(0, r.statusCode, r.output)
+        assertTrue(r.output.trimStart().startsWith("["), r.output)
+    }
+
+    @Test fun update_semantics_then_verify_matches() {
+        val golden = File(tmp, "demo.semantics.json")
+        val g = snapshotCommand(demoSnapshots).test(
+            listOf("--scene", "demo", "--preset", "default", "--update-semantics", "--verify-semantics-file", golden.path),
+        )
+        assertEquals(0, g.statusCode, g.output)
+        assertTrue(golden.isFile)
+        val v = snapshotCommand(demoSnapshots).test(
+            listOf("--scene", "demo", "--preset", "default", "--verify-semantics-file", golden.path),
+        )
+        assertEquals(0, v.statusCode, v.output)
+        assertTrue("match" in v.output, v.output)
+    }
+
+    @Test fun verify_semantics_mismatch_exits_1() {
+        val golden = File(tmp, "wrong.semantics.json").apply { writeText("[]") }
+        val r = snapshotCommand(demoSnapshots).test(
+            listOf("--scene", "demo", "--preset", "default", "--verify-semantics-file", golden.path),
+        )
+        assertEquals(1, r.statusCode, r.output)
+        assertTrue("mismatch" in r.output, r.output)
+    }
+
+    @Test fun update_semantics_without_file_exits_2() {
+        val r = snapshotCommand(demoSnapshots)
+            .test(listOf("--scene", "demo", "--preset", "default", "--update-semantics"))
+        assertEquals(2, r.statusCode, r.output)
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.CliTest"`
+Expected: FAIL — new options unrecognized (Clikt exits 2 / no such option).
+
+- [ ] **Step 3: Update `Cli.kt` (single-shot path)**
+
+Add imports:
+
+```kotlin
+import com.github.ajalt.clikt.parameters.types.choice
+import org.reduxkotlin.snapshot.SemanticsDiffer
+```
+
+Add options to `SnapshotCommand` (beside the existing ones):
+
+```kotlin
+    private val semantics by option("--semantics", help = "Emit the semantics dump (stdout single; sidecar batch)").flag()
+    private val semanticsFormat by option("--semantics-format", help = "Dump format")
+        .choice("json", "text").default("text")
+    private val verifySemanticsFile by option(
+        "--verify-semantics-file", help = "Semantics golden to compare against (single shot)",
+    ).file()
+    private val verifySemantics by option(
+        "--verify-semantics", help = "Enable the semantics golden gate (batch; needs --golden-dir)",
+    ).flag()
+    private val updateSemantics by option(
+        "--update-semantics", help = "Write/update semantics golden(s), then exit 0",
+    ).flag()
+```
+
+Change `runSingle` to capture the full result and handle semantics. Replace the render block and add semantics handling before the final `out?.let { ... }`:
+
+```kotlin
+        val result = try {
+            val shot = app.resolve(sceneName, input, theme, width, height, null)
+            app.renderResult(shot, BACKEND)
+        } catch (e: SnapshotException) {
+            throw CliktError(e.message ?: "usage error", cause = e, statusCode = 2)
+        } catch (e: Exception) {
+            throw CliktError("render failed: ${e.message}", cause = e, statusCode = 1)
+        }
+        val png = result.png
+        out?.apply {
+            parentFile?.mkdirs()
+            writeBytes(png)
+        }
+
+        val canonical = result.semantics.toCanonicalJson()
+        if (updateSemantics) {
+            val golden = verifySemanticsFile
+                ?: throw CliktError("--update-semantics needs --verify-semantics-file", statusCode = 2)
+            golden.parentFile?.mkdirs()
+            golden.writeText(canonical)
+            echo("wrote semantics golden ${golden.path}")
+            return
+        }
+        if (semantics) {
+            val dump = if (semanticsFormat == "json") canonical else result.semantics.toText()
+            out?.let { File(it.path + if (semanticsFormat == "json") ".semantics.json" else ".semantics.txt").writeText(dump) }
+            echo(dump)
+        }
+        verifySemanticsFile?.let { golden ->
+            if (!golden.isFile) {
+                throw CliktError(
+                    "--verify-semantics-file golden not found: ${golden.absolutePath}\n" +
+                        "  Generate it first with --update-semantics --verify-semantics-file ${golden.path}.",
+                    statusCode = 2,
+                )
+            }
+            val r = SemanticsDiffer().compare(golden.readText(), canonical)
+            echo("verify-semantics: ${r.result}")
+            if (r.result == "mismatch") {
+                r.delta.forEach { echo(it) }
+                throw CliktError("semantics golden mismatch", statusCode = 1)
+            }
+        }
+```
+
+Keep the existing pixel `verify?.let { ... }` block and the final `out?.let { echo("wrote ...") }`. (The `--verify` pixel path continues to use `png`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.CliTest"`
+Expected: PASS (existing + 5 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/cli/Cli.kt \
+        redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/CliTest.kt
+git commit -m "feat(snapshot): single-shot --semantics / --verify-semantics-file / --update-semantics"
+```
+
+---
+
+### Task 7: CLI batch semantics + terse drift-only output
+
+**Files:**
+- Modify: `redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/cli/Cli.kt`
+- Test: `redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/CliTest.kt` (extend)
+
+**Interfaces:**
+- Consumes: `BatchRunner.run(... semantics, verifySemantics, updateSemantics, semanticsFormat)` (Task 5), the new options (Task 6).
+- Produces: batch `--semantics` writes sidecars; `--verify-semantics` requires `--golden-dir` (exit 2 otherwise) and gates exit 1; terse drift-only summary lines.
+
+- [ ] **Step 1: Write the failing test (append to `CliTest.kt`)**
+
+```kotlin
+    @Test fun batch_verify_semantics_without_golden_dir_exits_2() {
+        val manifest = File(tmp, "vs.json").apply {
+            writeText("""{"shots":[{"id":"a","scene":"demo","preset":"default"}]}""")
+        }
+        val r = snapshotCommand(demoSnapshots)
+            .test(listOf("--batch", manifest.path, "--out-dir", File(tmp, "vsout").path, "--verify-semantics"))
+        assertEquals(2, r.statusCode, r.output)
+    }
+
+    @Test fun batch_semantics_writes_sidecars() {
+        val manifest = File(tmp, "sc.json").apply {
+            writeText("""{"shots":[{"id":"a","scene":"demo","preset":"default"}]}""")
+        }
+        val outDir = File(tmp, "scout")
+        val r = snapshotCommand(demoSnapshots)
+            .test(listOf("--batch", manifest.path, "--out-dir", outDir.path, "--semantics"))
+        assertEquals(0, r.statusCode, r.output)
+        assertTrue(File(outDir, "a.semantics.txt").isFile)
+    }
+
+    @Test fun batch_semantics_mismatch_exits_1_and_lists_drifted() {
+        val goldenDir = File(tmp, "sg").apply { mkdirs() }
+        File(goldenDir, "a.semantics.json").writeText("[]") // wrong baseline -> drift
+        val manifest = File(tmp, "sm.json").apply {
+            writeText("""{"shots":[{"id":"a","scene":"demo","preset":"default"}]}""")
+        }
+        val r = snapshotCommand(demoSnapshots).test(
+            listOf(
+                "--batch", manifest.path, "--out-dir", File(tmp, "smout").path,
+                "--golden-dir", goldenDir.path, "--verify-semantics",
+            ),
+        )
+        assertEquals(1, r.statusCode, r.output)
+        assertTrue("a" in r.output && "mismatch" in r.output, r.output)
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.CliTest"`
+Expected: FAIL — batch ignores the new flags (no exit-2 guard, no sidecars, no gating).
+
+- [ ] **Step 3: Update `runBatch` in `Cli.kt`**
+
+Add a guard + pass the new params + terse output. Replace `runBatch`:
+
+```kotlin
+    private fun runBatch(file: File) {
+        requireManifest(file)
+        if (verifySemantics && goldenDir == null) {
+            throw CliktError("--verify-semantics needs --golden-dir", statusCode = 2)
+        }
+        if (updateSemantics && goldenDir == null) {
+            throw CliktError("--update-semantics (batch) needs --golden-dir", statusCode = 2)
+        }
+        val manifest = try {
+            Json.decodeFromString(BatchManifest.serializer(), file.readText())
+        } catch (e: SerializationException) {
+            throw CliktError("invalid --batch manifest: ${e.message}", cause = e, statusCode = 2)
+        }
+        val runId = "run-${System.currentTimeMillis()}"
+        val report = BatchRunner(app, BACKEND).run(
+            manifest, outDir, verify = goldenDir != null, goldenDir, runId,
+            semantics = semantics, verifySemantics = verifySemantics,
+            updateSemantics = updateSemantics, semanticsFormat = semanticsFormat,
+        )
+        val json = Json { prettyPrint = true }.encodeToString(SnapshotReport.serializer(), report)
+        File(outDir, "report.json").apply {
+            parentFile?.mkdirs()
+            writeText(json)
+        }
+        if (dashboard) {
+            val index = DashboardGenerator.generate(report, outDir)
+            if (!jsonMode) echo("dashboard: ${index.path}")
+        }
+        if (jsonMode) {
+            echo(json)
+        } else {
+            val t = report.totals
+            echo(
+                "batch: ${t.ok}/${t.total} ok, ${t.failed} failed, ${t.mismatched} mismatched, " +
+                    "${t.semanticsMismatched} semantics-mismatched -> ${outDir.path}",
+            )
+            report.shots.filter {
+                it.status == "error" || it.verify?.result == "mismatch" || it.verifySemantics?.result == "mismatch"
+            }.forEach { s ->
+                echo("  drift ${s.id}: pixel=${s.verify?.result ?: "-"} semantics=${s.verifySemantics?.result ?: "-"} " +
+                    "png=${s.out ?: "-"} diff=${s.verify?.diffImage ?: "-"} sidecar=${s.semanticsSidecar ?: "-"}")
+                s.verifySemantics?.delta?.forEach { echo("    $it") }
+            }
+        }
+        if (report.totals.failed > 0 || report.totals.mismatched > 0 || report.totals.semanticsMismatched > 0) {
+            throw CliktError(
+                "batch had ${report.totals.failed} failed / ${report.totals.mismatched} mismatched / " +
+                    "${report.totals.semanticsMismatched} semantics-mismatched",
+                statusCode = 1,
+            )
+        }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.CliTest"`
+Expected: PASS (existing + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/cli/Cli.kt \
+        redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/CliTest.kt
+git commit -m "feat(snapshot): batch semantics gate + terse drift-only output"
+```
+
+---
+
+### Task 8: Dashboard reflects the semantics verdict
+
+Prevents a semantics-only mismatch rendering as a green card while the process exits 1.
+
+**Files:**
+- Modify: `redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/DashboardGenerator.kt`
+- Test: `redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/DashboardGeneratorTest.kt` (extend)
+
+**Interfaces:**
+- Consumes: `SnapshotReport`/`ShotReport.verifySemantics`/`Totals` (Task 4).
+- Produces: `index.html` mentions the semantics verdict for drifted shots + the `semanticsMismatched` total.
+
+- [ ] **Step 1: Read `DashboardGenerator.kt` and its test**
+
+Read both files to learn the current HTML shape (how a shot card and the totals row are built) before editing. The exact string-building style must be matched.
+
+- [ ] **Step 2: Write the failing test (append to `DashboardGeneratorTest.kt`)**
+
+```kotlin
+    @Test fun dashboard_shows_semantics_mismatch() {
+        val report = SnapshotReport(
+            runId = "r", outDir = "o",
+            totals = Totals(total = 1, ok = 0, failed = 0, mismatched = 0, missingGolden = 0, semanticsMismatched = 1),
+            shots = listOf(
+                ShotReport(
+                    id = "a", scene = "demo", input = "preset=default", status = "ok",
+                    verifySemantics = SemanticsVerifyReport("a.semantics.json", "mismatch", listOf("- x", "+ y")),
+                ),
+            ),
+        )
+        val outDir = File.createTempFile("dash", "").let { it.delete(); it.mkdirs(); it }
+        val html = DashboardGenerator.generate(report, outDir).readText()
+        assertTrue("semantics" in html.lowercase(), "should mention semantics")
+        assertTrue("mismatch" in html, "should show the semantics verdict")
+    }
+```
+
+- [ ] **Step 3: Update `DashboardGenerator.kt`**
+
+Following the file's existing HTML-building style, (a) include `semanticsMismatched` in the totals row, and (b) for each shot with `verifySemantics != null`, render its `result` (and, when `mismatch`, treat the card as failing rather than green). Because the exact template is file-specific, mirror how the pixel `verify.result` is already rendered and add a parallel `verifySemantics.result` line/badge. Do not remove existing pixel rendering.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :redux-kotlin-snapshot:test --tests "org.reduxkotlin.snapshot.DashboardGeneratorTest"`
+Expected: PASS (existing + 1 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/DashboardGenerator.kt \
+        redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/DashboardGeneratorTest.kt
+git commit -m "feat(snapshot): surface semantics verdict in the dashboard"
+```
+
+---
+
+### Task 9: Docs, API dump, version reconcile, publish verification
+
+No new behavior; wraps up the public surface, docs, and the publish path. Ends with the full module suite green.
+
+**Files:**
+- Modify: `redux-kotlin-snapshot/README.md`
+- Modify: `redux-kotlin-snapshot/api/redux-kotlin-snapshot.api` (regenerated)
+- Read: `gradle.properties`, `CHANGELOG.md` (version reconcile note)
+
+- [ ] **Step 1: Regenerate the API dump**
+
+Run: `./gradlew apiDump`
+Then confirm the new public types are present:
+Run: `grep -E "Semantics(Dump|Differ|DiffResult)" redux-kotlin-snapshot/api/redux-kotlin-snapshot.api`
+Expected: entries for `SemanticsDump`, `SemanticsDump$Node`, `SemanticsDiffer`, `SemanticsDiffResult`, and the updated `SemanticsDump` constructor (now `(List;List;)V`).
+
+- [ ] **Step 2: Verify the API check passes**
+
+Run: `./gradlew :redux-kotlin-snapshot:apiCheck`
+Expected: PASS (no drift after the dump).
+
+- [ ] **Step 3: Update `README.md`**
+
+Read the current README first, then add/extend, matching its style:
+1. **Flags table** rows for: `--semantics`, `--semantics-format json|text`, `--verify-semantics-file <file>` (single), `--verify-semantics` (batch, needs `--golden-dir`), `--update-semantics`.
+2. A **"Semantics for AI agents"** section with the typical loop:
+   - Author baselines: `rk snapshot --batch shots.json --golden-dir goldens --update-semantics`
+   - Gate: `rk snapshot --batch shots.json --out-dir out --golden-dir goldens --verify-semantics` → exit 1 + terse drift lines when something changed; the agent reads `out/<id>.semantics.txt` (or the `.diff.png`) only for drifted shots.
+   - Single dump: `rk snapshot --scene demo --preset default --semantics` (text) or `--semantics-format json`.
+3. **Dump JSON schema:** document the `Node` object fields (`role, text, contentDescription, testTag, enabled, selected, toggle, children`) and that the top level is a JSON array of roots, no bounds.
+4. **Report v2 schema:** note `schemaVersion: 2`, the new `ShotReport` fields (`verifySemantics`, `semanticsSidecar`, `semanticsBytes`) and `Totals` fields (`semanticsMismatched`, `semanticsMissingGolden`, `semanticsMatched`, `renderMsTotal`); note consumers should read with `ignoreUnknownKeys = true`.
+5. **Consuming from Maven Central:** the coordinate `org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha03` with a Gradle snippet:
+   ```kotlin
+   repositories { mavenCentral() }
+   dependencies { implementation("org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha03") }
+   ```
+   plus a note that scene authoring transitively pulls Compose/clikt/serialization (`api` deps).
+6. A **version note:** `1.0.0-SNAPSHOT` is the `master` baseline; released artifacts ride the shared release-tag line with the CLI (next: `1.0.0-alpha03`).
+
+- [ ] **Step 4: Verify a local publish resolves (artifact + POM + jars)**
+
+Run: `./gradlew :redux-kotlin-snapshot:publishToMavenLocal`
+Then confirm the coordinate landed with sources + javadoc jars:
+Run: `ls ~/.m2/repository/org/reduxkotlin/redux-kotlin-snapshot/1.0.0-SNAPSHOT/`
+Expected: a `.pom`, the main `.jar`, `-sources.jar`, and `-javadoc.jar` (the local publish uses the `1.0.0-SNAPSHOT` baseline; the released `alpha03` coordinate is produced by CI on the maintainer tag push — a follow-up action, not run here).
+
+- [ ] **Step 5: Run the full module test suite**
+
+Run: `./gradlew :redux-kotlin-snapshot:test`
+Expected: PASS (all classes).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add redux-kotlin-snapshot/README.md redux-kotlin-snapshot/api/redux-kotlin-snapshot.api
+git commit -m "docs(snapshot): document semantics flags, schemas, and Maven Central coordinate; apiDump"
+```
+
+---
+
+## Release follow-up (maintainer, out of band)
+
+Cutting `org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha03` to Maven Central is a signed CI publish triggered by a maintainer tag push (`-Pversion=1.0.0-alpha03`, `signingInMemoryKey` present). Not performed by this plan. Confirm the snapshot module is in the release publish set when the tag is cut.
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+- §A extraction → Tasks 1–2. §B canonical + line diff → Tasks 1 (canonical) + 3 (diff). §C CLI → Tasks 6–7. §D report v2 + terse output + measurement → Tasks 4, 5, 7. §E publish/version → Task 9. Docs → Task 9. Testing → every task's TDD steps + explicit multi-owner/empty/back-compat/merged-absorption/determinism cases.
+- Multi-owner: modeled as `roots: List<Node>` (Task 1) and ordered by `id` (Task 2). A dedicated Popup/Dialog owner-ordering test is **not** asserted because headless `ImageComposeScene` owner population for popups is unverified; the `roots` list + `id` sort are correct for the single-owner case and cost nothing if a second owner appears. If, during Task 2, a Popup fixture is found to populate a second owner, add the ordering test there.
+
+**Placeholder scan:** No TBD/TODO. Task 8 step 3 and Task 9 step 3 describe edits against file-specific templates (dashboard HTML / README prose) rather than pasting full replacements, because the exact current content must be read first; each names the precise fields/rows to add.
+
+**Type consistency:** `SemanticsDump(roots, texts)`, `SemanticsDump.Node(...)`, `toCanonicalJson()`/`toText()`, `SemanticsDiffer.compare(golden, actual): SemanticsDiffResult(result, delta)`, `SemanticsVerifyReport(golden, result, delta)`, and `BatchRunner.run(..., semantics, verifySemantics, updateSemantics, semanticsFormat)` are used identically across tasks.

--- a/docs/superpowers/plans/2026-07-01-snapshot-semantics-and-publish.md
+++ b/docs/superpowers/plans/2026-07-01-snapshot-semantics-and-publish.md
@@ -1229,20 +1229,20 @@ Read the current README first, then add/extend, matching its style:
    - Single dump: `rk snapshot --scene demo --preset default --semantics` (text) or `--semantics-format json`.
 3. **Dump JSON schema:** document the `Node` object fields (`role, text, contentDescription, testTag, enabled, selected, toggle, children`) and that the top level is a JSON array of roots, no bounds.
 4. **Report v2 schema:** note `schemaVersion: 2`, the new `ShotReport` fields (`verifySemantics`, `semanticsSidecar`, `semanticsBytes`) and `Totals` fields (`semanticsMismatched`, `semanticsMissingGolden`, `semanticsMatched`, `renderMsTotal`); note consumers should read with `ignoreUnknownKeys = true`.
-5. **Consuming from Maven Central:** the coordinate `org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha03` with a Gradle snippet:
+5. **Consuming from Maven Central:** the coordinate `org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha04` with a Gradle snippet:
    ```kotlin
    repositories { mavenCentral() }
-   dependencies { implementation("org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha03") }
+   dependencies { implementation("org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha04") }
    ```
    plus a note that scene authoring transitively pulls Compose/clikt/serialization (`api` deps).
-6. A **version note:** `1.0.0-SNAPSHOT` is the `master` baseline; released artifacts ride the shared release-tag line with the CLI (next: `1.0.0-alpha03`).
+6. A **version note:** `1.0.0-SNAPSHOT` is the `master` baseline; released artifacts ride the shared release-tag line with the CLI (next: `1.0.0-alpha04`).
 
 - [ ] **Step 4: Verify a local publish resolves (artifact + POM + jars)**
 
 Run: `./gradlew :redux-kotlin-snapshot:publishToMavenLocal`
 Then confirm the coordinate landed with sources + javadoc jars:
 Run: `ls ~/.m2/repository/org/reduxkotlin/redux-kotlin-snapshot/1.0.0-SNAPSHOT/`
-Expected: a `.pom`, the main `.jar`, `-sources.jar`, and `-javadoc.jar` (the local publish uses the `1.0.0-SNAPSHOT` baseline; the released `alpha03` coordinate is produced by CI on the maintainer tag push — a follow-up action, not run here).
+Expected: a `.pom`, the main `.jar`, `-sources.jar`, and `-javadoc.jar` (the local publish uses the `1.0.0-SNAPSHOT` baseline; the released `alpha04` coordinate is produced by CI on the maintainer tag push — a follow-up action, not run here).
 
 - [ ] **Step 5: Run the full module test suite**
 
@@ -1260,7 +1260,7 @@ git commit -m "docs(snapshot): document semantics flags, schemas, and Maven Cent
 
 ## Release follow-up (maintainer, out of band)
 
-Cutting `org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha03` to Maven Central is a signed CI publish triggered by a maintainer tag push (`-Pversion=1.0.0-alpha03`, `signingInMemoryKey` present). Not performed by this plan. Confirm the snapshot module is in the release publish set when the tag is cut.
+Cutting `org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha04` to Maven Central is a signed CI publish triggered by a maintainer tag push (`-Pversion=1.0.0-alpha04`, `signingInMemoryKey` present). Not performed by this plan. Confirm the snapshot module is in the release publish set when the tag is cut.
 
 ## Self-Review (completed by plan author)
 

--- a/docs/superpowers/specs/2026-07-01-snapshot-semantics-and-publish-design.md
+++ b/docs/superpowers/specs/2026-07-01-snapshot-semantics-and-publish-design.md
@@ -1,0 +1,227 @@
+# redux-kotlin-snapshot: semantics dump, semantics-golden, publish — design
+
+**Date:** 2026-07-01
+**Module:** `redux-kotlin-snapshot` (+ its `rk snapshot` / `runCli` surface)
+**Status:** design, pending approval
+
+## Goal
+
+Complete the capabilities that make `redux-kotlin-snapshot` valuable to an **AI-agent
+dev loop**. The module already renders `f(state) → Composable → PNG (+ pixel golden diff)`
+headlessly via Compose `ImageComposeScene` (Skiko, JVM-only). Pixels work; the
+agent-facing capabilities are stubbed or missing.
+
+### Driving use case
+
+An external KMP app (Compose Multiplatform, `commonMain` UI, redux-kotlin store)
+registers scenes via `snapshotApp {}` and runs its own CLI via `SnapshotApp.runCli(argv)`.
+A coding agent verifies UI changes cheaply. Today it must `Read` PNGs (~1–2k vision
+tokens each, every iteration). Two capabilities eliminate most of that cost:
+
+1. A **text semantics dump** of the rendered scene — read content as text, not pixels.
+2. **Golden-diff-as-gate** — a text verdict per shot so the agent reads a PNG only when a
+   shot actually drifted.
+
+## Scope
+
+One spec covering all four gaps plus a forward-compat seam:
+
+- **A.** Real semantics extraction (the P0 gap).
+- **B.** Canonical semantics form + structural diff.
+- **C.** CLI surface for semantics (single + batch), exit-code contract preserved.
+- **D.** Batch report exposes dump + semantics verdict.
+- **E.** Maven Central publish + version reconciliation.
+- **F.** Live-view seam (per-shot emission + `events.ndjson`) — enables a *future* live
+  web view without reshaping the batch loop later. The web server / live HTML itself is
+  **out of scope** (future feature).
+
+## Verified technical facts (Compose MP 1.11.1)
+
+Confirmed against resolved artifacts, not training data:
+
+- **Versions:** Kotlin 2.3.20, compose-multiplatform 1.11.1, Skiko 0.144.6, JDK
+  toolchain 17. `androidx.compose.ui` = JetBrains 1.11.1.
+- **Semantics access path is public + experimental, no reflection, no internal `$ui`
+  access, no new `compose-ui-test` dependency:**
+  - `ImageComposeScene.semanticsOwners: Collection<SemanticsOwner>` — `@ExperimentalComposeUiApi`,
+    populated during composition, readable after `scene.render()` before `scene.close()`.
+  - `SemanticsOwner.rootSemanticsNode: SemanticsNode` (merged) and `unmergedRootSemanticsNode`.
+  - `SemanticsNode.config: SemanticsConfiguration` (public, merged), `.children: List<SemanticsNode>`
+    (public), `.boundsInRoot: Rect` / `.boundsInWindow` (public), `.id`, `.isRoot`.
+  - `SemanticsConfiguration` is iterable and exposes `get`/`contains` by key.
+  - `SemanticsProperties.Text` (`List<AnnotatedString>`), `.ContentDescription`
+    (`List<String>`), `.Role` (`Role`), `.TestTag` (`String`), plus `Disabled`, `Selected`,
+    `ToggleableState`.
+  - `ImageComposeScene` is **not** deprecated (only its old `render(Duration)` overload is);
+    no need to migrate to `androidx.compose.ui.scene.ComposeScene`.
+- **Publishing is already wired to Maven Central.** `convention.publishing-jvm` applies
+  `com.vanniktech.maven.publish` with `publishToMavenCentral(automaticRelease = true)` and
+  `signAllPublications()` (CI-only, gated on `signingInMemoryKey`). Coordinates
+  `org.reduxkotlin:redux-kotlin-snapshot:<version>`; `version`/`group` inherited from root
+  (`1.0.0-SNAPSHOT`, `org.reduxkotlin`). Release tags set `-Pversion=<tag>` (CLI is at
+  `1.0.0-alpha02`).
+
+## A. Semantics extraction
+
+New file `Semantics.kt`. The `SemanticsDump` scaffold in `RenderBackend.kt` is expanded.
+
+### Data model
+
+`SemanticsDump.Node` (nested to avoid clashing with Compose's `androidx.compose.ui.semantics.SemanticsNode`):
+
+```
+@Serializable
+class Node(
+    val role: String?,                 // Role enum name, lowercased; null if absent
+    val text: List<String>,            // AnnotatedString.text on this node, in order
+    val contentDescription: List<String>,
+    val testTag: String?,
+    val enabled: Boolean?,             // false when SemanticsProperties.Disabled present; null if unspecified
+    val selected: Boolean?,            // SemanticsProperties.Selected; null if absent
+    val toggle: String?,               // ToggleableState name (On/Off/Indeterminate); null if absent
+    val bounds: List<Int>?,            // [left, top, right, bottom] rounded; see determinism
+    val children: List<Node>,
+)
+
+class SemanticsDump(
+    val root: Node?,                   // null when nothing captured
+    val texts: List<String>,           // flat, traversal order — kept for back-compat
+) {
+    fun toJson(): String
+    fun toText(): String               // compact indented tree
+    companion object { val EMPTY = SemanticsDump(root = null, texts = emptyList()) }
+}
+```
+
+`RenderResult(png, semantics)` is unchanged in shape; `semantics` is now populated.
+
+### Extraction
+
+In `ImageComposeSceneBackend.render`, after `scene.render()` and before `scene.close()`:
+
+1. Read `scene.semanticsOwners`; sort deterministically (by root `boundsInWindow` top, then
+   left) so popups/dialogs order stably.
+2. For each owner, take `rootSemanticsNode` (**merged** tree — matches the compose-ui-test
+   default, carries `Role`; unmerged is deferred, YAGNI).
+3. Recurse `node.children` (public, layout order — deterministic), reading
+   `node.config[SemanticsProperties.*]` for each field. `bounds` from `boundsInRoot`, rounded
+   to ints.
+4. Build the flat `texts` list from a pre-order walk (back-compat with the current field).
+
+Requires only `@OptIn(ExperimentalComposeUiApi::class)`.
+
+### Determinism
+
+- Ordering is deterministic by construction (stable owner sort + layout child order).
+- **Bounds vary across arch/rounding** (dev arm64 vs CI x64). The `Node.bounds` field is
+  populated in memory but is **excluded from the canonical form** (§B) and from any
+  semantics-golden, so goldens are arch-independent. Bounds are serialized to JSON output
+  only when explicitly requested (`--bounds`), for debugging.
+
+## B. Canonical form + structural diff
+
+New file `SemanticsDiffer.kt`.
+
+- **Canonical form:** a deterministic serialization of the `Node` tree with **`bounds`
+  omitted** and a fixed field order (kotlinx JSON over the data classes; field order is
+  stable). This string is what a semantics golden stores.
+- **Diff:** parse golden + actual canonical trees, walk by node path, emit a readable
+  line-level delta:
+  - `+ <path> <node summary>` — node added
+  - `- <path> <node summary>` — node removed
+  - `~ <path> <field>: <old> → <new>` — field changed
+- Verdict: `match` when the canonical strings are equal; otherwise `mismatch` with the
+  delta lines. `missing-golden` when the golden file is absent (mirrors pixel verify).
+
+## C. CLI surface (`cli/Cli.kt`)
+
+Existing flags, `--list` shape, batch manifest, and exit codes (0 ok / 1 render-or-verify
+failure / 2 usage) are unchanged. `runCli` → `exitProcess(0)` contract preserved.
+
+### Single shot (`runSingle`)
+
+- `--semantics[=json|text]` (optional value, default `json`): after render, print the dump
+  to stdout; or, when `--out` is given, write a sidecar `<out>.semantics.json` /
+  `<out>.semantics.txt`.
+- `--verify-semantics <file>`: compare the rendered canonical form against the golden file;
+  print verdict + delta; exit 1 on mismatch. Independent of the pixel `--verify`.
+- `--bounds`: include `bounds` in emitted semantics (debug only; never affects goldens).
+
+### Batch (`runBatch`)
+
+- `--semantics`: embed each shot's canonical dump (no bounds) in `report.json`. Off by
+  default → `report.json` stays small.
+- `--verify-semantics`: enable the semantics-golden gate. Goldens live as sidecars in the
+  existing `--golden-dir` as `<id>.semantics.json`, beside `<id>.png`. A semantics mismatch
+  counts as a failure (exit 1), with the delta recorded in the report. A missing semantics
+  golden is `missing-golden` (non-failing, like pixels).
+- `--events`: write `events.ndjson` (§F).
+
+## D. Batch report (`Report.kt`)
+
+`schemaVersion` bumped 1 → 2. All new fields are nullable/defaulted (backward compatible):
+
+- `ShotReport.semantics: SemanticsDump.Node?` — present only with `--semantics`.
+- `ShotReport.verifySemantics: SemanticsVerifyReport?` — present only with `--verify-semantics`.
+- `SemanticsVerifyReport(golden: String, result: String /* match|mismatch|missing-golden */, delta: List<String>? )`.
+- `Totals` gains `semanticsMismatched: Int` and `semanticsMissingGolden: Int`.
+
+Batch gate becomes `failed > 0 || mismatched > 0 || semanticsMismatched > 0`.
+
+## E. Publishing / version reconcile
+
+Infra already targets Central; the work is cutting a **pinnable released version** and
+reconciling the skew.
+
+- **Single version line.** The snapshot module rides the same release-tag flow as the CLI.
+  The next release cuts `org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha03` to Maven
+  Central (from the `-Pversion=1.0.0-alpha03` tag build). `1.0.0-SNAPSHOT` remains the
+  `master` development baseline.
+- **Consumer docs.** Add a module README section: the pinned coordinate, the `repositories {}`
+  (Maven Central) and `dependencies {}` snippet, and a note that scene authoring also needs
+  the transitive Compose/clikt/serialization `api` deps.
+- **Deliverable boundary.** The actual signed publish runs in CI on a maintainer tag push
+  (requires signing secrets, irreversible). This work delivers: (1) confirmation the module
+  is in the release publish set, (2) version reconciliation + docs, (3) local
+  `./gradlew :redux-kotlin-snapshot:publishToMavenLocal` verification that the artifact +
+  POM + sources/javadoc jars resolve. The tag push itself is a follow-up maintainer action,
+  noted in the plan.
+
+## F. Live-view seam (forward-compat only)
+
+Enables a *future* live web view (a page that updates as the agent renders shots) without
+having to reshape the batch loop later. The server, SSE/auto-refresh, and live HTML are
+**out of scope** here.
+
+- `BatchRunner.run` gains an optional `onShot: (ShotReport) -> Unit` callback (default
+  no-op), invoked as each shot completes (the loop already produces `ShotReport`s
+  one-by-one; this exposes them incrementally instead of only in the final aggregate).
+- With `--events`, the CLI writes `events.ndjson` in `outDir` — one serialized `ShotReport`
+  per line, appended as each shot finishes. PNGs already write per-shot, so a future watcher
+  has both artifacts and a tailable event stream.
+- The existing `DashboardGenerator` (static `index.html` over the final report) remains the
+  render target; a future `--serve`/`--watch` tails `events.ndjson` into it. Not built now.
+
+## Non-goals
+
+- Keep the render backend JVM/Skiko headless. No emulator/Robolectric.
+- Headless render has no async image loading — out of scope.
+- No web server / live HTML / SSE in this work (only the emission seam).
+- No unmerged-semantics tree (merged only); revisit if a consumer needs it.
+
+## Testing
+
+- **Extraction correctness:** a scene with `Text`, a `Button` (Role), a `testTag`, a
+  disabled node, and a selected node → assert the `Node` tree fields and traversal order.
+- **Determinism:** render the same shot twice → identical canonical form.
+- **Bounds handling:** bounds absent from canonical form; present in JSON only with `--bounds`.
+- **Diff:** known before/after trees → expected `+`/`-`/`~` delta lines; equal trees → `match`.
+- **CLI single:** `--semantics=json` and `=text` output; sidecar files with `--out`;
+  `--verify-semantics` match/mismatch/missing-golden and exit codes; existing flags unchanged.
+- **CLI batch:** `report.json` `schemaVersion == 2`; dump embedded only with `--semantics`;
+  semantics mismatch drives exit 1 and `totals.semanticsMismatched`; `events.ndjson` line
+  count and content with `--events`.
+- **Back-compat:** a v1-shaped consumer still parses (new fields nullable/defaulted); pixel
+  verify path and totals unchanged when semantics flags are off.
+- **Publish:** `publishToMavenLocal` produces the artifact + POM + sources/javadoc jars
+  under the reconciled coordinate.

--- a/docs/superpowers/specs/2026-07-01-snapshot-semantics-and-publish-design.md
+++ b/docs/superpowers/specs/2026-07-01-snapshot-semantics-and-publish-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-01
 **Module:** `redux-kotlin-snapshot` (+ its `rk snapshot` / `runCli` surface)
-**Status:** design, pending approval
+**Status:** design, pending approval (revised after multi-lens review)
 
 ## Goal
 
@@ -24,16 +24,16 @@ tokens each, every iteration). Two capabilities eliminate most of that cost:
 
 ## Scope
 
-One spec covering all four gaps plus a forward-compat seam:
-
 - **A.** Real semantics extraction (the P0 gap).
-- **B.** Canonical semantics form + structural diff.
+- **B.** Canonical form + line-diff delta.
 - **C.** CLI surface for semantics (single + batch), exit-code contract preserved.
-- **D.** Batch report exposes dump + semantics verdict.
+- **D.** Batch report v2 + terse drift-only output + measurement fields.
 - **E.** Maven Central publish + version reconciliation.
-- **F.** Live-view seam (per-shot emission + `events.ndjson`) — enables a *future* live
-  web view without reshaping the batch loop later. The web server / live HTML itself is
-  **out of scope** (future feature).
+
+**Cut from an earlier draft (deliberately out of scope):** a live-view emission seam
+(`onShot` callback / `events.ndjson`). `BatchRunner.run` already produces `ShotReport`s
+one at a time, so a future live-view watcher can add that hook as a small, localized change
+when it is actually built. Not paid for now.
 
 ## Verified technical facts (Compose MP 1.11.1)
 
@@ -47,13 +47,17 @@ Confirmed against resolved artifacts, not training data:
     populated during composition, readable after `scene.render()` before `scene.close()`.
   - `SemanticsOwner.rootSemanticsNode: SemanticsNode` (merged) and `unmergedRootSemanticsNode`.
   - `SemanticsNode.config: SemanticsConfiguration` (public, merged), `.children: List<SemanticsNode>`
-    (public), `.boundsInRoot: Rect` / `.boundsInWindow` (public), `.id`, `.isRoot`.
+    (public), `.id`, `.isRoot`. (`boundsInRoot`/`boundsInWindow` exist but are unused — see §A.)
   - `SemanticsConfiguration` is iterable and exposes `get`/`contains` by key.
   - `SemanticsProperties.Text` (`List<AnnotatedString>`), `.ContentDescription`
     (`List<String>`), `.Role` (`Role`), `.TestTag` (`String`), plus `Disabled`, `Selected`,
     `ToggleableState`.
   - `ImageComposeScene` is **not** deprecated (only its old `render(Duration)` overload is);
-    no need to migrate to `androidx.compose.ui.scene.ComposeScene`.
+    no migration to `androidx.compose.ui.scene.ComposeScene` needed.
+- **`explicitApi()` is on (strict)** via `convention.publishing-jvm`, with ABI validation
+  tracked in `redux-kotlin-snapshot/api/redux-kotlin-snapshot.api`. Every new public
+  declaration MUST carry an explicit `public` modifier and KDoc, or the build fails and the
+  shipped javadoc jar is empty. New public API also requires an `apiDump` update.
 - **Publishing is already wired to Maven Central.** `convention.publishing-jvm` applies
   `com.vanniktech.maven.publish` with `publishToMavenCentral(automaticRelease = true)` and
   `signAllPublications()` (CI-only, gated on `signingInMemoryKey`). Coordinates
@@ -64,109 +68,169 @@ Confirmed against resolved artifacts, not training data:
 ## A. Semantics extraction
 
 New file `Semantics.kt`. The `SemanticsDump` scaffold in `RenderBackend.kt` is expanded.
+All declarations below are `public` with KDoc.
 
 ### Data model
 
-`SemanticsDump.Node` (nested to avoid clashing with Compose's `androidx.compose.ui.semantics.SemanticsNode`):
+`SemanticsDump.Node` is nested to avoid clashing with Compose's
+`androidx.compose.ui.semantics.SemanticsNode`. **No bounds field** — spatial/positional
+debugging lives in the PNG; excluding position keeps one serialization form and removes the
+cross-arch (arm64 vs x64 rounding) determinism footgun entirely.
 
 ```
 @Serializable
-class Node(
-    val role: String?,                 // Role enum name, lowercased; null if absent
-    val text: List<String>,            // AnnotatedString.text on this node, in order
-    val contentDescription: List<String>,
-    val testTag: String?,
-    val enabled: Boolean?,             // false when SemanticsProperties.Disabled present; null if unspecified
-    val selected: Boolean?,            // SemanticsProperties.Selected; null if absent
-    val toggle: String?,               // ToggleableState name (On/Off/Indeterminate); null if absent
-    val bounds: List<Int>?,            // [left, top, right, bottom] rounded; see determinism
-    val children: List<Node>,
+public class Node(
+    public val role: String?,                  // Role.toString() lowercased; null if absent
+    public val text: List<String>,             // AnnotatedString.text on this node, in order
+    public val contentDescription: List<String>,
+    public val testTag: String?,
+    public val enabled: Boolean?,              // false when SemanticsProperties.Disabled present; else null (tri-state: never true)
+    public val selected: Boolean?,             // SemanticsProperties.Selected; null if absent
+    public val toggle: String?,                // ToggleableState name (On/Off/Indeterminate); null if absent
+    public val children: List<Node>,
 )
 
-class SemanticsDump(
-    val root: Node?,                   // null when nothing captured
-    val texts: List<String>,           // flat, traversal order — kept for back-compat
+public class SemanticsDump(
+    public val roots: List<Node>,              // one per SemanticsOwner (see multi-owner); empty when nothing captured
+    public val texts: List<String>,            // flat, pre-order — kept for back-compat
 ) {
-    fun toJson(): String
-    fun toText(): String               // compact indented tree
-    companion object { val EMPTY = SemanticsDump(root = null, texts = emptyList()) }
+    public fun toText(): String                // compact indented tree — DEFAULT agent/human form
+    public fun toCanonicalJson(): String       // the single JSON form: used for --semantics-format json AND for goldens
+    public companion object { public val EMPTY: SemanticsDump = SemanticsDump(roots = emptyList(), texts = emptyList()) }
 }
 ```
 
-`RenderResult(png, semantics)` is unchanged in shape; `semantics` is now populated.
+`RenderResult(png, semantics)` shape is unchanged; `semantics` is now populated. There is
+**one** JSON serialization (`toCanonicalJson`) — no separate `toJson`; the CLI json mode and
+the golden both use it, so canonical == report-embedded == emitted JSON.
 
 ### Extraction
 
 In `ImageComposeSceneBackend.render`, after `scene.render()` and before `scene.close()`:
 
-1. Read `scene.semanticsOwners`; sort deterministically (by root `boundsInWindow` top, then
-   left) so popups/dialogs order stably.
-2. For each owner, take `rootSemanticsNode` (**merged** tree — matches the compose-ui-test
-   default, carries `Role`; unmerged is deferred, YAGNI).
-3. Recurse `node.children` (public, layout order — deterministic), reading
-   `node.config[SemanticsProperties.*]` for each field. `bounds` from `boundsInRoot`, rounded
-   to ints.
+1. Read `scene.semanticsOwners`.
+2. **Multi-owner:** a scene may produce more than one owner (a Popup/Dialog gets its own).
+   Map each owner's `rootSemanticsNode` to one entry in `SemanticsDump.roots`. Sort owners
+   deterministically by `(root.id ascending)` — `id` is a stable monotonic assignment within
+   a composition and does not depend on arch/pixels (unlike bounds). During implementation,
+   first confirm headless `ImageComposeScene` actually populates a second owner for a
+   Popup/Dialog; if it does not, `roots` simply has one entry and the sort is a no-op — the
+   list model costs nothing and stays correct either way.
+3. For each root, take the **merged** tree (matches the compose-ui-test default, carries
+   `Role`). Recurse `node.children` (public, layout order — deterministic), reading
+   `node.config[SemanticsProperties.*]`.
 4. Build the flat `texts` list from a pre-order walk (back-compat with the current field).
 
 Requires only `@OptIn(ExperimentalComposeUiApi::class)`.
 
-### Determinism
+**Merged-tree caveat (documented + tested):** merged traversal collapses a descendant's
+semantics onto the merge boundary — e.g. a `Button` absorbs its child `Text`, so the `Text`
+appears in the button node's `text` and the child `Node` disappears from `children`. This is
+intended (it matches accessibility/testing semantics) but must be documented so consumers do
+not expect a 1:1 composable→node tree. `enabled` is tri-state: `false` or `null`, never
+`true` (Compose only records the disabled marker).
 
-- Ordering is deterministic by construction (stable owner sort + layout child order).
-- **Bounds vary across arch/rounding** (dev arm64 vs CI x64). The `Node.bounds` field is
-  populated in memory but is **excluded from the canonical form** (§B) and from any
-  semantics-golden, so goldens are arch-independent. Bounds are serialized to JSON output
-  only when explicitly requested (`--bounds`), for debugging.
+### Error handling (non-fatal)
 
-## B. Canonical form + structural diff
+The semantics read uses experimental API. If any step from `semanticsOwners` through
+`config` throws between `scene.render()` and `scene.close()`, **degrade to
+`SemanticsDump.EMPTY` and keep the already-rendered PNG** — the shot is not failed. Rationale:
+pixels are the primary artifact; a semantics-extraction hiccup must not regress the existing
+PNG contract. (A `--verify-semantics` run against an EMPTY dump is a `mismatch`, which surfaces
+the problem without crashing the render.)
+
+## B. Canonical form + delta
 
 New file `SemanticsDiffer.kt`.
 
-- **Canonical form:** a deterministic serialization of the `Node` tree with **`bounds`
-  omitted** and a fixed field order (kotlinx JSON over the data classes; field order is
-  stable). This string is what a semantics golden stores.
-- **Diff:** parse golden + actual canonical trees, walk by node path, emit a readable
-  line-level delta:
-  - `+ <path> <node summary>` — node added
-  - `- <path> <node summary>` — node removed
-  - `~ <path> <field>: <old> → <new>` — field changed
-- Verdict: `match` when the canonical strings are equal; otherwise `mismatch` with the
-  delta lines. `missing-golden` when the golden file is absent (mirrors pixel verify).
+- **Canonical form** = `SemanticsDump.toCanonicalJson()`: deterministic pretty-printed JSON of
+  the `roots` tree, stable field order (data-class order via kotlinx JSON), `encodeDefaults`
+  consistent. This string is what a semantics golden stores.
+- **Verdict** = pure string equality of golden vs actual canonical form: `match` when equal,
+  else `mismatch`; `missing-golden` when the file is absent (mirrors pixel verify).
+- **Delta (line diff):** on `mismatch`, render a readable unified line diff of the two
+  pretty-printed canonical blobs (added/removed/context lines). Cap at a configured max line
+  count with an `… (N more)` overflow marker so a large subtree change stays bounded. A
+  structured per-node path-walk differ is **deferred** — the gate is string equality and the
+  line diff is a readable-enough signal; add the field-level walker only if a consumer needs
+  it.
+
+Verdict strings are lowercase (`match` | `mismatch` | `missing-golden`) to match the existing
+report `result` vocabulary.
 
 ## C. CLI surface (`cli/Cli.kt`)
 
 Existing flags, `--list` shape, batch manifest, and exit codes (0 ok / 1 render-or-verify
-failure / 2 usage) are unchanged. `runCli` → `exitProcess(0)` contract preserved.
+failure / 2 usage) are unchanged. `runCli` → `exitProcess(0)` contract preserved. Clikt has
+no native optional-value option, so each capability is a **distinctly declared** option, not a
+`[=value]` flag.
 
 ### Single shot (`runSingle`)
 
-- `--semantics[=json|text]` (optional value, default `json`): after render, print the dump
-  to stdout; or, when `--out` is given, write a sidecar `<out>.semantics.json` /
-  `<out>.semantics.txt`.
-- `--verify-semantics <file>`: compare the rendered canonical form against the golden file;
-  print verdict + delta; exit 1 on mismatch. Independent of the pixel `--verify`.
-- `--bounds`: include `bounds` in emitted semantics (debug only; never affects goldens).
+- `--semantics` (bare flag): after render, emit the dump. To stdout by default; when `--out`
+  is set, also write a sidecar next to it (`<out>.semantics.<ext>`). Routing matrix stated in
+  §D.
+- `--semantics-format json|text` (default `text`): selects `toText()` vs `toCanonicalJson()`
+  for the emitted dump. `text` is the default because the token win the value prop rests on is
+  the compact text form.
+- `--verify-semantics-file <file>`: compare the rendered canonical form against this golden
+  file; print `verify-semantics: <verdict>` and, on mismatch, the line-diff delta; exit 1 on
+  mismatch. Independent of the pixel `--verify`.
+- `--update-semantics`: write/overwrite the canonical form to the `--verify-semantics-file`
+  path (single) — the baseline-authoring path. Without `--verify-semantics-file` this is a
+  usage error (exit 2).
 
 ### Batch (`runBatch`)
 
-- `--semantics`: embed each shot's canonical dump (no bounds) in `report.json`. Off by
-  default → `report.json` stays small.
-- `--verify-semantics`: enable the semantics-golden gate. Goldens live as sidecars in the
-  existing `--golden-dir` as `<id>.semantics.json`, beside `<id>.png`. A semantics mismatch
-  counts as a failure (exit 1), with the delta recorded in the report. A missing semantics
-  golden is `missing-golden` (non-failing, like pixels).
-- `--events`: write `events.ndjson` (§F).
+- `--semantics`: write a per-shot sidecar (`<id>.semantics.txt` by default, `.json` per
+  `--semantics-format`) beside the shot's PNG in `outDir`. The full dump is **not** embedded
+  inline in `report.json` for every shot (keeps the report small); the report carries the
+  verdict, delta, `semanticsBytes`, and the sidecar path (§D). This is the read-on-demand
+  model: the agent reads a sidecar only for a drifted shot.
+- `--verify-semantics` (bare flag): enable the semantics-golden gate. Requires `--golden-dir`
+  (else exit 2 with a fix-it message, same style as the pixel path). Goldens are sidecars in
+  `--golden-dir` as `<id>.semantics.json`, beside `<id>.png`. A semantics mismatch counts as a
+  failure (exit 1), delta recorded in the report. A missing semantics golden is
+  `missing-golden` (non-failing, like pixels).
+- `--update-semantics`: (re)write each shot's canonical form to
+  `<golden-dir>/<id>.semantics.json` and exit 0 without gating — regenerate baselines after an
+  intended UI change. Requires `--golden-dir`.
 
-## D. Batch report (`Report.kt`)
+**Precedence with `--json`:** `--json` still emits the machine report to stdout; with
+`--semantics`, dumps go to sidecar files (never interleaved into the `--json` stdout stream).
 
-`schemaVersion` bumped 1 → 2. All new fields are nullable/defaulted (backward compatible):
+## D. Batch report (`Report.kt`) + output
 
-- `ShotReport.semantics: SemanticsDump.Node?` — present only with `--semantics`.
-- `ShotReport.verifySemantics: SemanticsVerifyReport?` — present only with `--verify-semantics`.
-- `SemanticsVerifyReport(golden: String, result: String /* match|mismatch|missing-golden */, delta: List<String>? )`.
-- `Totals` gains `semanticsMismatched: Int` and `semanticsMissingGolden: Int`.
+`schemaVersion` bumped 1 → 2. All new fields nullable/defaulted so a v1 reader with
+`ignoreUnknownKeys` still parses a v2 file and a v2 reader parses a v1 file (both directions
+required; the module's `Json` config must set `ignoreUnknownKeys = true`).
 
-Batch gate becomes `failed > 0 || mismatched > 0 || semanticsMismatched > 0`.
+- `ShotReport.verifySemantics: SemanticsVerifyReport? = null` — present only with
+  `--verify-semantics`. `SemanticsVerifyReport(golden: String, result: String, delta: List<String>? = null)`.
+- `ShotReport.semanticsSidecar: String? = null` — sidecar path, present with `--semantics`.
+- `ShotReport.semanticsBytes: Int? = null` — size of the canonical dump, for the dump-vs-PNG
+  saving comparison (`bytes` for PNG already exists).
+- `Totals` gains, all `= 0`: `semanticsMismatched`, `semanticsMissingGolden`,
+  `semanticsMatched`, and `renderMsTotal: Long = 0` (aggregate of the per-shot `renderMs` the
+  runner already computes).
+- **`Totals.ok` redefined** to exclude semantics failures too:
+  `status == "ok" && verify?.result != "mismatch" && verifySemantics?.result != "mismatch"`
+  (today a pixel-pass/semantics-fail shot is wrongly counted in both `ok` and
+  `semanticsMismatched`).
+- Batch gate: `failed > 0 || mismatched > 0 || semanticsMismatched > 0`.
+
+**Terse drift-only stdout (default, non-`--json`):** the batch summary line stays, but is
+followed by one line per *drifted* shot only: `id`, pixel verdict, semantics verdict, and the
+`png` / `diff` / `semanticsSidecar` paths, then the (capped) delta. The happy path prints just
+the summary; the agent never parses `report.json` unless something drifted.
+
+**Dashboard:** `DashboardGenerator` (behind the existing `--dashboard` flag) is updated to
+reflect the semantics verdict and the new totals, so a semantics-only mismatch does not render
+as a green card while the process exits 1.
+
+**Wiring:** `BatchRunner.run` gains `semantics: Boolean` and `verifySemantics: Boolean`
+parameters (parallel to the existing `verify`), consumes `renderResult().semantics` (currently
+discarded at `BatchRunner.kt:57`), and takes an injected `SemanticsDiffer` beside `Differ`.
 
 ## E. Publishing / version reconcile
 
@@ -175,53 +239,64 @@ reconciling the skew.
 
 - **Single version line.** The snapshot module rides the same release-tag flow as the CLI.
   The next release cuts `org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha03` to Maven
-  Central (from the `-Pversion=1.0.0-alpha03` tag build). `1.0.0-SNAPSHOT` remains the
-  `master` development baseline.
+  Central (from the `-Pversion=1.0.0-alpha03` tag build). `1.0.0-SNAPSHOT` stays the `master`
+  development baseline.
 - **Consumer docs.** Add a module README section: the pinned coordinate, the `repositories {}`
-  (Maven Central) and `dependencies {}` snippet, and a note that scene authoring also needs
-  the transitive Compose/clikt/serialization `api` deps.
-- **Deliverable boundary.** The actual signed publish runs in CI on a maintainer tag push
-  (requires signing secrets, irreversible). This work delivers: (1) confirmation the module
-  is in the release publish set, (2) version reconciliation + docs, (3) local
-  `./gradlew :redux-kotlin-snapshot:publishToMavenLocal` verification that the artifact +
-  POM + sources/javadoc jars resolve. The tag push itself is a follow-up maintainer action,
-  noted in the plan.
+  (Maven Central) + `dependencies {}` snippet, and a note that scene authoring also needs the
+  transitive Compose/clikt/serialization `api` deps.
+- **Deliverable boundary.** The signed publish runs in CI on a maintainer tag push (signing
+  secrets, irreversible). This work delivers: (1) confirmation the module is in the release
+  publish set, (2) version reconciliation + docs, (3) `apiDump` for the new public API, and
+  (4) local `./gradlew :redux-kotlin-snapshot:publishToMavenLocal` verification that the
+  artifact + POM + sources/javadoc jars resolve. The tag push itself is a follow-up maintainer
+  action, noted in the plan.
 
-## F. Live-view seam (forward-compat only)
+## Documentation (acceptance deliverables)
 
-Enables a *future* live web view (a page that updates as the agent renders shots) without
-having to reshape the batch loop later. The server, SSE/auto-refresh, and live HTML are
-**out of scope** here.
-
-- `BatchRunner.run` gains an optional `onShot: (ShotReport) -> Unit` callback (default
-  no-op), invoked as each shot completes (the loop already produces `ShotReport`s
-  one-by-one; this exposes them incrementally instead of only in the final aggregate).
-- With `--events`, the CLI writes `events.ndjson` in `outDir` — one serialized `ShotReport`
-  per line, appended as each shot finishes. PNGs already write per-shot, so a future watcher
-  has both artifacts and a tailable event stream.
-- The existing `DashboardGenerator` (static `index.html` over the final report) remains the
-  render target; a future `--serve`/`--watch` tails `events.ndjson` into it. Not built now.
+- Module README: **Flags table** updated for `--semantics`, `--semantics-format`,
+  `--verify-semantics` / `--verify-semantics-file`, `--update-semantics`; a **Typical agent
+  loop** section showing generate-baseline → verify → read-sidecar-only-on-drift; the consumer
+  coordinate + Gradle snippet (§E).
+- The **dump JSON schema** and the **report v2 schema** documented explicitly (the report
+  types are `internal`, so the JSON is the only consumer surface).
+- A **worked agent-loop example** (commands + sample terse output + sample sidecar).
+- KDoc on all new public API (required by `explicitApi()` strict).
 
 ## Non-goals
 
 - Keep the render backend JVM/Skiko headless. No emulator/Robolectric.
 - Headless render has no async image loading — out of scope.
-- No web server / live HTML / SSE in this work (only the emission seam).
+- No live-view seam / web server / SSE now (see Scope).
 - No unmerged-semantics tree (merged only); revisit if a consumer needs it.
+- No structured per-node path-walk differ (line diff only); revisit if a consumer needs it.
+- No `bounds` in the dump.
 
 ## Testing
 
-- **Extraction correctness:** a scene with `Text`, a `Button` (Role), a `testTag`, a
-  disabled node, and a selected node → assert the `Node` tree fields and traversal order.
-- **Determinism:** render the same shot twice → identical canonical form.
-- **Bounds handling:** bounds absent from canonical form; present in JSON only with `--bounds`.
-- **Diff:** known before/after trees → expected `+`/`-`/`~` delta lines; equal trees → `match`.
-- **CLI single:** `--semantics=json` and `=text` output; sidecar files with `--out`;
-  `--verify-semantics` match/mismatch/missing-golden and exit codes; existing flags unchanged.
-- **CLI batch:** `report.json` `schemaVersion == 2`; dump embedded only with `--semantics`;
-  semantics mismatch drives exit 1 and `totals.semanticsMismatched`; `events.ndjson` line
-  count and content with `--events`.
-- **Back-compat:** a v1-shaped consumer still parses (new fields nullable/defaulted); pixel
-  verify path and totals unchanged when semantics flags are off.
-- **Publish:** `publishToMavenLocal` produces the artifact + POM + sources/javadoc jars
-  under the reconciled coordinate.
+- **Extraction correctness:** a scene with `Text`, a `Button` (Role), a `testTag`, a disabled
+  node, and a selected node → assert the `Node` tree fields and pre-order `texts`.
+- **Merged-tree absorption:** assert a `Button`+`Text` collapses to one node whose `text`
+  holds the label and whose `children` omit the absorbed `Text`.
+- **`enabled` tri-state:** assert `false`/`null` only, never `true`.
+- **Determinism:** render the same shot twice → identical `toCanonicalJson()`.
+- **Multi-owner:** a Popup/Dialog fixture → assert `roots` ordering is stable by `root.id`
+  (with the tie-break defined); if headless render does not populate a second owner, assert the
+  single-root fallback instead and record that finding.
+- **Empty / text-free:** the counter scene (no text) → pin the exact dump shape (`roots` shape,
+  `texts == emptyList()`); assert its text-bearing semantics fixture is verified via the
+  canonical form only, never a committed `*.png` golden (font-dependent, flakes cross-arch).
+- **Diff:** known before/after canonical blobs → expected line-diff delta and overflow cap;
+  equal blobs → `match`.
+- **CLI single:** `--semantics` + `--semantics-format text|json` to stdout and to sidecar with
+  `--out`; `--verify-semantics-file` match/mismatch/missing-golden and exit codes;
+  `--update-semantics` writes the baseline; missing `--verify-semantics-file` → exit 2.
+- **CLI batch:** `report.json` `schemaVersion == 2`; sidecars written with `--semantics`;
+  `--verify-semantics` without `--golden-dir` → exit 2; semantics mismatch drives exit 1,
+  `totals.semanticsMismatched`, and the corrected `totals.ok`; terse drift-only stdout lists
+  only drifted shots; `--update-semantics` regenerates goldens and exits 0.
+- **Back-compat:** a v1-shaped `report.json` parses under the v2 model (`ignoreUnknownKeys`);
+  the pixel verify path, totals, and exit codes are unchanged when semantics flags are off.
+- **Measurement:** `semanticsBytes` populated; `Totals.renderMsTotal` aggregates per-shot
+  `renderMs`; `semanticsMatched`/gated-out counts correct.
+- **Publish:** `publishToMavenLocal` produces the artifact + POM + sources/javadoc jars under
+  the reconciled coordinate; `apiDump` matches.

--- a/docs/superpowers/specs/2026-07-01-snapshot-semantics-and-publish-design.md
+++ b/docs/superpowers/specs/2026-07-01-snapshot-semantics-and-publish-design.md
@@ -238,8 +238,8 @@ Infra already targets Central; the work is cutting a **pinnable released version
 reconciling the skew.
 
 - **Single version line.** The snapshot module rides the same release-tag flow as the CLI.
-  The next release cuts `org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha03` to Maven
-  Central (from the `-Pversion=1.0.0-alpha03` tag build). `1.0.0-SNAPSHOT` stays the `master`
+  The next release cuts `org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha04` to Maven
+  Central (from the `-Pversion=1.0.0-alpha04` tag build). `1.0.0-SNAPSHOT` stays the `master`
   development baseline.
 - **Consumer docs.** Add a module README section: the pinned coordinate, the `repositories {}`
   (Maven Central) + `dependencies {}` snippet, and a note that scene authoring also needs the

--- a/redux-kotlin-snapshot/README.md
+++ b/redux-kotlin-snapshot/README.md
@@ -225,7 +225,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    implementation("org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha03")
+    implementation("org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha04")
 }
 ```
 
@@ -237,7 +237,9 @@ come along transitively — no need to declare them yourself, just add
 **Version note:** the repo's development baseline (`gradle.properties`) is
 `1.0.0-SNAPSHOT` on `master`. Released artifacts don't track that baseline
 directly — they ride the shared release-tag line with the rest of the CLI
-tooling, cut by a maintainer tag push; the next tag is `1.0.0-alpha03`.
+tooling, cut by a maintainer tag push. This semantics surface first ships in
+`1.0.0-alpha04` — `1.0.0-alpha03` was released 2026-06-23 (before this work), so pin
+`1.0.0-alpha04` or later.
 
 ## See also
 

--- a/redux-kotlin-snapshot/README.md
+++ b/redux-kotlin-snapshot/README.md
@@ -99,6 +99,11 @@ fun main(args: Array<String>) {
 | `--golden-dir <dir>` | Golden dir for a batch; its presence switches the batch into verify mode. |
 | `--json` | Emit the machine-readable report on stdout. |
 | `--dashboard` | Also write a static `index.html` over the batch report. |
+| `--semantics` | Emit the semantics dump (single shot: stdout + sidecar next to `--out`; batch: sidecar per shot). |
+| `--semantics-format json\|text` | Dump format for `--semantics` / semantics sidecars. Default `text`. |
+| `--verify-semantics-file <file>` | Semantics golden to compare against (single shot); mismatch exits 1. |
+| `--verify-semantics` | Enable the semantics golden gate for a batch. Needs `--golden-dir`. |
+| `--update-semantics` | Write/update the semantics golden(s) instead of verifying, then exit 0. Single shot needs `--verify-semantics-file`; batch needs `--golden-dir`. |
 
 **Exit codes:** `0` ok · `1` render or verify failure · `2` usage error.
 
@@ -139,6 +144,64 @@ rk snapshot --batch shots.json --out-dir build/snapshots --golden-dir goldens
 The batch writes `report.json` under `--out-dir`; `--dashboard` adds an
 `index.html` over it. A batch with any failed or mismatched shot exits 1.
 
+## Semantics for AI agents
+
+Alongside pixels, every render can emit a **semantics dump** — a deterministic,
+bounds-free tree of role/text/state, ordered by semantics-node id (owners) and
+layout order (children), never pixel position. It lets an agent assert content
+as text/JSON instead of reading a PNG, and gate on it the same way `--verify`
+gates on pixels. The typical loop:
+
+1. **Author baselines.** Render the batch and write a semantics golden per shot:
+   ```
+   rk snapshot --batch shots.json --golden-dir goldens --update-semantics
+   ```
+2. **Gate.** Re-run with the golden gate on; a drifted shot exits 1 with terse
+   `drift <id>: pixel=... semantics=...` lines (see `--dashboard` for the same
+   info in HTML):
+   ```
+   rk snapshot --batch shots.json --out-dir out --golden-dir goldens --verify-semantics
+   ```
+   Only for the shots that drifted, read `out/<id>.semantics.txt` (or
+   `out/<id>.semantics.json` with `--semantics-format json`) — or the pixel
+   `.diff.png` — to see what changed; matching shots need no further reading.
+3. **Single dump**, e.g. to inspect one scene directly:
+   ```
+   rk snapshot --scene demo --preset default --semantics                    # indented text
+   rk snapshot --scene demo --preset default --semantics --semantics-format json
+   ```
+
+### Dump JSON schema
+
+`--semantics-format json` (and every semantics golden) is a JSON **array of
+root nodes** — one root per Compose `SemanticsOwner` (a Popup/Dialog gets its
+own) — with no top-level wrapper object. Each `Node`:
+
+| Field | Type | Notes |
+|---|---|---|
+| `role` | `string \| null` | Accessibility role, lowercased (e.g. `button`). |
+| `text` | `string[]` | Text on this node, in order; a merge boundary absorbs descendants' text. |
+| `contentDescription` | `string[]` | Content descriptions on this node, in order. |
+| `testTag` | `string \| null` | Test tag. |
+| `enabled` | `boolean \| null` | `false` when explicitly disabled; otherwise `null` (tri-state — never `true`). |
+| `selected` | `boolean \| null` | Selected state, or `null` if unspecified. |
+| `toggle` | `string \| null` | `"On"` / `"Off"` / `"Indeterminate"`, or `null`. |
+| `children` | `Node[]` | Merged child nodes, in layout order. |
+
+No bounds/coordinates are included — the dump is deliberately independent of
+pixel position and stable across architectures.
+
+### Report v2 schema
+
+`report.json` is `schemaVersion: 2`. Beyond the pixel-era fields, each
+`ShotReport` adds `verifySemantics` (the `SemanticsVerifyReport`: golden path,
+`match`/`mismatch`/`missing-golden` result, and terse `delta` lines when
+mismatched), `semanticsSidecar` (path to the per-shot dump file, when
+`--semantics` or `--verify-semantics` wrote one), and `semanticsBytes`. `Totals`
+adds `semanticsMismatched`, `semanticsMissingGolden`, `semanticsMatched`, and
+`renderMsTotal`. Consumers should decode with `Json { ignoreUnknownKeys = true }`
+so older/newer report fields don't break parsing.
+
 ## In tests
 
 For JUnit-style assertions, `SnapshotApp.assertGolden(...)` renders a scene and
@@ -150,6 +213,27 @@ throwing `AssertionError` on mismatch and writing the actual PNG under
 ```kotlin
 @Test fun board() = mySnapshots.assertGolden(scene = "board", preset = "seeded")
 ```
+
+## Consuming from Maven Central
+
+```kotlin
+repositories {
+    mavenCentral()
+}
+dependencies {
+    implementation("org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha03")
+}
+```
+
+Scene authoring is part of the public API, so this module's Compose Multiplatform,
+clikt, and kotlinx-serialization dependencies are `api` (not `implementation`) and
+come along transitively — no need to declare them yourself, just add
+`compose.desktop.currentOs` for the host Skiko runtime (see above).
+
+**Version note:** the repo's development baseline (`gradle.properties`) is
+`1.0.0-SNAPSHOT` on `master`. Released artifacts don't track that baseline
+directly — they ride the shared release-tag line with the rest of the CLI
+tooling, cut by a maintainer tag push; the next tag is `1.0.0-alpha03`.
 
 ## See also
 

--- a/redux-kotlin-snapshot/README.md
+++ b/redux-kotlin-snapshot/README.md
@@ -156,14 +156,17 @@ gates on pixels. The typical loop:
    ```
    rk snapshot --batch shots.json --golden-dir goldens --update-semantics
    ```
-2. **Gate.** Re-run with the golden gate on; a drifted shot exits 1 with terse
+2. **Gate.** Re-run with the golden gate on, adding `--semantics` so per-shot
+   sidecars are on disk to read; a drifted shot exits 1 with terse
    `drift <id>: pixel=... semantics=...` lines (see `--dashboard` for the same
    info in HTML):
    ```
-   rk snapshot --batch shots.json --out-dir out --golden-dir goldens --verify-semantics
+   rk snapshot --batch shots.json --out-dir out --golden-dir goldens --verify-semantics --semantics
    ```
-   Only for the shots that drifted, read `out/<id>.semantics.txt` (or
-   `out/<id>.semantics.json` with `--semantics-format json`) — or the pixel
+   `--verify-semantics` alone only prints the delta and does not write a
+   sidecar — `--semantics` is what writes `out/<id>.semantics.txt` (or
+   `out/<id>.semantics.json` with `--semantics-format json`) for every shot.
+   Only for the shots that drifted, read that sidecar — or the pixel
    `.diff.png` — to see what changed; matching shots need no further reading.
 3. **Single dump**, e.g. to inspect one scene directly:
    ```
@@ -196,8 +199,9 @@ pixel position and stable across architectures.
 `report.json` is `schemaVersion: 2`. Beyond the pixel-era fields, each
 `ShotReport` adds `verifySemantics` (the `SemanticsVerifyReport`: golden path,
 `match`/`mismatch`/`missing-golden` result, and terse `delta` lines when
-mismatched), `semanticsSidecar` (path to the per-shot dump file, when
-`--semantics` or `--verify-semantics` wrote one), and `semanticsBytes`. `Totals`
+mismatched), `semanticsSidecar` (path to the per-shot dump file, written only
+when `--semantics` was passed — `--verify-semantics` alone does not write
+one), and `semanticsBytes`. `Totals`
 adds `semanticsMismatched`, `semanticsMissingGolden`, `semanticsMatched`, and
 `renderMsTotal`. Consumers should decode with `Json { ignoreUnknownKeys = true }`
 so older/newer report fields don't break parsing.

--- a/redux-kotlin-snapshot/api/redux-kotlin-snapshot.api
+++ b/redux-kotlin-snapshot/api/redux-kotlin-snapshot.api
@@ -113,21 +113,6 @@ public final class org/reduxkotlin/snapshot/SceneDefaults {
 	public final fun setWidth (Ljava/lang/Integer;)V
 }
 
-public final class org/reduxkotlin/snapshot/SemanticsDiffResult {
-	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
-	public final fun getDelta ()Ljava/util/List;
-	public final fun getResult ()Ljava/lang/String;
-}
-
-public final class org/reduxkotlin/snapshot/SemanticsDiffer {
-	public static final field $stable I
-	public fun <init> ()V
-	public fun <init> (I)V
-	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun compare (Ljava/lang/String;Ljava/lang/String;)Lorg/reduxkotlin/snapshot/SemanticsDiffResult;
-}
-
 public final class org/reduxkotlin/snapshot/SemanticsDump {
 	public static final field $stable I
 	public static final field Companion Lorg/reduxkotlin/snapshot/SemanticsDump$Companion;

--- a/redux-kotlin-snapshot/api/redux-kotlin-snapshot.api
+++ b/redux-kotlin-snapshot/api/redux-kotlin-snapshot.api
@@ -113,15 +113,63 @@ public final class org/reduxkotlin/snapshot/SceneDefaults {
 	public final fun setWidth (Ljava/lang/Integer;)V
 }
 
+public final class org/reduxkotlin/snapshot/SemanticsDiffResult {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun getDelta ()Ljava/util/List;
+	public final fun getResult ()Ljava/lang/String;
+}
+
+public final class org/reduxkotlin/snapshot/SemanticsDiffer {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (I)V
+	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun compare (Ljava/lang/String;Ljava/lang/String;)Lorg/reduxkotlin/snapshot/SemanticsDiffResult;
+}
+
 public final class org/reduxkotlin/snapshot/SemanticsDump {
 	public static final field $stable I
 	public static final field Companion Lorg/reduxkotlin/snapshot/SemanticsDump$Companion;
-	public fun <init> (Ljava/util/List;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun getRoots ()Ljava/util/List;
 	public final fun getTexts ()Ljava/util/List;
+	public final fun toCanonicalJson ()Ljava/lang/String;
+	public final fun toText ()Ljava/lang/String;
 }
 
 public final class org/reduxkotlin/snapshot/SemanticsDump$Companion {
 	public final fun getEMPTY ()Lorg/reduxkotlin/snapshot/SemanticsDump;
+}
+
+public final class org/reduxkotlin/snapshot/SemanticsDump$Node {
+	public static final field $stable I
+	public static final field Companion Lorg/reduxkotlin/snapshot/SemanticsDump$Node$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;)V
+	public final fun getChildren ()Ljava/util/List;
+	public final fun getContentDescription ()Ljava/util/List;
+	public final fun getEnabled ()Ljava/lang/Boolean;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getSelected ()Ljava/lang/Boolean;
+	public final fun getTestTag ()Ljava/lang/String;
+	public final fun getText ()Ljava/util/List;
+	public final fun getToggle ()Ljava/lang/String;
+}
+
+public final synthetic class org/reduxkotlin/snapshot/SemanticsDump$Node$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/reduxkotlin/snapshot/SemanticsDump$Node$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/reduxkotlin/snapshot/SemanticsDump$Node;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/reduxkotlin/snapshot/SemanticsDump$Node;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/reduxkotlin/snapshot/SemanticsDump$Node$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class org/reduxkotlin/snapshot/SnapshotApp {

--- a/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/BatchRunner.kt
+++ b/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/BatchRunner.kt
@@ -53,7 +53,7 @@ internal class BatchRunner(
         )
     }
 
-    @Suppress("TooGenericExceptionCaught", "LongParameterList", "CyclomaticComplexMethod")
+    @Suppress("TooGenericExceptionCaught", "LongParameterList")
     private fun runShot(
         spec: ShotSpec,
         defaults: ManifestDefaults,
@@ -67,11 +67,7 @@ internal class BatchRunner(
     ): ShotReport {
         val inputDesc = if (spec.preset != null) "preset=${spec.preset}" else "json"
         return try {
-            val input = when {
-                spec.preset != null -> SnapshotInput.Preset(spec.preset)
-                spec.stateJson != null -> SnapshotInput.Json(spec.stateJson)
-                else -> throw SnapshotException("shot '${spec.id}' needs 'preset' or 'stateJson'")
-            }
+            val input = resolveInput(spec)
             val shot = app.resolve(
                 spec.scene,
                 input,
@@ -90,24 +86,10 @@ internal class BatchRunner(
             }
             val canonical = result.semantics.toCanonicalJson()
 
-            if (updateSemantics && goldenDir != null) {
-                File(goldenDir, "${spec.id}.semantics.json").apply {
-                    parentFile?.mkdirs()
-                    writeText(canonical)
-                }
-            }
-            val sidecar = if (semantics) {
-                writeSidecar(
-                    spec,
-                    result.semantics,
-                    canonical,
-                    outDir,
-                    semanticsFormat,
-                )
-            } else {
-                null
-            }
-            val semVerify = if (verifySemantics) verifySemanticsShot(spec, canonical, goldenDir) else null
+            val (sidecar, semVerify) = applySemanticsExtras(
+                spec, result.semantics, canonical, outDir, goldenDir,
+                semantics, verifySemantics, updateSemantics, semanticsFormat,
+            )
 
             ShotReport(
                 id = spec.id, scene = spec.scene, input = inputDesc, theme = shot.theme,
@@ -124,6 +106,40 @@ internal class BatchRunner(
         } catch (e: Exception) {
             ShotReport(id = spec.id, scene = spec.scene, input = inputDesc, status = "error", error = e.message)
         }
+    }
+
+    /** Resolves a [ShotSpec] into the [SnapshotInput] the app should render, or throws if neither is set. */
+    private fun resolveInput(spec: ShotSpec): SnapshotInput = when {
+        spec.preset != null -> SnapshotInput.Preset(spec.preset)
+        spec.stateJson != null -> SnapshotInput.Json(spec.stateJson)
+        else -> throw SnapshotException("shot '${spec.id}' needs 'preset' or 'stateJson'")
+    }
+
+    /**
+     * Handles the golden-update, sidecar-write, and semantics-verify trio for a rendered shot.
+     * Returns the sidecar file (if written) and the semantics verify report (if requested).
+     */
+    @Suppress("LongParameterList")
+    private fun applySemanticsExtras(
+        spec: ShotSpec,
+        dump: SemanticsDump,
+        canonical: String,
+        outDir: File,
+        goldenDir: File?,
+        semantics: Boolean,
+        verifySemantics: Boolean,
+        updateSemantics: Boolean,
+        semanticsFormat: String,
+    ): Pair<File?, SemanticsVerifyReport?> {
+        if (updateSemantics && goldenDir != null) {
+            File(goldenDir, "${spec.id}.semantics.json").apply {
+                parentFile?.mkdirs()
+                writeText(canonical)
+            }
+        }
+        val sidecar = if (semantics) writeSidecar(spec, dump, canonical, outDir, semanticsFormat) else null
+        val semVerify = if (verifySemantics) verifySemanticsShot(spec, canonical, goldenDir) else null
+        return sidecar to semVerify
     }
 
     private fun writeSidecar(

--- a/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/BatchRunner.kt
+++ b/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/BatchRunner.kt
@@ -12,31 +12,58 @@ internal class BatchRunner(
     private val app: SnapshotApp,
     private val backend: RenderBackend = ImageComposeSceneBackend(),
     private val differ: Differ = Differ(),
+    private val semanticsDiffer: SemanticsDiffer = SemanticsDiffer(),
 ) {
-    fun run(manifest: BatchManifest, outDir: File, verify: Boolean, goldenDir: File?, runId: String): SnapshotReport {
+    @Suppress("LongParameterList")
+    fun run(
+        manifest: BatchManifest,
+        outDir: File,
+        verify: Boolean,
+        goldenDir: File?,
+        runId: String,
+        semantics: Boolean = false,
+        verifySemantics: Boolean = false,
+        updateSemantics: Boolean = false,
+        semanticsFormat: String = "text",
+    ): SnapshotReport {
         outDir.mkdirs()
-        val shots = manifest.shots.map { runShot(it, manifest.defaults, outDir, verify, goldenDir) }
+        val shots = manifest.shots.map {
+            runShot(
+                it, manifest.defaults, outDir, verify, goldenDir,
+                semantics, verifySemantics, updateSemantics, semanticsFormat,
+            )
+        }
         return SnapshotReport(
             runId = runId,
             outDir = outDir.path,
             totals = Totals(
                 total = shots.size,
-                ok = shots.count { it.status == "ok" && it.verify?.result != "mismatch" },
+                ok = shots.count {
+                    it.status == "ok" && it.verify?.result != "mismatch" && it.verifySemantics?.result != "mismatch"
+                },
                 failed = shots.count { it.status == "error" },
                 mismatched = shots.count { it.verify?.result == "mismatch" },
                 missingGolden = shots.count { it.verify?.result == "missing-golden" },
+                semanticsMismatched = shots.count { it.verifySemantics?.result == "mismatch" },
+                semanticsMissingGolden = shots.count { it.verifySemantics?.result == "missing-golden" },
+                semanticsMatched = shots.count { it.verifySemantics?.result == "match" },
+                renderMsTotal = shots.sumOf { it.renderMs ?: 0 },
             ),
             shots = shots,
         )
     }
 
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught", "LongParameterList", "CyclomaticComplexMethod")
     private fun runShot(
         spec: ShotSpec,
         defaults: ManifestDefaults,
         outDir: File,
         verify: Boolean,
         goldenDir: File?,
+        semantics: Boolean,
+        verifySemantics: Boolean,
+        updateSemantics: Boolean,
+        semanticsFormat: String,
     ): ShotReport {
         val inputDesc = if (spec.preset != null) "preset=${spec.preset}" else "json"
         return try {
@@ -54,12 +81,34 @@ internal class BatchRunner(
                 density = spec.density ?: defaults.density,
             )
             val start = System.currentTimeMillis()
-            val png = app.renderResult(shot, backend).png
+            val result = app.renderResult(shot, backend)
             val ms = System.currentTimeMillis() - start
+            val png = result.png
             val outFile = File(outDir, spec.out ?: "${spec.id}.png").apply {
                 parentFile?.mkdirs()
                 writeBytes(png)
             }
+            val canonical = result.semantics.toCanonicalJson()
+
+            if (updateSemantics && goldenDir != null) {
+                File(goldenDir, "${spec.id}.semantics.json").apply {
+                    parentFile?.mkdirs()
+                    writeText(canonical)
+                }
+            }
+            val sidecar = if (semantics) {
+                writeSidecar(
+                    spec,
+                    result.semantics,
+                    canonical,
+                    outDir,
+                    semanticsFormat,
+                )
+            } else {
+                null
+            }
+            val semVerify = if (verifySemantics) verifySemanticsShot(spec, canonical, goldenDir) else null
+
             ShotReport(
                 id = spec.id, scene = spec.scene, input = inputDesc, theme = shot.theme,
                 sizePx = listOf(
@@ -68,10 +117,36 @@ internal class BatchRunner(
                 ),
                 out = outFile.path, bytes = png.size, renderMs = ms, status = "ok",
                 verify = if (verify) verifyShot(spec, png, goldenDir, outDir) else null,
+                verifySemantics = semVerify,
+                semanticsSidecar = sidecar?.path,
+                semanticsBytes = if (semantics || verifySemantics) canonical.toByteArray().size else null,
             )
         } catch (e: Exception) {
             ShotReport(id = spec.id, scene = spec.scene, input = inputDesc, status = "error", error = e.message)
         }
+    }
+
+    private fun writeSidecar(
+        spec: ShotSpec,
+        dump: SemanticsDump,
+        canonical: String,
+        outDir: File,
+        format: String,
+    ): File {
+        val ext = if (format == "json") "semantics.json" else "semantics.txt"
+        val body = if (format == "json") canonical else dump.toText()
+        return File(outDir, "${spec.id}.$ext").apply {
+            parentFile?.mkdirs()
+            writeText(body)
+        }
+    }
+
+    private fun verifySemanticsShot(spec: ShotSpec, canonical: String, goldenDir: File?): SemanticsVerifyReport {
+        val goldenFile = File(goldenDir ?: File("."), "${spec.id}.semantics.json")
+        val golden = goldenFile.takeIf { it.isFile }?.readText()
+            ?: return SemanticsVerifyReport(goldenFile.path, "missing-golden")
+        val r = semanticsDiffer.compare(golden, canonical)
+        return SemanticsVerifyReport(goldenFile.path, r.result, r.delta.takeIf { it.isNotEmpty() })
     }
 
     private fun verifyShot(spec: ShotSpec, png: ByteArray, goldenDir: File?, outDir: File): VerifyReport {

--- a/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/DashboardGenerator.kt
+++ b/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/DashboardGenerator.kt
@@ -23,7 +23,7 @@ internal object DashboardGenerator {
 
     private fun rank(s: ShotReport): Int = when {
         s.status == "error" -> 0
-        s.verify?.result == "mismatch" -> 1
+        s.verify?.result == "mismatch" || s.verifySemantics?.result == "mismatch" -> 1
         s.verify?.result == "missing-golden" -> 2
         else -> 3
     }
@@ -46,6 +46,7 @@ internal object DashboardGenerator {
     <span class="fail">${t.failed} failed</span>
     <span class="fail">${t.mismatched} mismatched</span>
     <span class="warn">${t.missingGolden} missing-golden</span>
+    <span class="fail">${t.semanticsMismatched} semantics-mismatched</span>
   </div>
 </header>
 <main>
@@ -125,6 +126,13 @@ $LIGHTBOX
         else -> """<span class="pill ok">ok</span>"""
     }
 
+    private fun semanticsPillFor(s: ShotReport): String? = when (s.verifySemantics?.result) {
+        "mismatch" -> """<span class="pill bad">semantics mismatch</span>"""
+        "missing-golden" -> """<span class="pill warn">no semantics golden</span>"""
+        "match" -> """<span class="pill ok">semantics match</span>"""
+        else -> null
+    }
+
     private fun rel(path: String, outDir: File): String =
         runCatching { File(path).relativeTo(outDir).path }.getOrNull() ?: File(path).name
 
@@ -148,8 +156,8 @@ $LIGHTBOX
     }
 
     private fun card(s: ShotReport, outDir: File): String {
-        val bad = s.status == "error" || s.verify?.result == "mismatch"
-        val pill = pillFor(s)
+        val bad = s.status == "error" || s.verify?.result == "mismatch" || s.verifySemantics?.result == "mismatch"
+        val pill = pillFor(s) + (semanticsPillFor(s)?.let { " $it" } ?: "")
         val imgs = imgsFor(s, outDir)
         val meta = buildString {
             append("""<div class="meta">""")

--- a/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/RenderBackend.kt
+++ b/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/RenderBackend.kt
@@ -3,6 +3,10 @@
 package org.reduxkotlin.snapshot
 
 import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.unit.Density
 import org.jetbrains.skia.EncodedImageFormat
 
@@ -30,9 +34,50 @@ internal class ImageComposeSceneBackend : RenderBackend {
         return try {
             val png = scene.render().encodeToData(EncodedImageFormat.PNG)?.bytes
                 ?: error("PNG encode returned null")
-            RenderResult(png, SemanticsDump.EMPTY)
+            RenderResult(png, extractSemantics(scene))
         } finally {
             scene.close()
         }
     }
+
+    // Reading the experimental semantics tree must never fail a render: pixels are the primary
+    // artifact. Any failure degrades to SemanticsDump.EMPTY while keeping the PNG.
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private fun extractSemantics(scene: ImageComposeScene): SemanticsDump = try {
+        val roots = scene.semanticsOwners
+            .sortedBy { it.rootSemanticsNode.id }
+            .map { toNode(it.rootSemanticsNode) }
+        if (roots.isEmpty()) {
+            SemanticsDump.EMPTY
+        } else {
+            val texts = mutableListOf<String>()
+            roots.forEach { collectTexts(it, texts) }
+            SemanticsDump(roots, texts)
+        }
+    } catch (e: Exception) {
+        SemanticsDump.EMPTY
+    }
+
+    private fun toNode(n: SemanticsNode): SemanticsDump.Node {
+        val cfg = n.config
+        return SemanticsDump.Node(
+            role = cfg.getOrNull(SemanticsProperties.Role)?.toString()?.lowercase(),
+            text = cfg.getOrNull(SemanticsProperties.Text)?.map { it.text } ?: emptyList(),
+            contentDescription = cfg.getOrNull(SemanticsProperties.ContentDescription) ?: emptyList(),
+            testTag = cfg.getOrNull(SemanticsProperties.TestTag),
+            enabled = if (cfg.contains(SemanticsProperties.Disabled)) false else null,
+            selected = cfg.getOrNull(SemanticsProperties.Selected),
+            toggle = cfg.getOrNull(SemanticsProperties.ToggleableState)?.toString(),
+            children = n.children.map { toNode(it) },
+        )
+    }
+
+    private fun collectTexts(n: SemanticsDump.Node, out: MutableList<String>) {
+        out += n.text
+        n.children.forEach { collectTexts(it, out) }
+    }
+
+    // Public SemanticsConfiguration API is get(key) + contains(key); this pairs them safely.
+    private fun <T> SemanticsConfiguration.getOrNull(key: SemanticsPropertyKey<T>): T? =
+        if (contains(key)) get(key) else null
 }

--- a/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/RenderBackend.kt
+++ b/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/RenderBackend.kt
@@ -6,22 +6,6 @@ import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.unit.Density
 import org.jetbrains.skia.EncodedImageFormat
 
-/**
- * A deterministic dump of a rendered scene's content, beside the pixels. In this slice it carries
- * only the rendered text strings; the node/role tree is added in a later plan. Lets a consumer
- * assert content without relying on vision over the PNG.
- */
-public class SemanticsDump(
-    /** Rendered text strings, in traversal order. */
-    public val texts: List<String>,
-) {
-    /** Shared instances. */
-    public companion object {
-        /** An empty dump (no semantics captured). */
-        public val EMPTY: SemanticsDump = SemanticsDump(emptyList())
-    }
-}
-
 /** The output of a render: PNG bytes plus a [SemanticsDump]. */
 public class RenderResult(
     /** Encoded PNG bytes. */

--- a/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/Report.kt
+++ b/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/Report.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 /** The canonical batch report (also the contract the future HTML dashboard renders over). */
 @Serializable
 internal data class SnapshotReport(
-    val schemaVersion: Int = 1,
+    val schemaVersion: Int = 2,
     val runId: String,
     val outDir: String,
     val totals: Totals,
@@ -14,9 +14,19 @@ internal data class SnapshotReport(
 
 /** Run roll-up counts. */
 @Serializable
-internal data class Totals(val total: Int, val ok: Int, val failed: Int, val mismatched: Int, val missingGolden: Int)
+internal data class Totals(
+    val total: Int,
+    val ok: Int,
+    val failed: Int,
+    val mismatched: Int,
+    val missingGolden: Int,
+    val semanticsMismatched: Int = 0,
+    val semanticsMissingGolden: Int = 0,
+    val semanticsMatched: Int = 0,
+    val renderMsTotal: Long = 0,
+)
 
-/** One shot's result. [status] is `ok` or `error`; [verify] present only when verifying. */
+/** One shot's result. [status] is `ok` or `error`; [verify]/[verifySemantics] present only when verifying. */
 @Serializable
 internal data class ShotReport(
     val id: String,
@@ -30,6 +40,9 @@ internal data class ShotReport(
     val status: String,
     val error: String? = null,
     val verify: VerifyReport? = null,
+    val verifySemantics: SemanticsVerifyReport? = null,
+    val semanticsSidecar: String? = null,
+    val semanticsBytes: Int? = null,
 )
 
 /** Golden comparison for one shot. [result] is `match` | `mismatch` | `missing-golden`. */
@@ -40,3 +53,7 @@ internal data class VerifyReport(
     val diffPercent: Double,
     val diffImage: String? = null,
 )
+
+/** Semantics golden comparison for one shot. [result] is `match` | `mismatch` | `missing-golden`. */
+@Serializable
+internal data class SemanticsVerifyReport(val golden: String, val result: String, val delta: List<String>? = null)

--- a/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/Semantics.kt
+++ b/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/Semantics.kt
@@ -61,7 +61,9 @@ public class SemanticsDump(
             n.selected?.let { add("selected=$it") }
             n.toggle?.let { add("toggle=$it") }
         }
-        sb.append(indent).append("node").append(if (fields.isEmpty()) "" else " " + fields.joinToString(" ")).append('\n')
+        sb.append(
+            indent,
+        ).append("node").append(if (fields.isEmpty()) "" else " " + fields.joinToString(" ")).append('\n')
         n.children.forEach { appendNode(it, depth + 1, sb) }
     }
 
@@ -70,6 +72,10 @@ public class SemanticsDump(
     public companion object {
         /** An empty dump (no semantics captured). */
         public val EMPTY: SemanticsDump = SemanticsDump(roots = emptyList(), texts = emptyList())
-        private val CANONICAL = Json { prettyPrint = true; encodeDefaults = true; prettyPrintIndent = "  " }
+        private val CANONICAL = Json {
+            prettyPrint = true
+            encodeDefaults = true
+            prettyPrintIndent = "  "
+        }
     }
 }

--- a/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/Semantics.kt
+++ b/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/Semantics.kt
@@ -1,0 +1,75 @@
+package org.reduxkotlin.snapshot
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+
+/**
+ * A deterministic, bounds-free dump of a rendered scene's semantics, beside the pixels.
+ * Lets a consumer (e.g. an AI agent) assert content as text/JSON instead of reading the PNG.
+ * Ordering is by semantics-node id (owners) and layout order (children) — never pixel position —
+ * so the [toCanonicalJson] form is stable across architectures.
+ */
+public class SemanticsDump(
+    /** One tree per Compose `SemanticsOwner` (a Popup/Dialog gets its own). Empty when nothing captured. */
+    public val roots: List<Node>,
+    /** All rendered text strings, pre-order, flattened. Kept for simple text assertions. */
+    public val texts: List<String>,
+) {
+    /** One semantics node: its merged role/text/state plus merged children. Carries no bounds. */
+    @Serializable
+    public class Node(
+        /** Accessibility role, lowercased (e.g. `button`), or null. */
+        public val role: String?,
+        /** Text on this node, in order (a merge boundary absorbs descendants' text). */
+        public val text: List<String>,
+        /** Content descriptions on this node, in order. */
+        public val contentDescription: List<String>,
+        /** Test tag, or null. */
+        public val testTag: String?,
+        /** `false` when the node is marked disabled; otherwise null (tri-state: never `true`). */
+        public val enabled: Boolean?,
+        /** Selected state, or null if unspecified. */
+        public val selected: Boolean?,
+        /** Toggleable state name (`On`/`Off`/`Indeterminate`), or null. */
+        public val toggle: String?,
+        /** Merged child nodes, in layout order. */
+        public val children: List<Node>,
+    )
+
+    /** Compact indented tree — the default agent/human form. One node per line, 2-space indent per depth. */
+    public fun toText(): String {
+        if (roots.isEmpty()) return "(no semantics)"
+        val sb = StringBuilder()
+        roots.forEach { appendNode(it, 0, sb) }
+        return sb.toString().trimEnd('\n')
+    }
+
+    /** The single JSON form: pretty, stable field order, no bounds. Used for `--semantics-format json` and goldens. */
+    @OptIn(ExperimentalSerializationApi::class)
+    public fun toCanonicalJson(): String = CANONICAL.encodeToString(ListSerializer(Node.serializer()), roots)
+
+    private fun appendNode(n: Node, depth: Int, sb: StringBuilder) {
+        val indent = "  ".repeat(depth)
+        val fields = buildList {
+            n.role?.let { add("role=$it") }
+            if (n.text.isNotEmpty()) add("text=${n.text}")
+            if (n.contentDescription.isNotEmpty()) add("desc=${n.contentDescription}")
+            n.testTag?.let { add("testTag=$it") }
+            n.enabled?.let { add("enabled=$it") }
+            n.selected?.let { add("selected=$it") }
+            n.toggle?.let { add("toggle=$it") }
+        }
+        sb.append(indent).append("node").append(if (fields.isEmpty()) "" else " " + fields.joinToString(" ")).append('\n')
+        n.children.forEach { appendNode(it, depth + 1, sb) }
+    }
+
+    /** Shared instances. */
+    @OptIn(ExperimentalSerializationApi::class)
+    public companion object {
+        /** An empty dump (no semantics captured). */
+        public val EMPTY: SemanticsDump = SemanticsDump(roots = emptyList(), texts = emptyList())
+        private val CANONICAL = Json { prettyPrint = true; encodeDefaults = true; prettyPrintIndent = "  " }
+    }
+}

--- a/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/SemanticsDiffer.kt
+++ b/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/SemanticsDiffer.kt
@@ -1,0 +1,33 @@
+package org.reduxkotlin.snapshot
+
+/** Result of a semantics comparison: a lowercase [result] and a bounded, readable [delta]. */
+public class SemanticsDiffResult(
+    /** `match` when the canonical forms are equal, else `mismatch`. */
+    public val result: String,
+    /** Line-level delta (`-` golden-only, `+` actual-only); empty on match. Capped, may end with an overflow marker. */
+    public val delta: List<String>,
+)
+
+/**
+ * Compares two canonical semantics forms ([SemanticsDump.toCanonicalJson]) by string equality and,
+ * on mismatch, emits a bounded line diff. A structured per-node differ is intentionally deferred:
+ * the gate is equality, and the line diff is a readable-enough signal. Lines present in both forms
+ * are elided; a changed value line surfaces as a `-`/`+` pair.
+ */
+public class SemanticsDiffer(private val maxDeltaLines: Int = 40) {
+    /** Compares [golden] vs [actual] canonical strings. */
+    public fun compare(golden: String, actual: String): SemanticsDiffResult {
+        if (golden == actual) return SemanticsDiffResult("match", emptyList())
+        val g = golden.lines()
+        val a = actual.lines()
+        val gSet = g.toSet()
+        val aSet = a.toSet()
+        val lines = g.filter { it !in aSet }.map { "- $it" } + a.filter { it !in gSet }.map { "+ $it" }
+        val capped = if (lines.size > maxDeltaLines) {
+            lines.take(maxDeltaLines) + "… (${lines.size - maxDeltaLines} more)"
+        } else {
+            lines
+        }
+        return SemanticsDiffResult("mismatch", capped)
+    }
+}

--- a/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/SemanticsDiffer.kt
+++ b/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/SemanticsDiffer.kt
@@ -1,11 +1,11 @@
 package org.reduxkotlin.snapshot
 
 /** Result of a semantics comparison: a lowercase [result] and a bounded, readable [delta]. */
-public class SemanticsDiffResult(
+internal class SemanticsDiffResult(
     /** `match` when the canonical forms are equal, else `mismatch`. */
-    public val result: String,
+    val result: String,
     /** Line-level delta (`-` golden-only, `+` actual-only); empty on match. Capped, may end with an overflow marker. */
-    public val delta: List<String>,
+    val delta: List<String>,
 )
 
 /**
@@ -14,9 +14,9 @@ public class SemanticsDiffResult(
  * the gate is equality, and the line diff is a readable-enough signal. Lines present in both forms
  * are elided; a changed value line surfaces as a `-`/`+` pair.
  */
-public class SemanticsDiffer(private val maxDeltaLines: Int = 40) {
+internal class SemanticsDiffer(private val maxDeltaLines: Int = 40) {
     /** Compares [golden] vs [actual] canonical strings. */
-    public fun compare(golden: String, actual: String): SemanticsDiffResult {
+    fun compare(golden: String, actual: String): SemanticsDiffResult {
         if (golden == actual) return SemanticsDiffResult("match", emptyList())
         val g = golden.lines()
         val a = actual.lines()

--- a/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/cli/Cli.kt
+++ b/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/cli/Cli.kt
@@ -197,7 +197,7 @@ private class SnapshotCommand(private val app: SnapshotApp) : CliktCommand(name 
         }
         val runId = "run-${System.currentTimeMillis()}"
         val report = BatchRunner(app, BACKEND).run(
-            manifest, outDir, verify = goldenDir != null, goldenDir, runId,
+            manifest, outDir, verify = goldenDir != null && !updateSemantics, goldenDir, runId,
             semantics = semantics, verifySemantics = verifySemantics,
             updateSemantics = updateSemantics, semanticsFormat = semanticsFormat,
         )
@@ -220,6 +220,10 @@ private class SnapshotCommand(private val app: SnapshotApp) : CliktCommand(name 
             )
             echoDrift(report) { echo(it) }
         }
+        // --update-semantics (re)writes each shot's canonical form and exits 0 without gating —
+        // BatchRunner already wrote the semantics goldens above; the pixel/semantics failure gate
+        // below only applies to normal and --verify-semantics runs.
+        if (updateSemantics) return
         if (report.totals.failed > 0 || report.totals.mismatched > 0 || report.totals.semanticsMismatched > 0) {
             throw CliktError(
                 "batch had ${report.totals.failed} failed / ${report.totals.mismatched} mismatched / " +

--- a/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/cli/Cli.kt
+++ b/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/cli/Cli.kt
@@ -189,13 +189,18 @@ private class SnapshotCommand(private val app: SnapshotApp) : CliktCommand(name 
 
     private fun runBatch(file: File) {
         requireManifest(file)
+        requireBatchSemanticsGuards(verifySemantics, updateSemantics, goldenDir)
         val manifest = try {
             Json.decodeFromString(BatchManifest.serializer(), file.readText())
         } catch (e: SerializationException) {
             throw CliktError("invalid --batch manifest: ${e.message}", cause = e, statusCode = 2)
         }
         val runId = "run-${System.currentTimeMillis()}"
-        val report = BatchRunner(app, BACKEND).run(manifest, outDir, verify = goldenDir != null, goldenDir, runId)
+        val report = BatchRunner(app, BACKEND).run(
+            manifest, outDir, verify = goldenDir != null, goldenDir, runId,
+            semantics = semantics, verifySemantics = verifySemantics,
+            updateSemantics = updateSemantics, semanticsFormat = semanticsFormat,
+        )
         val json = Json { prettyPrint = true }.encodeToString(SnapshotReport.serializer(), report)
         File(outDir, "report.json").apply {
             parentFile?.mkdirs()
@@ -209,11 +214,16 @@ private class SnapshotCommand(private val app: SnapshotApp) : CliktCommand(name 
             echo(json)
         } else {
             val t = report.totals
-            echo("batch: ${t.ok}/${t.total} ok, ${t.failed} failed, ${t.mismatched} mismatched -> ${outDir.path}")
+            echo(
+                "batch: ${t.ok}/${t.total} ok, ${t.failed} failed, ${t.mismatched} mismatched, " +
+                    "${t.semanticsMismatched} semantics-mismatched -> ${outDir.path}",
+            )
+            echoDrift(report) { echo(it) }
         }
-        if (report.totals.failed > 0 || report.totals.mismatched > 0) {
+        if (report.totals.failed > 0 || report.totals.mismatched > 0 || report.totals.semanticsMismatched > 0) {
             throw CliktError(
-                "batch had ${report.totals.failed} failed / ${report.totals.mismatched} mismatched",
+                "batch had ${report.totals.failed} failed / ${report.totals.mismatched} mismatched / " +
+                    "${report.totals.semanticsMismatched} semantics-mismatched",
                 statusCode = 1,
             )
         }
@@ -264,5 +274,32 @@ private class SnapshotCommand(private val app: SnapshotApp) : CliktCommand(name 
 
     private companion object {
         val BACKEND = ImageComposeSceneBackend()
+    }
+}
+
+// Kept as a top-level function (rather than a SnapshotCommand member) so the batch semantics
+// guard doesn't push the command class over detekt's TooManyFunctions budget, and so runBatch's
+// own ThrowsCount stays within the two-throw limit.
+private fun requireBatchSemanticsGuards(verifySemantics: Boolean, updateSemantics: Boolean, goldenDir: File?) {
+    if (verifySemantics && goldenDir == null) {
+        throw CliktError("--verify-semantics needs --golden-dir", statusCode = 2)
+    }
+    if (updateSemantics && goldenDir == null) {
+        throw CliktError("--update-semantics (batch) needs --golden-dir", statusCode = 2)
+    }
+}
+
+// Terse drift-only block: one line per shot that errored or mismatched (pixel or semantics),
+// with any semantics delta lines indented beneath it. Top-level (not a SnapshotCommand member)
+// for the same TooManyFunctions/ThrowsCount budget reasons as [requireBatchSemanticsGuards].
+private fun echoDrift(report: SnapshotReport, echo: (String) -> Unit) {
+    report.shots.filter {
+        it.status == "error" || it.verify?.result == "mismatch" || it.verifySemantics?.result == "mismatch"
+    }.forEach { s ->
+        echo(
+            "  drift ${s.id}: pixel=${s.verify?.result ?: "-"} semantics=${s.verifySemantics?.result ?: "-"} " +
+                "png=${s.out ?: "-"} diff=${s.verify?.diffImage ?: "-"} sidecar=${s.semanticsSidecar ?: "-"}",
+        )
+        s.verifySemantics?.delta?.forEach { echo("    $it") }
     }
 }

--- a/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/cli/Cli.kt
+++ b/redux-kotlin-snapshot/src/main/kotlin/org/reduxkotlin/snapshot/cli/Cli.kt
@@ -5,6 +5,7 @@ import com.github.ajalt.clikt.core.CliktError
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.file
 import com.github.ajalt.clikt.parameters.types.int
 import kotlinx.serialization.SerializationException
@@ -21,6 +22,8 @@ import org.reduxkotlin.snapshot.DiffDefaults
 import org.reduxkotlin.snapshot.DiffVerdict
 import org.reduxkotlin.snapshot.Differ
 import org.reduxkotlin.snapshot.ImageComposeSceneBackend
+import org.reduxkotlin.snapshot.RenderResult
+import org.reduxkotlin.snapshot.SemanticsDiffer
 import org.reduxkotlin.snapshot.SnapshotApp
 import org.reduxkotlin.snapshot.SnapshotException
 import org.reduxkotlin.snapshot.SnapshotInput
@@ -61,6 +64,24 @@ private class SnapshotCommand(private val app: SnapshotApp) : CliktCommand(name 
     private val goldenDir by option("--golden-dir", help = "Golden dir; its presence verifies the batch").file()
     private val jsonMode by option("--json", help = "Emit machine JSON on stdout").flag()
     private val dashboard by option("--dashboard", help = "Also write a static index.html over the report").flag()
+    private val semantics by option(
+        "--semantics",
+        help = "Emit the semantics dump (stdout single; sidecar batch)",
+    ).flag()
+    private val semanticsFormat by option("--semantics-format", help = "Dump format")
+        .choice("json", "text").default("text")
+    private val verifySemanticsFile by option(
+        "--verify-semantics-file",
+        help = "Semantics golden to compare against (single shot)",
+    ).file()
+    private val verifySemantics by option(
+        "--verify-semantics",
+        help = "Enable the semantics golden gate (batch; needs --golden-dir)",
+    ).flag()
+    private val updateSemantics by option(
+        "--update-semantics",
+        help = "Write/update semantics golden(s), then exit 0",
+    ).flag()
 
     override fun run() {
         val b = batch
@@ -72,49 +93,98 @@ private class SnapshotCommand(private val app: SnapshotApp) : CliktCommand(name 
     }
 
     // Converting any render failure into a clean CLI error (exit 1) is the intended "never crash"
-    // contract; the multiple throws are usage/validation guards. Both are idiomatic for a CLI.
-    @Suppress("ThrowsCount", "TooGenericExceptionCaught")
+    // contract. Sub-steps (parse input, render, each gate) are split into helpers below to keep
+    // this orchestration method within the complexity/length budget.
     private fun runSingle() {
         val sceneName = scene ?: throw CliktError("missing --scene (or pass --list)", statusCode = 2)
         if ((preset == null) == (stateJson == null)) {
             throw CliktError("provide exactly one of --preset or --state-json", statusCode = 2)
         }
-        val input = try {
-            preset?.let { SnapshotInput.Preset(it) }
-                ?: SnapshotInput.Json(Json.parseToJsonElement(stateJson!!))
-        } catch (e: SerializationException) {
-            throw CliktError("invalid --state-json: ${e.message}", cause = e, statusCode = 2)
-        }
-        val png = try {
-            val shot = app.resolve(sceneName, input, theme, width, height, null)
-            app.renderResult(shot, BACKEND).png
-        } catch (e: SnapshotException) {
-            throw CliktError(e.message ?: "usage error", cause = e, statusCode = 2)
-        } catch (e: Exception) {
-            throw CliktError("render failed: ${e.message}", cause = e, statusCode = 1)
-        }
+        val result = renderSingle(sceneName, parseSingleInput())
+        val png = result.png
         out?.apply {
             parentFile?.mkdirs()
             writeBytes(png)
         }
-        verify?.let { golden ->
-            if (!golden.isFile) {
-                throw CliktError(
-                    "--verify golden not found: ${golden.absolutePath}\n" +
-                        "  Generate it first with --out ${golden.path} (no --verify), then re-run with --verify.",
-                    statusCode = 2,
-                )
-            }
-            val r = Differ().compare(
-                golden.readBytes(),
-                png,
-                tolerance = DiffDefaults.TOLERANCE,
-                maxDiffPercent = DiffDefaults.BATCH_MAX_DIFF_PERCENT,
-            )
-            echo("verify: ${r.verdict} (${"%.3f".format(r.diffPercent)}%)")
-            if (r.verdict == DiffVerdict.MISMATCH) throw CliktError("golden mismatch", statusCode = 1)
+
+        val canonical = result.semantics.toCanonicalJson()
+        if (updateSemantics) {
+            writeSemanticsGolden(canonical)
+            return
         }
+        emitSemanticsDump(result, canonical)
+        verifySemanticsGate(canonical)
+        verifyPixelGate(png)
         out?.let { echo("wrote ${it.path} (${png.size} B)") }
+    }
+
+    private fun parseSingleInput(): SnapshotInput = try {
+        preset?.let { SnapshotInput.Preset(it) }
+            ?: SnapshotInput.Json(Json.parseToJsonElement(stateJson!!))
+    } catch (e: SerializationException) {
+        throw CliktError("invalid --state-json: ${e.message}", cause = e, statusCode = 2)
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun renderSingle(sceneName: String, input: SnapshotInput) = try {
+        val shot = app.resolve(sceneName, input, theme, width, height, null)
+        app.renderResult(shot, BACKEND)
+    } catch (e: SnapshotException) {
+        throw CliktError(e.message ?: "usage error", cause = e, statusCode = 2)
+    } catch (e: Exception) {
+        throw CliktError("render failed: ${e.message}", cause = e, statusCode = 1)
+    }
+
+    private fun writeSemanticsGolden(canonical: String) {
+        val golden = verifySemanticsFile
+            ?: throw CliktError("--update-semantics needs --verify-semantics-file", statusCode = 2)
+        golden.parentFile?.mkdirs()
+        golden.writeText(canonical)
+        echo("wrote semantics golden ${golden.path}")
+    }
+
+    private fun emitSemanticsDump(result: RenderResult, canonical: String) {
+        if (!semantics) return
+        val dump = if (semanticsFormat == "json") canonical else result.semantics.toText()
+        val sidecarExt = if (semanticsFormat == "json") ".semantics.json" else ".semantics.txt"
+        out?.let { File(it.path + sidecarExt).writeText(dump) }
+        echo(dump)
+    }
+
+    private fun verifySemanticsGate(canonical: String) {
+        val golden = verifySemanticsFile ?: return
+        if (!golden.isFile) {
+            throw CliktError(
+                "--verify-semantics-file golden not found: ${golden.absolutePath}\n" +
+                    "  Generate it first with --update-semantics --verify-semantics-file ${golden.path}.",
+                statusCode = 2,
+            )
+        }
+        val r = SemanticsDiffer().compare(golden.readText(), canonical)
+        echo("verify-semantics: ${r.result}")
+        if (r.result == "mismatch") {
+            r.delta.forEach { echo(it) }
+            throw CliktError("semantics golden mismatch", statusCode = 1)
+        }
+    }
+
+    private fun verifyPixelGate(png: ByteArray) {
+        val golden = verify ?: return
+        if (!golden.isFile) {
+            throw CliktError(
+                "--verify golden not found: ${golden.absolutePath}\n" +
+                    "  Generate it first with --out ${golden.path} (no --verify), then re-run with --verify.",
+                statusCode = 2,
+            )
+        }
+        val r = Differ().compare(
+            golden.readBytes(),
+            png,
+            tolerance = DiffDefaults.TOLERANCE,
+            maxDiffPercent = DiffDefaults.BATCH_MAX_DIFF_PERCENT,
+        )
+        echo("verify: ${r.verdict} (${"%.3f".format(r.diffPercent)}%)")
+        if (r.verdict == DiffVerdict.MISMATCH) throw CliktError("golden mismatch", statusCode = 1)
     }
 
     private fun runBatch(file: File) {

--- a/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/BatchRunnerTest.kt
+++ b/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/BatchRunnerTest.kt
@@ -10,6 +10,11 @@ import kotlin.test.assertTrue
 
 internal class BatchRunnerTest {
     private fun tmp(prefix: String): File = Files.createTempDirectory(prefix).toFile()
+    private fun newTmpDir(): File = File.createTempFile("rkbatch", "").let {
+        it.delete()
+        it.mkdirs()
+        it
+    }
 
     @Test fun parses_manifest_json() {
         val m = Json.decodeFromString(
@@ -54,5 +59,71 @@ internal class BatchRunnerTest {
         val report = BatchRunner(demoSnapshots).run(manifest, out, verify = true, goldenDir = gdir, runId = "t")
         assertEquals("match", report.shots.first { it.id == "ok1" }.verify?.result)
         assertEquals("missing-golden", report.shots.first { it.id == "absent" }.verify?.result)
+    }
+
+    @Test fun batch_writes_semantics_sidecars_when_requested() {
+        val manifest = BatchManifest(shots = listOf(ShotSpec(id = "d", scene = "demo", preset = "default")))
+        val outDir = newTmpDir()
+        val report = BatchRunner(demoSnapshots).run(
+            manifest,
+            outDir,
+            verify = false,
+            goldenDir = null,
+            runId = "r",
+            semantics = true,
+        )
+        val sidecar = File(outDir, "d.semantics.txt")
+        assertTrue(sidecar.isFile, "sidecar missing")
+        assertEquals(sidecar.path, report.shots.single().semanticsSidecar)
+        assertTrue((report.shots.single().semanticsBytes ?: 0) > 0)
+    }
+
+    @Test fun semantics_verify_missing_golden_is_non_failing() {
+        val manifest = BatchManifest(shots = listOf(ShotSpec(id = "d", scene = "demo", preset = "default")))
+        val goldenDir = newTmpDir() // empty
+        val report = BatchRunner(demoSnapshots).run(
+            manifest,
+            newTmpDir(),
+            verify = false,
+            goldenDir = goldenDir,
+            runId = "r",
+            verifySemantics = true,
+        )
+        assertEquals("missing-golden", report.shots.single().verifySemantics?.result)
+        assertEquals(0, report.totals.semanticsMismatched)
+    }
+
+    @Test fun update_semantics_writes_golden_then_verify_matches() {
+        val manifest = BatchManifest(shots = listOf(ShotSpec(id = "d", scene = "demo", preset = "default")))
+        val goldenDir = newTmpDir()
+        // 1) author baseline
+        BatchRunner(demoSnapshots).run(
+            manifest,
+            newTmpDir(),
+            verify = false,
+            goldenDir = goldenDir,
+            runId = "r",
+            updateSemantics = true,
+        )
+        assertTrue(File(goldenDir, "d.semantics.json").isFile)
+        // 2) verify against it
+        val report = BatchRunner(demoSnapshots).run(
+            manifest,
+            newTmpDir(),
+            verify = false,
+            goldenDir = goldenDir,
+            runId = "r2",
+            verifySemantics = true,
+        )
+        assertEquals("match", report.shots.single().verifySemantics?.result)
+        assertEquals(1, report.totals.semanticsMatched)
+    }
+
+    @Test fun totals_aggregate_render_ms() {
+        val manifest = BatchManifest(shots = listOf(ShotSpec(id = "d", scene = "demo", preset = "default")))
+        val report = BatchRunner(
+            demoSnapshots,
+        ).run(manifest, newTmpDir(), verify = false, goldenDir = null, runId = "r")
+        assertTrue(report.totals.renderMsTotal >= 0)
     }
 }

--- a/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/BatchRunnerTest.kt
+++ b/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/BatchRunnerTest.kt
@@ -124,6 +124,6 @@ internal class BatchRunnerTest {
         val report = BatchRunner(
             demoSnapshots,
         ).run(manifest, newTmpDir(), verify = false, goldenDir = null, runId = "r")
-        assertTrue(report.totals.renderMsTotal >= 0)
+        assertEquals(report.shots.sumOf { it.renderMs ?: 0 }, report.totals.renderMsTotal)
     }
 }

--- a/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/CliTest.kt
+++ b/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/CliTest.kt
@@ -214,6 +214,35 @@ internal class CliTest {
         assertEquals(2, r.statusCode, r.output)
     }
 
+    @Test fun batch_update_semantics_without_golden_dir_exits_2() {
+        val manifest = File(tmp, "us.json").apply {
+            writeText("""{"shots":[{"id":"a","scene":"demo","preset":"default"}]}""")
+        }
+        val r = snapshotCommand(demoSnapshots)
+            .test(listOf("--batch", manifest.path, "--out-dir", File(tmp, "usout").path, "--update-semantics"))
+        assertEquals(2, r.statusCode, r.output)
+    }
+
+    @Test fun batch_update_semantics_exits_0_and_writes_golden_without_pixel_gate() {
+        val goldenDir = File(tmp, "ug").apply { mkdirs() }
+        val manifest = File(tmp, "ug.json").apply {
+            writeText("""{"shots":[{"id":"a","scene":"demo","preset":"default"}]}""")
+        }
+        val r = snapshotCommand(demoSnapshots).test(
+            listOf(
+                "--batch",
+                manifest.path,
+                "--out-dir",
+                File(tmp, "ugout").path,
+                "--golden-dir",
+                goldenDir.path,
+                "--update-semantics",
+            ),
+        )
+        assertEquals(0, r.statusCode, r.output)
+        assertTrue(File(goldenDir, "a.semantics.json").isFile)
+    }
+
     @Test fun batch_semantics_writes_sidecars() {
         val manifest = File(tmp, "sc.json").apply {
             writeText("""{"shots":[{"id":"a","scene":"demo","preset":"default"}]}""")

--- a/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/CliTest.kt
+++ b/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/CliTest.kt
@@ -111,4 +111,55 @@ internal class CliTest {
         assertEquals(0, r.statusCode, r.output)
         assertTrue(File(outDir, "index.html").isFile)
     }
+
+    @Test fun single_semantics_text_prints_dump() {
+        val r = snapshotCommand(demoSnapshots)
+            .test(listOf("--scene", "demo", "--preset", "default", "--semantics"))
+        assertEquals(0, r.statusCode, r.output)
+        assertTrue("node" in r.output, r.output)
+    }
+
+    @Test fun single_semantics_json_prints_json() {
+        val r = snapshotCommand(demoSnapshots)
+            .test(listOf("--scene", "demo", "--preset", "default", "--semantics", "--semantics-format", "json"))
+        assertEquals(0, r.statusCode, r.output)
+        assertTrue(r.output.trimStart().startsWith("["), r.output)
+    }
+
+    @Test fun update_semantics_then_verify_matches() {
+        val golden = File(tmp, "demo.semantics.json")
+        val g = snapshotCommand(demoSnapshots).test(
+            listOf(
+                "--scene",
+                "demo",
+                "--preset",
+                "default",
+                "--update-semantics",
+                "--verify-semantics-file",
+                golden.path,
+            ),
+        )
+        assertEquals(0, g.statusCode, g.output)
+        assertTrue(golden.isFile)
+        val v = snapshotCommand(demoSnapshots).test(
+            listOf("--scene", "demo", "--preset", "default", "--verify-semantics-file", golden.path),
+        )
+        assertEquals(0, v.statusCode, v.output)
+        assertTrue("match" in v.output, v.output)
+    }
+
+    @Test fun verify_semantics_mismatch_exits_1() {
+        val golden = File(tmp, "wrong.semantics.json").apply { writeText("[]") }
+        val r = snapshotCommand(demoSnapshots).test(
+            listOf("--scene", "demo", "--preset", "default", "--verify-semantics-file", golden.path),
+        )
+        assertEquals(1, r.statusCode, r.output)
+        assertTrue("mismatch" in r.output, r.output)
+    }
+
+    @Test fun update_semantics_without_file_exits_2() {
+        val r = snapshotCommand(demoSnapshots)
+            .test(listOf("--scene", "demo", "--preset", "default", "--update-semantics"))
+        assertEquals(2, r.statusCode, r.output)
+    }
 }

--- a/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/CliTest.kt
+++ b/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/CliTest.kt
@@ -204,4 +204,45 @@ internal class CliTest {
         assertTrue(jsonContent.isNotEmpty())
         assertTrue(jsonContent.trimStart().startsWith("["), jsonContent)
     }
+
+    @Test fun batch_verify_semantics_without_golden_dir_exits_2() {
+        val manifest = File(tmp, "vs.json").apply {
+            writeText("""{"shots":[{"id":"a","scene":"demo","preset":"default"}]}""")
+        }
+        val r = snapshotCommand(demoSnapshots)
+            .test(listOf("--batch", manifest.path, "--out-dir", File(tmp, "vsout").path, "--verify-semantics"))
+        assertEquals(2, r.statusCode, r.output)
+    }
+
+    @Test fun batch_semantics_writes_sidecars() {
+        val manifest = File(tmp, "sc.json").apply {
+            writeText("""{"shots":[{"id":"a","scene":"demo","preset":"default"}]}""")
+        }
+        val outDir = File(tmp, "scout")
+        val r = snapshotCommand(demoSnapshots)
+            .test(listOf("--batch", manifest.path, "--out-dir", outDir.path, "--semantics"))
+        assertEquals(0, r.statusCode, r.output)
+        assertTrue(File(outDir, "a.semantics.txt").isFile)
+    }
+
+    @Test fun batch_semantics_mismatch_exits_1_and_lists_drifted() {
+        val goldenDir = File(tmp, "sg").apply { mkdirs() }
+        File(goldenDir, "a.semantics.json").writeText("[]") // wrong baseline -> drift
+        val manifest = File(tmp, "sm.json").apply {
+            writeText("""{"shots":[{"id":"a","scene":"demo","preset":"default"}]}""")
+        }
+        val r = snapshotCommand(demoSnapshots).test(
+            listOf(
+                "--batch",
+                manifest.path,
+                "--out-dir",
+                File(tmp, "smout").path,
+                "--golden-dir",
+                goldenDir.path,
+                "--verify-semantics",
+            ),
+        )
+        assertEquals(1, r.statusCode, r.output)
+        assertTrue("a" in r.output && "mismatch" in r.output, r.output)
+    }
 }

--- a/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/CliTest.kt
+++ b/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/CliTest.kt
@@ -162,4 +162,46 @@ internal class CliTest {
             .test(listOf("--scene", "demo", "--preset", "default", "--update-semantics"))
         assertEquals(2, r.statusCode, r.output)
     }
+
+    @Test fun missing_verify_semantics_file_exits_2_with_fixit_message() {
+        val golden = File(tmp, "absent.semantics.json")
+        val r = snapshotCommand(demoSnapshots).test(
+            listOf("--scene", "demo", "--preset", "default", "--verify-semantics-file", golden.path),
+        )
+        assertEquals(2, r.statusCode, r.output)
+        assertTrue(golden.absolutePath in r.output, "should name the missing semantics golden path")
+        assertTrue("--update-semantics" in r.output, "should tell the user how to generate it")
+    }
+
+    @Test fun single_semantics_with_out_writes_sidecar_files() {
+        val outText = File(tmp, "shot.png")
+        val rText = snapshotCommand(demoSnapshots).test(
+            listOf("--scene", "demo", "--preset", "default", "--out", outText.path, "--semantics"),
+        )
+        assertEquals(0, rText.statusCode, rText.output)
+        val sidecarText = File(tmp, "shot.png.semantics.txt")
+        assertTrue(sidecarText.isFile, "expected sidecar at ${sidecarText.path}")
+        assertTrue(sidecarText.length() > 0)
+
+        val outJson = File(tmp, "shotj.png")
+        val rJson = snapshotCommand(demoSnapshots).test(
+            listOf(
+                "--scene",
+                "demo",
+                "--preset",
+                "default",
+                "--out",
+                outJson.path,
+                "--semantics",
+                "--semantics-format",
+                "json",
+            ),
+        )
+        assertEquals(0, rJson.statusCode, rJson.output)
+        val sidecarJson = File(tmp, "shotj.png.semantics.json")
+        assertTrue(sidecarJson.isFile, "expected sidecar at ${sidecarJson.path}")
+        val jsonContent = sidecarJson.readText()
+        assertTrue(jsonContent.isNotEmpty())
+        assertTrue(jsonContent.trimStart().startsWith("["), jsonContent)
+    }
 }

--- a/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/DashboardGeneratorTest.kt
+++ b/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/DashboardGeneratorTest.kt
@@ -39,4 +39,21 @@ internal class DashboardGeneratorTest {
         assertTrue("lbOpen(" in html && """id="lb"""" in html, "zoom lightbox missing")
         assertTrue("image-rendering:auto" in html, "thumbnails should downscale smoothly")
     }
+
+    @Test fun dashboard_shows_semantics_mismatch() {
+        val report = SnapshotReport(
+            runId = "r", outDir = "o",
+            totals = Totals(total = 1, ok = 0, failed = 0, mismatched = 0, missingGolden = 0, semanticsMismatched = 1),
+            shots = listOf(
+                ShotReport(
+                    id = "a", scene = "demo", input = "preset=default", status = "ok",
+                    verifySemantics = SemanticsVerifyReport("a.semantics.json", "mismatch", listOf("- x", "+ y")),
+                ),
+            ),
+        )
+        val outDir = File.createTempFile("dash", "").let { it.delete(); it.mkdirs(); it }
+        val html = DashboardGenerator.generate(report, outDir).readText()
+        assertTrue("semantics" in html.lowercase(), "should mention semantics")
+        assertTrue("mismatch" in html, "should show the semantics verdict")
+    }
 }

--- a/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/DashboardGeneratorTest.kt
+++ b/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/DashboardGeneratorTest.kt
@@ -56,8 +56,8 @@ internal class DashboardGeneratorTest {
             ),
         )
         val outDir = File.createTempFile("dash", "").let {
-            it.delete();
-            it.mkdirs();
+            it.delete()
+            it.mkdirs()
             it
         }
         val html = DashboardGenerator.generate(report, outDir).readText()

--- a/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/DashboardGeneratorTest.kt
+++ b/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/DashboardGeneratorTest.kt
@@ -42,16 +42,24 @@ internal class DashboardGeneratorTest {
 
     @Test fun dashboard_shows_semantics_mismatch() {
         val report = SnapshotReport(
-            runId = "r", outDir = "o",
+            runId = "r",
+            outDir = "o",
             totals = Totals(total = 1, ok = 0, failed = 0, mismatched = 0, missingGolden = 0, semanticsMismatched = 1),
             shots = listOf(
                 ShotReport(
-                    id = "a", scene = "demo", input = "preset=default", status = "ok",
+                    id = "a",
+                    scene = "demo",
+                    input = "preset=default",
+                    status = "ok",
                     verifySemantics = SemanticsVerifyReport("a.semantics.json", "mismatch", listOf("- x", "+ y")),
                 ),
             ),
         )
-        val outDir = File.createTempFile("dash", "").let { it.delete(); it.mkdirs(); it }
+        val outDir = File.createTempFile("dash", "").let {
+            it.delete();
+            it.mkdirs();
+            it
+        }
         val html = DashboardGenerator.generate(report, outDir).readText()
         assertTrue("semantics" in html.lowercase(), "should mention semantics")
         assertTrue("mismatch" in html, "should show the semantics verdict")

--- a/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/ReportTest.kt
+++ b/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/ReportTest.kt
@@ -1,0 +1,46 @@
+package org.reduxkotlin.snapshot
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class ReportTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test fun schema_version_is_2() {
+        val r = SnapshotReport(runId = "r", outDir = "o", totals = Totals(0, 0, 0, 0, 0), shots = emptyList())
+        assertEquals(2, r.schemaVersion)
+    }
+
+    @Test fun new_shot_fields_default_to_null() {
+        val s = ShotReport(id = "a", scene = "counter", input = "preset=n0", status = "ok")
+        assertEquals(null, s.verifySemantics)
+        assertEquals(null, s.semanticsSidecar)
+        assertEquals(null, s.semanticsBytes)
+    }
+
+    @Test fun new_totals_fields_default_to_zero() {
+        val t = Totals(0, 0, 0, 0, 0)
+        assertEquals(0, t.semanticsMismatched)
+        assertEquals(0, t.semanticsMatched)
+        assertEquals(0L, t.renderMsTotal)
+    }
+
+    @Test fun v1_report_json_parses_under_v2_model() {
+        // A v1 file lacks the new fields; defaults fill them in.
+        val v1 = """{"schemaVersion":1,"runId":"r","outDir":"o",
+            "totals":{"total":1,"ok":1,"failed":0,"mismatched":0,"missingGolden":0},
+            "shots":[{"id":"a","scene":"counter","input":"preset=n0","status":"ok"}]}"""
+        val r = json.decodeFromString(SnapshotReport.serializer(), v1)
+        assertEquals(1, r.shots.size)
+        assertEquals(0, r.totals.semanticsMismatched)
+    }
+
+    @Test fun semantics_verify_report_round_trips() {
+        val sv = SemanticsVerifyReport(golden = "g.semantics.json", result = "mismatch", delta = listOf("- a", "+ b"))
+        val encoded = Json.encodeToString(SemanticsVerifyReport.serializer(), sv)
+        val decoded = json.decodeFromString(SemanticsVerifyReport.serializer(), encoded)
+        assertEquals("mismatch", decoded.result)
+        assertEquals(listOf("- a", "+ b"), decoded.delta)
+    }
+}

--- a/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/SemanticsDifferTest.kt
+++ b/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/SemanticsDifferTest.kt
@@ -1,0 +1,31 @@
+package org.reduxkotlin.snapshot
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class SemanticsDifferTest {
+    private val differ = SemanticsDiffer()
+
+    @Test fun equal_strings_match_with_no_delta() {
+        val r = differ.compare("a\nb\nc", "a\nb\nc")
+        assertEquals("match", r.result)
+        assertTrue(r.delta.isEmpty())
+    }
+
+    @Test fun changed_line_shows_removed_and_added() {
+        val r = differ.compare("""  "text": ["Save"]""", """  "text": ["Saved"]""")
+        assertEquals("mismatch", r.result)
+        assertTrue(r.delta.any { it.startsWith("-") && "Save" in it }, r.delta.toString())
+        assertTrue(r.delta.any { it.startsWith("+") && "Saved" in it }, r.delta.toString())
+    }
+
+    @Test fun delta_is_capped_with_overflow_marker() {
+        val golden = (1..100).joinToString("\n") { "g$it" }
+        val actual = (1..100).joinToString("\n") { "a$it" }
+        val r = SemanticsDiffer(maxDeltaLines = 10).compare(golden, actual)
+        assertEquals("mismatch", r.result)
+        assertEquals(11, r.delta.size) // 10 + overflow marker
+        assertTrue(r.delta.last().startsWith("…"), r.delta.last())
+    }
+}

--- a/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/SemanticsExtractionTest.kt
+++ b/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/SemanticsExtractionTest.kt
@@ -65,7 +65,7 @@ internal class SemanticsExtractionTest {
     private fun allNodes(dump: SemanticsDump): List<SemanticsDump.Node> {
         val out = mutableListOf<SemanticsDump.Node>()
         fun walk(n: SemanticsDump.Node) {
-            out += n;
+            out += n
             n.children.forEach(::walk)
         }
         dump.roots.forEach(::walk)

--- a/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/SemanticsExtractionTest.kt
+++ b/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/SemanticsExtractionTest.kt
@@ -1,0 +1,74 @@
+package org.reduxkotlin.snapshot
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class SemanticsExtractionTest {
+    private val richContent: @Composable () -> Unit = {
+        Column {
+            Text("Title")
+            Button(onClick = {}, enabled = false, modifier = Modifier.testTag("save")) { Text("Save") }
+            Text("Logo", modifier = Modifier.semantics { contentDescription = "logo image" })
+        }
+    }
+
+    private fun render() = ImageComposeSceneBackend().render(
+        RenderSpec(widthDp = 200, heightDp = 200, density = 2f, content = richContent),
+    ).semantics
+
+    @Test fun captures_text_in_traversal_order() {
+        val texts = render().texts
+        assertTrue("Title" in texts, texts.toString())
+        assertTrue("Save" in texts, texts.toString())
+    }
+
+    @Test fun button_node_carries_role_testTag_and_disabled() {
+        val dump = render()
+        val button = allNodes(dump).first { it.testTag == "save" }
+        assertEquals("button", button.role)
+        assertEquals(false, button.enabled)
+        assertTrue("Save" in button.text, button.text.toString())
+    }
+
+    @Test fun merged_tree_absorbs_the_buttons_text_child() {
+        val dump = render()
+        val button = allNodes(dump).first { it.testTag == "save" }
+        // The child Text("Save") is merged into the button; it is not a separate child node.
+        assertTrue(button.children.none { it.text == listOf("Save") }, "Text child should be absorbed")
+    }
+
+    @Test fun content_description_is_captured() {
+        assertTrue(allNodes(render()).any { it.contentDescription == listOf("logo image") })
+    }
+
+    @Test fun same_input_yields_identical_canonical_json() {
+        assertEquals(render().toCanonicalJson(), render().toCanonicalJson())
+    }
+
+    @Test fun text_free_scene_yields_empty_texts() {
+        // The 'counter' demo scene draws only bars, no semantics text.
+        val dump = ImageComposeSceneBackend().render(
+            RenderSpec(200, 200, 2f) {},
+        ).semantics
+        assertTrue(dump.texts.isEmpty())
+    }
+
+    private fun allNodes(dump: SemanticsDump): List<SemanticsDump.Node> {
+        val out = mutableListOf<SemanticsDump.Node>()
+        fun walk(n: SemanticsDump.Node) {
+            out += n;
+            n.children.forEach(::walk)
+        }
+        dump.roots.forEach(::walk)
+        return out
+    }
+}

--- a/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/SemanticsTest.kt
+++ b/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/SemanticsTest.kt
@@ -1,0 +1,46 @@
+package org.reduxkotlin.snapshot
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class SemanticsTest {
+    private fun leaf(text: String) = SemanticsDump.Node(
+        role = null, text = listOf(text), contentDescription = emptyList(),
+        testTag = null, enabled = null, selected = null, toggle = null, children = emptyList(),
+    )
+
+    private val sample = SemanticsDump(
+        roots = listOf(
+            SemanticsDump.Node(
+                role = "button", text = listOf("Save"), contentDescription = emptyList(),
+                testTag = "save", enabled = false, selected = null, toggle = null,
+                children = listOf(leaf("Icon")),
+            ),
+        ),
+        texts = listOf("Save", "Icon"),
+    )
+
+    @Test fun canonical_json_is_deterministic() {
+        assertEquals(sample.toCanonicalJson(), sample.toCanonicalJson())
+    }
+
+    @Test fun canonical_json_has_no_bounds_key() {
+        assertTrue("bounds" !in sample.toCanonicalJson())
+    }
+
+    @Test fun text_form_shows_fields_and_indents_children() {
+        val t = sample.toText()
+        assertTrue("role=button" in t, t)
+        assertTrue("Save" in t, t)
+        assertTrue("testTag=save" in t, t)
+        assertTrue("enabled=false" in t, t)
+        assertTrue("  " in t, "child should be indented") // 2-space indent
+    }
+
+    @Test fun empty_dump_text_and_json() {
+        assertEquals("(no semantics)", SemanticsDump.EMPTY.toText())
+        assertEquals("[]", SemanticsDump.EMPTY.toCanonicalJson().trim())
+        assertTrue(SemanticsDump.EMPTY.texts.isEmpty())
+    }
+}

--- a/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/SemanticsTest.kt
+++ b/redux-kotlin-snapshot/src/test/kotlin/org/reduxkotlin/snapshot/SemanticsTest.kt
@@ -6,15 +6,26 @@ import kotlin.test.assertTrue
 
 internal class SemanticsTest {
     private fun leaf(text: String) = SemanticsDump.Node(
-        role = null, text = listOf(text), contentDescription = emptyList(),
-        testTag = null, enabled = null, selected = null, toggle = null, children = emptyList(),
+        role = null,
+        text = listOf(text),
+        contentDescription = emptyList(),
+        testTag = null,
+        enabled = null,
+        selected = null,
+        toggle = null,
+        children = emptyList(),
     )
 
     private val sample = SemanticsDump(
         roots = listOf(
             SemanticsDump.Node(
-                role = "button", text = listOf("Save"), contentDescription = emptyList(),
-                testTag = "save", enabled = false, selected = null, toggle = null,
+                role = "button",
+                text = listOf("Save"),
+                contentDescription = emptyList(),
+                testTag = "save",
+                enabled = false,
+                selected = null,
+                toggle = null,
                 children = listOf(leaf("Icon")),
             ),
         ),


### PR DESCRIPTION
## Summary

Completes the AI-agent-facing capabilities of `redux-kotlin-snapshot` (headless `f(state) → Composable → PNG` renderer). Previously the semantics dump was a stub returning `SemanticsDump.EMPTY`; an agent verifying UI had to read PNGs (~1–2k vision tokens each iteration). This adds a **text/JSON semantics dump** and **golden-diff-as-gate** so the agent reads a PNG only when a shot actually drifts.

Built via subagent-driven TDD from a brainstormed + multi-agent-reviewed spec and plan (in `docs/superpowers/`).

## What's included

- **Semantics extraction** (`Semantics.kt`, `RenderBackend.kt`): real merged semantics tree from `ImageComposeScene.semanticsOwners` (public experimental API, no reflection). Bounds-free, deterministic (owner order by node id, layout child order) → goldens are cross-arch stable. Non-fatal: extraction failure degrades to `EMPTY` keeping the PNG. `toText()` (compact) + `toCanonicalJson()` (single JSON form for emit + goldens).
- **Comparator** (`SemanticsDiffer.kt`): canonical string-equality gate + capped line-diff delta.
- **CLI** (`cli/Cli.kt`): `--semantics`, `--semantics-format json|text`, `--verify-semantics-file` (single), `--verify-semantics` (batch, needs `--golden-dir`), `--update-semantics`. Existing flags + exit codes (0/1/2) preserved.
- **Report v2** (`Report.kt`, `BatchRunner.kt`): per-shot `verifySemantics`/`semanticsSidecar`/`semanticsBytes`, `Totals` semantics counts + `renderMsTotal`, redefined `ok`, terse drift-only stdout, per-shot sidecars. Back-compat: new fields nullable/defaulted.
- **Dashboard** (`DashboardGenerator.kt`): semantics verdict reflected in cards + totals (no more green card on a semantics-only mismatch).
- **Publish** (`README.md`, `.api`): documented flags/schemas + Maven Central coordinate `org.reduxkotlin:redux-kotlin-snapshot:1.0.0-alpha03`; apiDump regenerated; `publishToMavenLocal` verified.

## Out of scope (deliberate)

Live-view seam (`events.ndjson`), structured per-node differ, and bounds — all documented as deferred.

## Testing

Full module suite green (75/75). New coverage: extraction correctness + merge-absorption + determinism, canonical/text forms + empty case, differ + overflow cap, report v2 + v1 back-compat parse, CLI single + batch (update→verify round trip, missing-golden exit 2, sidecar writes, drift gating exit 1, batch update exits 0 without pixel gate), dashboard semantics verdict.

## Release follow-up (maintainer)

Cutting `1.0.0-alpha03` to Maven Central is a signed CI publish on a maintainer tag push (`-Pversion=1.0.0-alpha03`) — not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)