### PR TITLE
feat(site): add one-prompt agent onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Video TBA
 ## How to add to project
 
 Artifacts are hosted on Maven Central. Replace `<version>` with the latest release shown by the
-badge above — currently **`1.0.0-alpha01`**, the first `1.0.0` pre-release (whole module set; API
+badge above — currently **`1.0.0-alpha06`**, on the `1.0.0` pre-release line (whole module set; API
 stabilizing toward `1.0.0`). Snapshots of `master` publish as `1.0.0-SNAPSHOT` to the Central Portal
 snapshots repository — add it to use them:
 

--- a/docs/agent/AGENTS-external.md
+++ b/docs/agent/AGENTS-external.md
@@ -15,16 +15,16 @@ bag, Compose bindings) on that same contract. Take the core, add only what you n
 
 ```kotlin
 // latest published release (1.0.0 pre-release line)
-implementation("org.reduxkotlin:redux-kotlin:1.0.0-alpha01")
+implementation("org.reduxkotlin:redux-kotlin:1.0.0-alpha06")
 // add companions as needed, e.g.:
-// implementation("org.reduxkotlin:redux-kotlin-compose:1.0.0-alpha01")
+// implementation("org.reduxkotlin:redux-kotlin-compose:1.0.0-alpha06")
 ```
 
 For app code prefer the one-dependency bundle and align à-la-carte modules with the BOM:
 
 ```kotlin
-implementation("org.reduxkotlin:redux-kotlin-bundle-compose:1.0.0-alpha01") // or redux-kotlin-bundle (no Compose)
-implementation(platform("org.reduxkotlin:redux-kotlin-bom:1.0.0-alpha01"))  // then add modules without versions
+implementation("org.reduxkotlin:redux-kotlin-bundle-compose:1.0.0-alpha06") // or redux-kotlin-bundle (no Compose)
+implementation(platform("org.reduxkotlin:redux-kotlin-bom:1.0.0-alpha06"))  // then add modules without versions
 ```
 
 ## Module map
@@ -118,24 +118,6 @@ Full guide: https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/r
 > **your own app's screens**, depend on `redux-kotlin-snapshot` as a library and
 > call `yourRegistry.runCli(args)` from your `main` (then `exitProcess(0)` — Skiko
 > leaves non-daemon threads alive).
-
-## DevTools CLI — `rk-devtools`
-
-A terminal tool that inspects a running redux-kotlin app — action log, per-field
-JSON diffs, per-store `.jsonl` captures — ideal for agents and headless
-debugging (`serve` → reproduce → `actions`/`diff`/`state`). It is **not** a Maven
-dependency and not yet on a package manager; today you build it from the
-redux-kotlin repo with the JVM `application` plugin's `installDist`:
-
-```
-git clone https://github.com/reduxkotlin/redux-kotlin && cd redux-kotlin
-./gradlew :redux-kotlin-devtools-cli:installDist   # needs JDK 17+
-# binary: redux-kotlin-devtools-cli/build/install/rk-devtools/bin/rk-devtools
-```
-
-(A sibling tool, `rk-snapshot` — `:redux-kotlin-snapshot:installDist` — renders a
-Compose screen from state to PNG with golden diffing.) Agent guide:
-https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/devtools.md
 
 ## Verify loop
 

--- a/docs/agent/SKILL-external.md
+++ b/docs/agent/SKILL-external.md
@@ -1,0 +1,50 @@
+---
+name: redux-kotlin
+description: Use when building or reviewing redux-kotlin (Kotlin Multiplatform Redux) code — adding/editing a feature slice, wiring the store, Compose state binding, effects/sync middleware, testing, platform shims, or modularization.
+---
+
+# redux-kotlin
+
+Kotlin Multiplatform port of the Redux contract: a minimal core (`redux-kotlin`) plus opt-in
+companion modules on one `Store<S>` contract. Recommended app organization is **package-by-feature**
+(`feature/<name>/` slice + shared `core` · `infra` · `app` · `ui`).
+
+## Always-apply rules
+
+<!-- assemble:rules:start -->
+- **Rule C — Render isolation.** No composable reads a model (board/cards/columns) wholesale; every leaf binds the narrowest slice via `selectorState`/`fieldStateOf` and is wrapped in `key(...)`; list derivation lives in pure functions/reducers.
+- **Rule D — Identity split.** A profile edit fans `EditProfile` to the root account directory, the per-account `CollaboratorsModel`, and `SessionModel` (bio) — identity is never duplicated inconsistently.
+- **Rule E — Off-main effects.** Effects originate only in middleware and run off-main; dispatch marshals back to main via `NotificationContext` (no explicit main hop). Per-feature handlers compose into one `effectsMiddleware`.
+- **Rule F — Delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
+- **Rule G — Mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
+- **Rule H — Single inset point.** Window insets are applied once at the shell root.
+- **Rule I — State-keyed lifecycle effects.** Screen-data loads key on **state** (the nav-derived slice, e.g. `BoardLifecycleEffect` on `nav.activeBoardId`), never on navigation events — state-only entry points (process-death restore, deep links, DevTools time-travel, account-switch hydration) set state without replaying events, so an event-keyed load silently never runs. Fallback: match the hydrating action in middleware.
+<!-- assemble:rules:end -->
+
+Full architecture and rules:
+https://github.com/reduxkotlin/redux-kotlin/blob/master/examples/taskflow/ARCHITECTURE.md
+
+## Decision routing
+
+| If you are… | Read |
+|---|---|
+| Adding or editing a **feature** | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/feature-slice.md |
+| Setting up the **store / topology** | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/store-setup.md |
+| **Compose** state binding (Rule C) | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/compose-binding.md |
+| **Effects + sync** (Rule E) | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/effects-sync.md |
+| **Testing** + the verify loop | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/testing.md |
+| **Visual / golden UI** verification | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/snapshot.md |
+| The 5 **platform shims** | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/platform-shims.md |
+| **Modularization** | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/modularization.md |
+| **Debugging** a running app | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/devtools.md |
+| **Persisting/restoring state** | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/state-persistence.md |
+| **Store consistency model** | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/store-consistency-model.md |
+
+## Pointers
+
+- Project guide: https://reduxkotlin.org/agent-setup/AGENTS.md
+- Public API surface: https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/api-map.md
+- Reference index: https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/README.md
+
+Build/lint gate: `./gradlew build`, `./gradlew detektAll`, and `./gradlew apiCheck` for public API changes.
+Never bypass verification. Projects using `explicitApi()` need an explicit modifier and KDoc on every public declaration.

--- a/redux-kotlin-cli/README.md
+++ b/redux-kotlin-cli/README.md
@@ -23,7 +23,7 @@ scoop bucket add reduxkotlin https://github.com/reduxkotlin/scoop-bucket
 scoop install rk
 ```
 
-Published from `1.0.0-alpha01` onward (latest: `1.0.0-alpha02`). The macOS bottle is
+Published from `1.0.0-alpha01` onward (latest: `1.0.0-alpha06`). The macOS bottle is
 **Apple Silicon only** for now — on an Intel Mac, build from source (below).
 
 ### From source (any OS, needs JDK 17+)

--- a/scripts/assemble-agent-knowledge.sh
+++ b/scripts/assemble-agent-knowledge.sh
@@ -9,6 +9,7 @@ MAP=(
   "AGENTS.md|modules|$FRAG/modules.md"
   "docs/agent/AGENTS-external.md|rules|$FRAG/rules.md"
   "docs/agent/AGENTS-external.md|modules|$FRAG/modules.md"
+  "docs/agent/SKILL-external.md|rules|$FRAG/rules.md"
 )
 inject() { # stdin=content, $1=marker, $2=fragfile -> stdout
   awk -v s="<!-- assemble:$1:start -->" -v e="<!-- assemble:$1:end -->" -v f="$2" '
@@ -68,5 +69,23 @@ if [ -f "$PAGE" ] && [ -f "$SRC" ]; then
     printf '%s\n' "$rendered_page" > "$PAGE"
   fi
 fi
+
+# --- Stable raw setup files served by reduxkotlin.org ---
+publish_static() { # $1=source, $2=target
+  local source="$1" target="$2" rendered_static
+  [ -f "$source" ] || { echo "ASSEMBLE-FAIL: missing source $source"; rc=1; return; }
+  rendered_static="$(grep -v '<!-- assemble:' "$source")"
+  if [ "$CHECK" -eq 1 ]; then
+    if [ ! -f "$target" ] || ! diff -q <(printf '%s\n' "$rendered_static") "$target" >/dev/null; then
+      echo "ASSEMBLE-FAIL: $target out of sync — run scripts/assemble-agent-knowledge.sh"; rc=1
+    fi
+  else
+    mkdir -p "$(dirname "$target")"
+    printf '%s\n' "$rendered_static" > "$target"
+  fi
+}
+publish_static "docs/agent/AGENTS-external.md" "website/static/agent-setup/AGENTS.md"
+publish_static "docs/agent/SKILL-external.md" "website/static/agent-setup/SKILL.md"
+
 [ "$rc" -eq 0 ] && { [ "$CHECK" -eq 1 ] && echo "ASSEMBLE CHECK OK" || echo "ASSEMBLED"; } || echo "ASSEMBLE FAILED"
 exit "$rc"

--- a/scripts/check-site-agent-links.sh
+++ b/scripts/check-site-agent-links.sh
@@ -3,7 +3,14 @@ set -uo pipefail
 cd "$(git rev-parse --show-toplevel)" || exit 2
 fail=0
 # Files whose GitHub blob/tree links to in-repo docs we must keep alive.
-files=("docs/agent/AGENTS-external.md" "website/docs/ai-agents/BuildingWithAI.md")
+files=(
+  "docs/agent/AGENTS-external.md"
+  "docs/agent/SKILL-external.md"
+  "website/docs/ai-agents/BuildingWithAI.md"
+  "website/static/agent-setup/AGENTS.md"
+  "website/static/agent-setup/SKILL.md"
+  "website/static/agent-setup/prompt.md"
+)
 for f in "${files[@]}"; do
   [ -f "$f" ] || { echo "LINK-FAIL: missing $f"; fail=1; continue; }
   # Extract repo-relative paths from github.com/reduxkotlin/redux-kotlin/(blob|tree)/<ref>/<path>
@@ -13,5 +20,18 @@ for f in "${files[@]}"; do
   done < <(grep -oE 'github\.com/reduxkotlin/redux-kotlin/(blob|tree)/[^/]+/[^)" ]+' "$f" \
             | sed -E 's#.*/(blob|tree)/[^/]+/##' | sort -u)
 done
+
+setup_url="https://reduxkotlin.org/agent-setup/prompt.md"
+banner="website/src/components/AgentOnboardingBanner/index.tsx"
+grep -qF "$setup_url" "$banner" || {
+  echo "LINK-FAIL: onboarding banner does not copy the canonical setup URL"; fail=1;
+}
+grep -qF "https://reduxkotlin.org/agent-setup/AGENTS.md" "website/static/agent-setup/prompt.md" || {
+  echo "LINK-FAIL: setup prompt does not reference the published AGENTS.md"; fail=1;
+}
+grep -qF "https://reduxkotlin.org/agent-setup/SKILL.md" "website/static/agent-setup/prompt.md" || {
+  echo "LINK-FAIL: setup prompt does not reference the published SKILL.md"; fail=1;
+}
+
 [ "$fail" -ne 0 ] && { echo "SITE-LINK CHECK FAILED"; exit 1; }
 echo "SITE-LINK CHECK OK"

--- a/website/docs/advanced/DevTools.md
+++ b/website/docs/advanced/DevTools.md
@@ -24,9 +24,9 @@ full stability promise.
 :::info Availability
 
 All six DevTools libraries are on **Maven Central**, group `org.reduxkotlin`,
-published with the rest of the stack. The current release is **`1.0.0-alpha01`**.
+published with the rest of the stack. The current release is **`1.0.0-alpha06`**.
 There is no umbrella `redux-kotlin-devtools` artifact — depend on the specific
-modules below (replace `<version>` with `1.0.0-alpha01`).
+modules below (replace `<version>` with `1.0.0-alpha06`).
 
 `master` snapshots publish as **`1.0.0-SNAPSHOT`** to the Central Portal
 snapshots repository — add it and use `1.0.0-SNAPSHOT` as the version:

--- a/website/docs/introduction/GettingStarted.md
+++ b/website/docs/introduction/GettingStarted.md
@@ -22,7 +22,7 @@ ReduxKotlin is published to Maven Central. Replace `<version>` with the latest
 release.
 
 :::info Current release
-The latest is **`1.0.0-alpha01`** — the first `1.0.0` pre-release, covering the
+The latest is **`1.0.0-alpha06`**, on the `1.0.0` pre-release line and covering the
 whole module set (core, concurrent, granular, multimodel, registry, routing,
 bundles, Compose bindings, and the experimental DevTools). The API is stabilizing
 toward `1.0.0`; pin an exact alpha and expect minor changes between alphas.

--- a/website/docs/introduction/Threading.md
+++ b/website/docs/introduction/Threading.md
@@ -105,11 +105,10 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation "org.reduxkotlin:redux-kotlin:1.0.0-alpha01"
+                implementation "org.reduxkotlin:redux-kotlin:1.0.0-alpha06"
             }
         }
     }
 }
 ```
 **ONLY USE THE ABOVE IF YOU DO NOT WANT THREAD SAFETY**
-

--- a/website/src/components/AgentOnboardingBanner/index.tsx
+++ b/website/src/components/AgentOnboardingBanner/index.tsx
@@ -1,0 +1,103 @@
+import type {ReactNode} from 'react';
+import {useEffect, useRef, useState} from 'react';
+import clsx from 'clsx';
+
+import styles from './styles.module.css';
+
+export const AGENT_SETUP_PROMPT =
+  'Fetch and execute the appropriate instructions to set me up for ReduxKotlin from https://reduxkotlin.org/agent-setup/prompt.md';
+
+type CopyState = 'idle' | 'copied' | 'error';
+
+type AgentOnboardingBannerProps = {
+  className?: string;
+};
+
+function AgentMarks(): ReactNode {
+  return (
+    <span className={styles.agentMarks} aria-hidden="true">
+      <svg viewBox="0 0 256 257" className={styles.agentMark}>
+        <path
+          fill="#d97757"
+          d="m50.228 170.321 50.357-28.257.843-2.463-.843-1.361h-2.462l-8.426-.518-28.775-.778-24.952-1.037-24.175-1.296-6.092-1.297L0 125.796l.583-3.759 5.12-3.434 7.324.648 16.202 1.101 24.304 1.685 17.629 1.037 26.118 2.722h4.148l.583-1.685-1.426-1.037-1.101-1.037-25.147-17.045-27.22-18.017-14.258-10.37-7.713-5.25-3.888-4.925-1.685-10.758 7-7.713 9.397.649 2.398.648 9.527 7.323 20.35 15.75L94.817 91.9l3.889 3.24 1.555-1.102.195-.777-1.75-2.917-14.453-26.118-15.425-26.572-6.87-11.018-1.814-6.61c-.648-2.723-1.102-4.991-1.102-7.778l7.972-10.823L71.42 0 82.05 1.426l4.472 3.888 6.61 15.101 10.694 23.786 16.591 32.34 4.861 9.592 2.592 8.879.973 2.722h1.685v-1.556l1.36-18.211 2.528-22.36 2.463-28.776.843-8.1 4.018-9.722 7.971-5.25 6.222 2.981 5.12 7.324-.713 4.73-3.046 19.768-5.962 30.98-3.889 20.739h2.268l2.593-2.593 10.499-13.934 17.628-22.036 7.778-8.749 9.073-9.657 5.833-4.601h11.018l8.1 12.055-3.628 12.443-11.342 14.388-9.398 12.184-13.48 18.147-8.426 14.518.778 1.166 2.01-.194 30.46-6.481 16.462-2.982 19.637-3.37 8.88 4.148.971 4.213-3.5 8.62-20.998 5.184-24.628 4.926-36.682 8.685-.454.324.519.648 16.526 1.555 7.065.389h17.304l32.21 2.398 8.426 5.574 5.055 6.805-.843 5.184-12.962 6.611-17.498-4.148-40.83-9.721-14-3.5h-1.944v1.167l11.666 11.406 21.387 19.314 26.767 24.887 1.36 6.157-3.434 4.86-3.63-.518-23.526-17.693-9.073-7.972-20.545-17.304h-1.36v1.814l4.73 6.935 25.017 37.59 1.296 11.536-1.814 3.76-6.481 2.268-7.13-1.297-14.647-20.544-15.1-23.138-12.185-20.739-1.49.843-7.194 77.448-3.37 3.953-7.778 2.981-6.48-4.925-3.436-7.972 3.435-15.749 4.148-20.544 3.37-16.333 3.046-20.285 1.815-6.74-.13-.454-1.49.194-15.295 20.999-23.267 31.433-18.406 19.702-4.407 1.75-7.648-3.954.713-7.064 4.277-6.286 25.47-32.405 15.36-20.092 9.917-11.6-.065-1.686h-.583L44.07 198.125l-12.055 1.555-5.185-4.86.648-7.972 2.463-2.593 20.35-13.999-.064.065Z"
+        />
+      </svg>
+      <svg viewBox="0 0 24 24" className={styles.agentMark} fill="currentColor">
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M8.086.457a6.105 6.105 0 0 1 3.046-.415c1.333.153 2.521.72 3.564 1.7a.117.117 0 0 0 .107.029c1.408-.346 2.762-.224 4.061.366l.217.106c1.357.703 2.33 1.77 2.918 3.198.278.679.418 1.388.421 2.126a5.655 5.655 0 0 1-.18 1.631.167.167 0 0 0 .04.155 5.982 5.982 0 0 1 1.578 2.891c.385 1.901-.01 3.615-1.183 5.14l-.182.22a6.063 6.063 0 0 1-2.934 1.851.162.162 0 0 0-.108.102c-.255.736-.511 1.364-.987 1.992-1.199 1.582-2.962 2.462-4.948 2.451-1.583-.008-2.986-.587-4.21-1.736a.145.145 0 0 0-.14-.032c-.518.167-1.04.191-1.604.185a5.924 5.924 0 0 1-2.595-.622 6.058 6.058 0 0 1-2.146-1.781c-.203-.269-.404-.522-.551-.821a7.74 7.74 0 0 1-.495-1.283 6.11 6.11 0 0 1-.017-3.064.166.166 0 0 0 .008-.074.115.115 0 0 0-.037-.064 5.958 5.958 0 0 1-1.38-2.202 5.196 5.196 0 0 1-.333-1.589 6.915 6.915 0 0 1 .188-2.132c.45-1.484 1.309-2.648 2.577-3.493.282-.188.55-.334.802-.438.286-.12.573-.22.861-.304a.129.129 0 0 0 .087-.087A6.016 6.016 0 0 1 5.635 2.31C6.315 1.464 7.132.846 8.086.457Zm-.804 7.85a.848.848 0 0 0-1.473.842l1.694 2.965-1.688 2.848a.849.849 0 0 0 1.46.864l1.94-3.272a.849.849 0 0 0 .007-.854l-1.94-3.393Zm5.446 6.24a.849.849 0 0 0 0 1.695h4.848a.849.849 0 0 0 0-1.696h-4.848Z"
+        />
+      </svg>
+      <svg viewBox="0 0 466.73 532.09" className={styles.agentMark} fill="currentColor">
+        <path d="M457.43 125.94 244.42 2.96a22.13 22.13 0 0 0-22.12 0L9.3 125.94A18.61 18.61 0 0 0 0 142.05v247.99c0 6.65 3.55 12.79 9.3 16.11l213.01 122.98a22.13 22.13 0 0 0 22.12 0l213.01-122.98a18.61 18.61 0 0 0 9.3-16.11V142.05c0-6.65-3.55-12.79-9.3-16.11ZM444.05 151.99 238.42 508.15c-1.39 2.4-5.06 1.42-5.06-1.36V273.58c0-4.66-2.49-8.97-6.53-11.31L24.87 145.67c-2.4-1.39-1.42-5.06 1.36-5.06h411.26c5.84 0 9.49 6.33 6.57 11.39Z" />
+      </svg>
+      <svg viewBox="0 0 32 40" className={clsx(styles.agentMark, styles.openCodeMark)}>
+        <path d="M24 32H8V16h16v16Z" fill="currentColor" opacity="0.3" />
+        <path d="M24 8H8v24h16V8Zm8 32H0V0h32v40Z" fill="currentColor" />
+      </svg>
+    </span>
+  );
+}
+
+export default function AgentOnboardingBanner({
+  className,
+}: AgentOnboardingBannerProps): ReactNode {
+  const [copyState, setCopyState] = useState<CopyState>('idle');
+  const resetTimer = useRef<number | undefined>(undefined);
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current !== undefined) {
+        window.clearTimeout(resetTimer.current);
+      }
+    },
+    [],
+  );
+
+  async function copySetupPrompt(): Promise<void> {
+    try {
+      if (!navigator.clipboard?.writeText) {
+        throw new Error('Clipboard API unavailable');
+      }
+      await navigator.clipboard.writeText(AGENT_SETUP_PROMPT);
+      setCopyState('copied');
+    } catch {
+      setCopyState('error');
+    }
+
+    if (resetTimer.current !== undefined) {
+      window.clearTimeout(resetTimer.current);
+    }
+    resetTimer.current = window.setTimeout(() => setCopyState('idle'), 2600);
+  }
+
+  return (
+    <div className={clsx(styles.wrapper, className)}>
+      <button
+        type="button"
+        className={styles.button}
+        onClick={copySetupPrompt}
+        aria-label="Copy the ReduxKotlin agent setup prompt. Works with Claude, Codex, Cursor, and OpenCode."
+      >
+        <span>Onboard your agent to ReduxKotlin</span>
+        <AgentMarks />
+        <span className={styles.screenReaderOnly}>
+          Works with Claude, Codex, Cursor, and OpenCode
+        </span>
+      </button>
+      <span
+        className={clsx(styles.copyStatus, copyState !== 'idle' && styles.copyStatusVisible)}
+        role="status"
+        aria-live="polite"
+      >
+        {copyState === 'copied' && 'Setup prompt copied'}
+        {copyState === 'error' && (
+          <>
+            Copy failed — <a href="/agent-setup/prompt.md">open the prompt</a>
+          </>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/website/src/components/AgentOnboardingBanner/styles.module.css
+++ b/website/src/components/AgentOnboardingBanner/styles.module.css
@@ -1,0 +1,138 @@
+.wrapper {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  width: fit-content;
+  max-width: 100%;
+  margin: 1.5rem auto 2.5rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.7rem;
+  min-height: 2.5rem;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid var(--ifm-color-emphasis-400);
+  border-radius: 999px;
+  background: var(--ifm-background-surface-color);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
+  color: var(--ifm-font-color-base);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.2;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.button:hover {
+  border-color: var(--ifm-color-primary);
+  background: var(--ifm-color-emphasis-100);
+  box-shadow: 0 4px 12px rgb(19 122 249 / 15%);
+  transform: translateY(-1px);
+}
+
+.button:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--ifm-color-primary) 35%, transparent);
+  outline-offset: 3px;
+}
+
+.button:active {
+  transform: translateY(0);
+}
+
+.agentMarks {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  color: var(--ifm-font-color-base);
+}
+
+.agentMark {
+  width: 1.15rem;
+  height: 1.15rem;
+  flex: 0 0 auto;
+}
+
+.openCodeMark {
+  width: 0.92rem;
+}
+
+.copyStatus {
+  position: absolute;
+  top: calc(100% + 0.55rem);
+  left: 50%;
+  z-index: 2;
+  width: max-content;
+  max-width: calc(100vw - 2rem);
+  padding: 0.38rem 0.65rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 0.4rem;
+  background: var(--ifm-background-surface-color);
+  box-shadow: 0 4px 14px rgb(0 0 0 / 14%);
+  color: var(--ifm-font-color-base);
+  font-size: 0.8rem;
+  line-height: 1.3;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -0.25rem);
+  transition:
+    opacity 140ms ease,
+    transform 140ms ease;
+}
+
+.copyStatusVisible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, 0);
+}
+
+.screenReaderOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+:global([data-theme='dark']) .button,
+:global([data-theme='dark']) .copyStatus {
+  border-color: var(--ifm-color-emphasis-500);
+}
+
+@media screen and (max-width: 576px) {
+  .wrapper {
+    width: 100%;
+  }
+
+  .button {
+    width: 100%;
+    max-width: 22rem;
+    gap: 0.55rem;
+    padding-inline: 0.75rem;
+    font-size: 0.84rem;
+  }
+
+  .agentMarks {
+    gap: 0.2rem;
+  }
+
+  .agentMark {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .openCodeMark {
+    width: 0.8rem;
+  }
+}

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -17,6 +17,11 @@
   gap: 1rem;
 }
 
+.agentBanner {
+  margin-top: 0;
+  margin-bottom: 2rem;
+}
+
 .projectTitle {
   font-size: 3rem;
   margin: 0;

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -6,6 +6,8 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 
+import AgentOnboardingBanner from '@site/src/components/AgentOnboardingBanner';
+
 import DevicesIcon from '@site/static/img/multiplatform-devices.svg';
 import CheckIcon from '@site/static/img/noun_Check_1870817.svg';
 import CubesIcon from '@site/static/img/cubes-solid.svg';
@@ -116,6 +118,7 @@ function HeroSplash(): ReactNode {
   return (
     <header className={clsx('hero', styles.heroBanner)}>
       <div className="container">
+        <AgentOnboardingBanner className={styles.agentBanner} />
         <div className={styles.heroTitle}>
           <img src={logoUrl} alt="ReduxKotlin logo" width={100} height={100} />
           <Heading as="h1" className={styles.projectTitle}>

--- a/website/static/agent-setup/AGENTS.md
+++ b/website/static/agent-setup/AGENTS.md
@@ -1,29 +1,3 @@
----
-id: building-with-ai-agents
-title: Building with AI Agents
-sidebar_label: Building with AI Agents
----
-
-import AgentOnboardingBanner from '@site/src/components/AgentOnboardingBanner';
-
-redux-kotlin is built to be **agent-ready**. Point your coding agent at the knowledge
-below and it can build Android / iOS / Web / Desktop apps on redux-kotlin with fewer
-tokens, fewer write→verify cycles, and correct-by-default patterns.
-
-<AgentOnboardingBanner />
-
-Click the banner once, then paste the copied prompt into Claude, Codex, Cursor, or
-OpenCode. Your agent will preserve existing project guidance, install the portable
-ReduxKotlin guide, and add the optional skill when its client supports Agent Skills.
-You can also <a href="/agent-setup/prompt.md">open the setup prompt directly</a>.
-
-## Manual setup: drop `AGENTS.md` in your repo
-
-Save the block below as `AGENTS.md` at your repo root. Any agent that reads `AGENTS.md`
-(Cursor, Copilot, Codex, Claude Code, …) will load it automatically.
-
-{/* assemble:agents-external:start */}
-````markdown title="AGENTS.md"
 # AGENTS.md — redux-kotlin
 
 Token-tight index for AI agents building an app **with** redux-kotlin
@@ -146,26 +120,3 @@ Full guide: https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/r
 After writing code, run (Gradle): build (`./gradlew build`), lint
 (`./gradlew detektAll`), and — if you publish a library module — `./gradlew apiCheck`.
 `explicitApi()` projects need a KDoc on every public declaration.
-````
-{/* assemble:agents-external:end */}
-
-## Optional: install the Agent Skill
-
-Clients that support Agent Skills get decision-routing and progressive disclosure over
-the same knowledge. Download the standalone <a href="/agent-setup/SKILL.md">`SKILL.md`</a> to
-`.agents/skills/redux-kotlin/SKILL.md` (Agent Skills / Codex) or
-`.claude/skills/redux-kotlin/SKILL.md` (Claude Code). The one-prompt setup above detects
-and handles this automatically.
-
-## Reference set
-
-The `AGENTS.md` above links to per-concern guides on GitHub (where their source anchors
-stay live). Start with
-[feature-slice](https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/feature-slice.md)
-and the [reference index](https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/README.md).
-
-## Verify loop
-
-After writing code your agent should run `./gradlew build` (compile + test + detekt +
-`apiCheck`) and `./gradlew detektAll`. Detail:
-[testing guide](https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/testing.md).

--- a/website/static/agent-setup/SKILL.md
+++ b/website/static/agent-setup/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: redux-kotlin
+description: Use when building or reviewing redux-kotlin (Kotlin Multiplatform Redux) code — adding/editing a feature slice, wiring the store, Compose state binding, effects/sync middleware, testing, platform shims, or modularization.
+---
+
+# redux-kotlin
+
+Kotlin Multiplatform port of the Redux contract: a minimal core (`redux-kotlin`) plus opt-in
+companion modules on one `Store<S>` contract. Recommended app organization is **package-by-feature**
+(`feature/<name>/` slice + shared `core` · `infra` · `app` · `ui`).
+
+## Always-apply rules
+
+- **Rule C — Render isolation.** No composable reads a model (board/cards/columns) wholesale; every leaf binds the narrowest slice via `selectorState`/`fieldStateOf` and is wrapped in `key(...)`; list derivation lives in pure functions/reducers.
+- **Rule D — Identity split.** A profile edit fans `EditProfile` to the root account directory, the per-account `CollaboratorsModel`, and `SessionModel` (bio) — identity is never duplicated inconsistently.
+- **Rule E — Off-main effects.** Effects originate only in middleware and run off-main; dispatch marshals back to main via `NotificationContext` (no explicit main hop). Per-feature handlers compose into one `effectsMiddleware`.
+- **Rule F — Delta-only status.** `SyncEngine` emits `onStatus` only on a real `SyncStatus` change.
+- **Rule G — Mint at the edge.** Ids and timestamps come from `LocalIdGenerator`/`LocalClock` at the dispatch site, never from a reducer.
+- **Rule H — Single inset point.** Window insets are applied once at the shell root.
+- **Rule I — State-keyed lifecycle effects.** Screen-data loads key on **state** (the nav-derived slice, e.g. `BoardLifecycleEffect` on `nav.activeBoardId`), never on navigation events — state-only entry points (process-death restore, deep links, DevTools time-travel, account-switch hydration) set state without replaying events, so an event-keyed load silently never runs. Fallback: match the hydrating action in middleware.
+
+Full architecture and rules:
+https://github.com/reduxkotlin/redux-kotlin/blob/master/examples/taskflow/ARCHITECTURE.md
+
+## Decision routing
+
+| If you are… | Read |
+|---|---|
+| Adding or editing a **feature** | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/feature-slice.md |
+| Setting up the **store / topology** | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/store-setup.md |
+| **Compose** state binding (Rule C) | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/compose-binding.md |
+| **Effects + sync** (Rule E) | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/effects-sync.md |
+| **Testing** + the verify loop | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/testing.md |
+| **Visual / golden UI** verification | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/snapshot.md |
+| The 5 **platform shims** | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/platform-shims.md |
+| **Modularization** | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/modularization.md |
+| **Debugging** a running app | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/devtools.md |
+| **Persisting/restoring state** | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/state-persistence.md |
+| **Store consistency model** | https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/store-consistency-model.md |
+
+## Pointers
+
+- Project guide: https://reduxkotlin.org/agent-setup/AGENTS.md
+- Public API surface: https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/api-map.md
+- Reference index: https://github.com/reduxkotlin/redux-kotlin/blob/master/docs/agent/references/README.md
+
+Build/lint gate: `./gradlew build`, `./gradlew detektAll`, and `./gradlew apiCheck` for public API changes.
+Never bypass verification. Projects using `explicitApi()` need an explicit modifier and KDoc on every public declaration.

--- a/website/static/agent-setup/prompt.md
+++ b/website/static/agent-setup/prompt.md
@@ -1,0 +1,56 @@
+# Set up a coding agent for ReduxKotlin
+
+Set up the current repository so its coding agents can work effectively with ReduxKotlin. Follow
+only the steps that apply, preserve all existing project instructions, and do not add a ReduxKotlin
+dependency or install tooling unless the user separately asked for that.
+
+## 1. Inspect the repository
+
+- Find the repository root and read its existing `AGENTS.md`, `CLAUDE.md`, or other agent guidance.
+- Check whether the project already uses `org.reduxkotlin` dependencies and which version it pins.
+- Treat repository-local instructions as authoritative when they are more specific than this setup.
+
+## 2. Install the cross-agent project guide
+
+Fetch the canonical guide from:
+
+https://reduxkotlin.org/agent-setup/AGENTS.md
+
+- If the repository has no root `AGENTS.md`, save the fetched guide there.
+- If a root `AGENTS.md` already exists, do not replace it. Save the fetched guide as
+  `docs/agent/redux-kotlin.md`, then add a short, clearly labeled ReduxKotlin section to the existing
+  root guide telling agents to read that file for ReduxKotlin work.
+- Preserve the fetched guide's links. They route agents to focused references instead of loading the
+  entire documentation set into context.
+
+## 3. Install the optional Agent Skill when supported
+
+Fetch the standalone skill from:
+
+https://reduxkotlin.org/agent-setup/SKILL.md
+
+Install it only if the current coding agent supports project-scoped Agent Skills:
+
+- Agent Skills / Codex convention: `.agents/skills/redux-kotlin/SKILL.md`
+- Claude Code convention: `.claude/skills/redux-kotlin/SKILL.md`
+
+Do not invent a skill directory for clients that do not support skills. The `AGENTS.md` setup is the
+portable baseline and is sufficient on its own.
+
+## 4. Use the right integration path
+
+- For an existing ReduxKotlin project, preserve its pinned dependency versions unless the user asks
+  for an upgrade.
+- For a new integration, consult the current installation page and Maven Central before choosing a
+  release: https://reduxkotlin.org/introduction/getting-started
+- For action/state debugging or golden UI work, use the unified `rk` CLI (`rk devtools` and
+  `rk snapshot`). Do not install the superseded standalone `rk-devtools` command.
+- Read only the per-concern guide that matches the task before changing application code.
+
+## 5. Verify and report
+
+- Confirm every created file is reachable from the repository's root agent instructions.
+- Do not run package-manager installs or change application code when the user asked only for agent
+  onboarding.
+- Summarize the files created or updated, the detected ReduxKotlin version (if any), and the next
+  relevant command or guide.


### PR DESCRIPTION
## Summary

- add a Cloudflare-inspired one-click agent onboarding banner to the landing page and AI Agents guide
- publish stable raw prompt, AGENTS.md, and standalone SKILL.md endpoints with drift checks
- align public agent and CLI guidance with the unified `rk` command and current alpha06 release

## Verification

- `bash scripts/assemble-agent-knowledge.sh --check`
- `bash scripts/check-site-agent-links.sh`
- `bash scripts/check-agent-refs.sh`
- website typecheck and production build under Node 22
- `./gradlew detektAll`
- `JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home ./gradlew build` (2,823 tasks)
- production-served `/agent-setup/prompt.md`, `/agent-setup/AGENTS.md`, and `/agent-setup/SKILL.md` all return 200