### PR TITLE
fix(cli): rk devtools serve --ui is broken on every Homebrew install

### DIFF
--- a/redux-kotlin-cli-dist/build.gradle.kts
+++ b/redux-kotlin-cli-dist/build.gradle.kts
@@ -37,6 +37,56 @@ compose.desktop {
     }
 }
 
+// macOS only: make the bundled JRE's libjvm.dylib findable by an rpath SEARCH, not just by matching
+// an already-loaded image's install name.
+//
+// Temurin's runtime links AWT against `@rpath/libjvm.dylib`, but the only LC_RPATH on those dylibs is
+// `@loader_path/.` — and libjvm.dylib lives in `lib/server/`. That normally resolves anyway: the
+// launcher dlopens libjvm first, and dyld matches the dependency against the loaded image's install
+// name (`@rpath/libjvm.dylib`). Any packager that rewrites LC_ID_DYLIB breaks that match and dyld
+// falls back to a search that cannot succeed. Homebrew does exactly this (Keg#fix_dynamic_linkage
+// rewrites EVERY dylib's id to its absolute opt path), which broke `rk devtools serve --ui` — the JVM
+// booted, then dlopen(libjawt.dylib) died with "Library not loaded: @rpath/libjvm.dylib".
+//
+// Adding `@loader_path/<...>/server` to each dependent makes the search resolve regardless of the id,
+// so the image survives relocation by brew or anything else. (Homebrew's own openjdk build ships this
+// rpath for the same reason.) Mutating a Mach-O invalidates its signature, so each patched file — and
+// then the bundle — is re-signed ad-hoc, matching what jpackage produced.
+val hardenRuntimeRpaths by tasks.registering {
+    dependsOn("createDistributable")
+    onlyIf { System.getProperty("os.name").lowercase().contains("mac") }
+    val appDir = layout.buildDirectory.dir("compose/binaries/main/app")
+    inputs.dir(appDir)
+    outputs.upToDateWhen { false } // in-place binary patch; no separate output to track
+    doLast {
+        val app = appDir.get().asFile.resolve("rk.app")
+        val libDir = app.resolve("Contents/runtime/Contents/Home/lib")
+        check(libDir.isDirectory) { "bundled runtime not found at $libDir" }
+        val serverDir = libDir.resolve("server")
+        var patched = 0
+        libDir.walkTopDown().filter { it.isFile && it.extension == "dylib" }.forEach { dylib ->
+            val links = providers.exec {
+                commandLine("otool", "-L", dylib.absolutePath)
+            }.standardOutput.asText.get()
+            if (!links.contains("@rpath/libjvm.dylib")) return@forEach
+            val rel = serverDir.relativeTo(dylib.parentFile).path.ifEmpty { "." }
+            providers.exec {
+                commandLine("install_name_tool", "-add_rpath", "@loader_path/$rel", dylib.absolutePath)
+                isIgnoreExitValue = true // already-present rpath is not an error for us
+            }.standardOutput.asText.get()
+            providers.exec {
+                commandLine("codesign", "--force", "--sign", "-", dylib.absolutePath)
+            }.standardOutput.asText.get()
+            patched++
+        }
+        check(patched > 0) { "no runtime dylib links @rpath/libjvm.dylib — the runtime layout changed" }
+        providers.exec {
+            commandLine("codesign", "--force", "--sign", "-", "--deep", app.absolutePath)
+        }.standardOutput.asText.get()
+        logger.lifecycle("hardenRuntimeRpaths: added @loader_path/server to $patched runtime dylib(s)")
+    }
+}
+
 // Archives the per-OS app-image under build/distributions with the JReleaser platform suffix
 // (e.g. rk-1.0.0-osx-aarch_64.zip). Each CI runner builds + archives its own host's image;
 // JReleaser (Task 3) consumes these by exact path. macOS/Windows → zip; Linux → tar.gz.
@@ -45,7 +95,7 @@ compose.desktop {
 tasks.register<Zip>("packageRkArchiveZip") {
     val osName = System.getProperty("os.name").lowercase()
     onlyIf { osName.contains("mac") || osName.contains("windows") }
-    dependsOn("createDistributable")
+    dependsOn("createDistributable", hardenRuntimeRpaths)
     val ver = project.version.toString()
     val platform = rkJReleaserPlatform()
     archiveFileName.set("rk-$ver-$platform.zip")

--- a/redux-kotlin-cli-dist/src/jreleaser/distributions/rk/brew/formula-multi.rb.tpl
+++ b/redux-kotlin-cli-dist/src/jreleaser/distributions/rk/brew/formula-multi.rb.tpl
@@ -29,8 +29,7 @@ class {{brewFormulaName}} < Formula
   # self-locates from $0, and Homebrew's relative double-symlink (HOMEBREW/bin/rk -> ../Cellar/.../bin/rk
   # -> libexec/...) makes it mis-resolve its app dir (it looks for Contents/app/rk.cfg in the wrong
   # place). The macOS zip also loses the launcher's exec bit (Gradle Zip doesn't preserve unix perms),
-  # so restore it. post_install dylib re-signing is dropped: the .app's dylibs are inside the bundle,
-  # and the bundled runtime + Skiko load fine as-is (verified end-to-end via a real brew install).
+  # so restore it.
   def install
     libexec.install Dir["*"]
     target = OS.mac? ? "#{libexec}/Contents/MacOS/rk" : "#{libexec}/bin/rk"
@@ -42,8 +41,37 @@ class {{brewFormulaName}} < Formula
     chmod 0755, bin/"rk"
   end
 
+  # Undo Homebrew's relocation of the bundled JRE.
+  #
+  # Keg#fix_dynamic_linkage rewrites EVERY dylib's LC_ID_DYLIB to its absolute opt path, including
+  # the bundled runtime's libjvm.dylib (`@rpath/libjvm.dylib` -> `#{HOMEBREW_PREFIX}/opt/rk/...`).
+  # AWT's libjawt.dylib links `@rpath/libjvm.dylib` and resolved it by matching the already-loaded
+  # image's install name; once the id is absolute that match fails and dyld searches the rpaths
+  # instead. So the JVM booted (the launcher dlopens libjvm by path) but the first window died with
+  # "Library not loaded: @rpath/libjvm.dylib" — i.e. headless `rk` worked and `rk devtools serve
+  # --ui` did not. post_install runs AFTER fix_dynamic_linkage, so restore the id and re-sign here.
+  #
+  # 1.0.0-alpha05+ app-images also carry an `@loader_path/server` rpath, which makes the search
+  # succeed on its own; this stays as the second line of defence and to fix relocated older images.
+  def post_install
+    return unless OS.mac?
+
+    jvm = libexec/"Contents/runtime/Contents/Home/lib/server/libjvm.dylib"
+    return unless jvm.exist?
+
+    system "install_name_tool", "-id", "@rpath/libjvm.dylib", jvm
+    system "codesign", "--force", "--sign", "-", jvm
+  end
+
   test do
     output = shell_output("#{bin}/rk --version")
     assert_match "{{projectVersion}}", output
+
+    # Guards the relocation repair above: with an absolute id, AWT/Skiko cannot load libjvm and
+    # every GUI subcommand fails at the first window.
+    if OS.mac?
+      jvm = "#{libexec}/Contents/runtime/Contents/Home/lib/server/libjvm.dylib"
+      assert_match "@rpath/libjvm.dylib", shell_output("otool -D #{jvm}")
+    end
   end
 end

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/ServeCommand.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/ServeCommand.kt
@@ -24,6 +24,31 @@ import org.reduxkotlin.devtools.monitor.ui.MonitorApp
 import java.io.File
 import java.net.BindException
 
+/**
+ * Renders an actionable message for a GUI launch that failed on a missing system library, or null
+ * when [error] is not that case and should keep its stack trace.
+ *
+ * Only Linux is affected: the app-image bundles a JRE but no X11 client libraries, and AWT loads
+ * them by SONAME through the system linker.
+ */
+internal fun missingNativeLibraryHint(error: UnsatisfiedLinkError, osName: String): String? {
+    val missing = if (osName.lowercase().contains("linux")) {
+        Regex("""([\w.+-]+\.so(?:\.\d+)*): cannot open shared object file""")
+            .find(error.message.orEmpty())
+            ?.groupValues
+            ?.get(1)
+    } else {
+        null
+    } ?: return null
+    return """
+        cannot start the GUI: $missing is missing — the bundled runtime ships a JRE, but the X11
+        client libraries the GUI draws through have to come from the system.
+          Debian/Ubuntu:  sudo apt install libxtst6 libxi6 libxrender1
+          Fedora/RHEL:    sudo dnf install libXtst libXi libXrender
+        Drop --ui to serve the bridge headlessly.
+    """.trimIndent()
+}
+
 /** `serve` — host the bridge receiver, write per-store captures, optionally launch the GUI. */
 internal class ServeCommand : CliktCommand(name = "serve") {
     private val port by option("--port", help = "port to listen on").int().default(9090)
@@ -43,20 +68,34 @@ internal class ServeCommand : CliktCommand(name = "serve") {
         Runtime.getRuntime().addShutdownHook(Thread { flushAll(ingest, dir) })
         echo("serving bridge on $host:$bound  -> captures in ${dir.path}")
         if (ui) {
-            application {
-                Window(
-                    onCloseRequest = {
-                        server.stop()
-                        exitApplication()
-                    },
-                    title = "Redux DevTools Monitor",
-                ) {
-                    MonitorApp(ingest, rememberMonitorState(ingest, endpoint = "ws://$host:$bound"))
-                }
-            }
+            launchUi(server, ingest, bound)
         } else {
             runBlocking { awaitCancellation() }
         }
+    }
+
+    /**
+     * Runs the GUI, turning a missing system native library into an actionable one-line error.
+     *
+     * The bundled JRE carries no X11 client libraries — jpackage cannot ship them — so on a bare
+     * Linux box AWT dies in `dlopen(libawt_xawt.so)` with a stack trace nobody can act on.
+     */
+    private fun launchUi(server: MonitorServer, ingest: MonitorIngest, bound: Int) = try {
+        application {
+            Window(
+                onCloseRequest = {
+                    server.stop()
+                    exitApplication()
+                },
+                title = "Redux DevTools Monitor",
+            ) {
+                MonitorApp(ingest, rememberMonitorState(ingest, endpoint = "ws://$host:$bound"))
+            }
+        }
+    } catch (e: UnsatisfiedLinkError) {
+        val hint = missingNativeLibraryHint(e, System.getProperty("os.name").orEmpty())
+            ?: throw e
+        throw PrintMessage(hint, statusCode = 1, printError = true)
     }
 
     /** Starts [server], mapping startup failures to one-line CLI errors instead of stack traces. */

--- a/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/ServeCommand.kt
+++ b/redux-kotlin-devtools-cli/src/main/kotlin/org/reduxkotlin/devtools/cli/command/ServeCommand.kt
@@ -9,6 +9,7 @@ import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -59,19 +60,27 @@ internal class ServeCommand : CliktCommand(name = "serve") {
     }
 
     /** Starts [server], mapping startup failures to one-line CLI errors instead of stack traces. */
-    @Suppress("TooGenericExceptionCaught") // cause chains are scanned for BindException, rest rethrown
+    // TooGenericExceptionCaught: the cause chain is scanned for BindException; anything else is rethrown.
+    // SwallowedException: startup failures are reported as one-line CLI errors by design — the message
+    // is the whole contract, and Clikt's errors take no cause.
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     private fun startServer(server: MonitorServer): Int = try {
         server.start()
-    } catch (e: IllegalStateException) {
-        // e.g. non-loopback bind without a token
-        throw UsageError(e.message ?: "invalid server configuration").initCause(e)
     } catch (e: Exception) {
+        // Ktor reports a failed bind by cancelling the engine job, so the BindException arrives
+        // wrapped in a CancellationException — which is itself an IllegalStateException. Scan the
+        // cause chain before treating an IllegalStateException as a configuration error.
         if (generateSequence<Throwable>(e) { it.cause }.any { it is BindException }) {
             throw PrintMessage(
                 "port $port already in use on $host (--port to change)",
                 statusCode = 1,
                 printError = true,
             )
+        }
+        // e.g. non-loopback bind without a token. UsageError fixes its cause at construction, so
+        // initCause() on it always throws "Can't overwrite cause" — pass the message only.
+        if (e is IllegalStateException && e !is CancellationException) {
+            throw UsageError(e.message ?: "invalid server configuration")
         }
         throw e
     }

--- a/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/command/ServeCommandTest.kt
+++ b/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/command/ServeCommandTest.kt
@@ -1,0 +1,41 @@
+package org.reduxkotlin.devtools.cli.command
+
+import com.github.ajalt.clikt.testing.test
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** Verifies `serve`'s startup-failure paths report one-line CLI errors instead of stack traces. */
+class ServeCommandTest {
+    /**
+     * A port already bound by another process must produce the friendly "already in use" message.
+     *
+     * Ktor CIO surfaces a bind failure by cancelling the engine job, so `start()` throws a
+     * [kotlinx.coroutines.CancellationException] — which is an `IllegalStateException` — rather than
+     * a `BindException`. The command must not mistake that for a configuration error.
+     */
+    @Test fun bound_port_reports_already_in_use() {
+        ServerSocket().use { squatter ->
+            squatter.bind(InetSocketAddress("127.0.0.1", 0))
+            val port = squatter.localPort
+            val result = devToolsCommand().test("serve --port $port")
+            assertEquals(1, result.statusCode, "expected a failing exit code, got:\n${result.output}")
+            assertTrue(
+                "already in use" in result.stderr,
+                "expected a port-in-use message, got:\n${result.stderr}",
+            )
+        }
+    }
+
+    /** Binding a non-loopback host without a token is a usage error, not a crash. */
+    @Test fun non_loopback_without_token_is_a_usage_error() {
+        val result = devToolsCommand().test("serve --host 0.0.0.0 --port 0")
+        assertEquals(1, result.statusCode, "expected a failing exit code, got:\n${result.output}")
+        assertTrue(
+            "token" in result.stderr,
+            "expected the missing-token usage error, got:\n${result.stderr}",
+        )
+    }
+}

--- a/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/command/ServeCommandTest.kt
+++ b/redux-kotlin-devtools-cli/src/test/kotlin/org/reduxkotlin/devtools/cli/command/ServeCommandTest.kt
@@ -5,6 +5,8 @@ import java.net.InetSocketAddress
 import java.net.ServerSocket
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /** Verifies `serve`'s startup-failure paths report one-line CLI errors instead of stack traces. */
@@ -37,5 +39,25 @@ class ServeCommandTest {
             "token" in result.stderr,
             "expected the missing-token usage error, got:\n${result.stderr}",
         )
+    }
+
+    /** The verbatim error a bare Ubuntu box throws for `--ui`; it must name the lib and the fix. */
+    @Test fun missing_x11_library_on_linux_names_the_library_and_the_packages() {
+        val error = UnsatisfiedLinkError(
+            "/home/u/rk/lib/runtime/lib/libawt_xawt.so: libXtst.so.6: " +
+                "cannot open shared object file: No such file or directory",
+        )
+        val hint = missingNativeLibraryHint(error, "Linux")
+        assertNotNull(hint, "expected a hint for a missing X11 library")
+        assertTrue("libXtst.so.6" in hint, "hint must name the missing library, got:\n$hint")
+        assertTrue("apt install" in hint, "hint must say how to install it, got:\n$hint")
+    }
+
+    /** Anything that is not a missing system library keeps its stack trace. */
+    @Test fun unrelated_link_errors_are_not_rewritten() {
+        val unrelated = UnsatisfiedLinkError("no skiko in java.library.path")
+        assertNull(missingNativeLibraryHint(unrelated, "Linux"))
+        val macOs = UnsatisfiedLinkError("libXtst.so.6: cannot open shared object file")
+        assertNull(missingNativeLibraryHint(macOs, "Mac OS X"))
     }
 }


### PR DESCRIPTION
## What's broken

`rk devtools serve --ui` from a Homebrew install (alpha04) dies the moment it opens a window:

```
Library not loaded: @rpath/libjvm.dylib
  Referenced from: .../runtime/Contents/Home/lib/libjawt.dylib
  Reason: tried: '.../Home/lib/./libjvm.dylib' (no such file)
```

`libjvm.dylib` is present — in `lib/server/`, where it belongs. The bug is that Homebrew's `Keg#fix_dynamic_linkage` rewrites **every** dylib's `LC_ID_DYLIB` to its absolute opt path, the bundled JRE's libjvm included (`@rpath/libjvm.dylib` → `/opt/homebrew/opt/rk/…`).

AWT links `@rpath/libjvm.dylib`, and the only `LC_RPATH` on those Temurin dylibs is `@loader_path/.` — so it was never resolving by search at all. It resolved because dyld matched the dependency against the already-loaded image's *install name*. Absolutize the id and that match fails, leaving dyld to search a directory libjvm was never in.

The JVM itself still boots (the jpackage launcher dlopens libjvm by path), which is why every headless `rk` command worked and only the first window failed — and why the release zip is fine while every brew install is broken.

## Fixes

**1. `hardenRuntimeRpaths` (macOS)** — adds `@loader_path/server` to the 27 runtime dylibs that link `@rpath/libjvm.dylib`, then re-signs them and the bundle. The search now resolves no matter what a packager does to the id. Homebrew's own openjdk build ships this rpath for the same reason.

**2. Brew formula `post_install`** — restores the id (post_install runs *after* `fix_dynamic_linkage`) and `test` asserts it. This is what repairs images relocated before the hardening existed; a tap-side hotfix of the same change unbreaks alpha04 without a release.

**3. `serve` port conflict** (`6eba8798`) — a taken port printed a stack trace ending in `IllegalStateException: Can't overwrite cause`, never `port N already in use`. Ktor CIO reports a failed bind by cancelling the engine job, so `start()` throws a `CancellationException` wrapping the `BindException` — and `CancellationException` *is* an `IllegalStateException`, so it hit the config-error branch and the `BindException` scan below it was dead code. That branch then called `initCause()` on a `UsageError`, whose cause slot is fixed at construction. The genuine config error (non-loopback bind without a token) crashed identically.

**4. Linux `--ui` X11 libs** (`c0abca65`) — on a clean Ubuntu box the GUI died in a 40-line `UnsatisfiedLinkError` (`libXtst.so.6: cannot open shared object file`). The app-image bundles a JRE but cannot bundle X11 client libs. Now it names the library and the `apt`/`dnf` line that installs it.

Linux needs no rpath hardening: ELF resolves `NEEDED libjvm.so` by SONAME from the loaded set, and Linuxbrew's `change_rpath!` preserves `$ORIGIN` entries and never rewrites SONAMEs.

## Verification

- Absolutized libjvm's id on the hardened app-image exactly as brew does → GUI still launches. Without the hardening, same mutation → the dyld error above.
- Real `brew reinstall` of alpha04 with the patched formula → `rk devtools serve --ui` runs; `brew test rk` passes.
- Bare Ubuntu 24.04 host: with `libXtst.so.6` hidden the new message appears (exit 1); with it installed the GUI starts under Xvfb.
- New `ServeCommandTest` covers the bind conflict, the missing-token usage error, and the X11 message mapping. `detektAll` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)